### PR TITLE
Create RollCall tests 

### DIFF
--- a/tests/karate/src/test/java/be/ServerTest.java
+++ b/tests/karate/src/test/java/be/ServerTest.java
@@ -9,4 +9,8 @@ public class ServerTest {
   Karate testCreateLAO() {
     return Karate.run("classpath:be/createLAO");
   }
+  @Karate.Test
+  Karate testCreateRollCall() {
+    return Karate.run("classpath:be/rollCall");
+  }
 }

--- a/tests/karate/src/test/java/be/common/badMessageDataRequest.feature
+++ b/tests/karate/src/test/java/be/common/badMessageDataRequest.feature
@@ -19,4 +19,4 @@ Feature: Test behavior of server given invalid message data
     When eval socket.send(bad_request)
     * json answer = socket.listen(timeout)
     * karate.log("Answer: "+ karate.pretty(answer))
-    Then match answer == deep {jsonrpc: '2.0', id: 1, error: {code: #(err_code), description: '#string'}
+    Then match answer == deep {jsonrpc: '2.0', id: #(bad_request.id), error: {code: #(err_code), description: '#string'}

--- a/tests/karate/src/test/java/be/common/badMessageDataRequest.feature
+++ b/tests/karate/src/test/java/be/common/badMessageDataRequest.feature
@@ -1,0 +1,22 @@
+@ignore
+# This feature is used to modularize tests only
+# The args should be passed as a json {bad_request: <string>, err_code: <int>}
+# upon calling this feature file.
+# Assumes server is already running.
+# For more info on calling *.feature files: https://github.com/karatelabs/karate#calling-other-feature-files
+# Careful with shared Scopes: https://github.com/karatelabs/karate#shared-scope
+Feature: Test behavior of server given invalid message data
+        for expected error-valued answers
+
+  Background:
+    * assert isServerRunning
+    * call read('classpath:be/createLAO/create.feature@name=createLAO')
+    * def socket = karate.webSocket(wsURL,handle)
+
+  Scenario: Test invalid request messages should fail
+    Given eval bad_request
+    * karate.log("Invalid request: "+ karate.pretty(bad_request))
+    When eval socket.send(bad_request)
+    * json answer = socket.listen(timeout)
+    * karate.log("Answer: "+ karate.pretty(answer))
+    Then match answer == deep {jsonrpc: '2.0', id: 1, error: {code: #(err_code), description: '#string'}

--- a/tests/karate/src/test/java/be/createLAO/create.feature
+++ b/tests/karate/src/test/java/be/createLAO/create.feature
@@ -8,7 +8,7 @@ Feature: Create a pop LAO
         # * call wait <timeout>
         # * karate.set(varName, newValue)
     * call read('classpath:be/utils/server.feature')
-
+  @name=createLAO
   Scenario: Create should succeed with a valid creation request
     Given def createLaoReq =
         """

--- a/tests/karate/src/test/java/be/rollCall/createRollCall.feature
+++ b/tests/karate/src/test/java/be/rollCall/createRollCall.feature
@@ -1,0 +1,86 @@
+Feature: Create a RollCall
+  # TODO: Add missing test data 
+  Background:
+    * call read('classpath:be/utils/server.feature')
+    * def createLAO = read('classpath:be/createLAO/create.feature@name=createLAO')
+    * def badMessageDataTest = read('classpath:be/common/badMessageDataRequest.feature')
+    * def valideRollCall = {} /
+    * def success = {"jsonrpc": "2.0","id": 'id here',"result": 0}
+    * def socket = karate.webSocket(wsURL,handle)
+
+  @name=rollcall
+  Scenario: Create RollCall with valid request succeeds
+    Given call createLAO
+    * karate.log('RollCall: ' + karate.pretty(valideRollCall))
+    And string success = ""
+    When eval socket.send(valideRollCall)
+    And string answer = socket.listen(timeout)
+    * karate.log('Received answer = ' + answer)
+    Then match answer == success
+
+  Scenario: Creating two different RollCalls succeeds with valid ID
+    Given call createLAO
+    # First roll call same lao
+    And valideRollCall, success
+    # Second different rollcall same lao
+    And string createRollCall_2 = ""
+    *   string success_id2 = {"jsonrpc": "2.0","id": 'id here',"result": 0}
+    * karate.log('Creating first rollcall...')
+    When eval socket.send(createRollCall_1)
+    * listen timeout
+    * karate.log('First response = ' + listenResult')
+    Then match listenResult == expected_1
+
+    * karate.log('Creating second rollcall...')
+    When eval socket.send(createLaoReq)
+    * karate.log('Second response = ' + listenResult)
+    * listen timeout
+    Then match listenResult == expected_2
+
+  Scenario: Creating same/duplicate RollCalls should fail with correct error
+    Given call createLAO
+    And valideRollCall, success
+    * karate.log('Creating rollcall...')
+    When eval socket.send(createRollCall)
+    * listen timeout
+    * karate.log('Response = ' + listenResult')
+    Then match listenResult == success
+    * karate.log('Creating same rollcall again...')
+    When eval socket.send(createRollCall)
+    * listen timeout
+    * karate.log('Response = ' + listenResult')
+    * json answer = listenResult
+    Then match answer == {jsonrpc: '2.0', id: 1, error: {code: -3, description: '#string'}}
+
+  Scenario: Create RollCall without existing LAO should failwith correct error code
+    Given valideRollCall
+    * def socket = karate.webSocket(wsURL,handle)
+    When eval socket.send(valideRollCall)
+    And json answer = socket.listen(timeout)
+    * karate.log('Received answer = ' + answer)
+    Then match answer == {jsonrpc: '2.0', id: 1, error: {code: -2, description: '#string'}}
+
+  Scenario: Create RollCall with invalid/empty name should fail with correct error code
+    Given def invalidRollCall = ""
+    And   json args = {bad_request: #(invalidRollCall), err_code: -4}
+    Then  call badMessageDataTest args
+
+  Scenario: Create RollCall with invalid creation timestamp should fail with correct error code
+    Given def invalidRollCall = ""
+    And   json args = {bad_request: #(invalidRollCall), err_code: -4}
+    Then  call badMessageDataTest args
+
+  Scenario: Create RollCall with invalid proposed start timestamp should fail with correct error code
+    Given def invalidRollCall = ""
+    And   json args = {bad_request: #(invalidRollCall), err_code: -4}
+    Then  call badMessageDataTest args
+
+  Scenario: Create RollCall with invalid proposed end timestamp should fail with correct error code
+    Given def invalidRollCall = ""
+    And   json args = {bad_request: #(invalidRollCall), err_code: -4}
+    Then  call badMessageDataTest args
+
+  Scenario: Create RollCall with empty location should fail with correct error code
+    Given def invalidRollCall = ""
+    And   json args = {bad_request: #(invalidRollCall), err_code: -4}
+    Then  call badMessageDataTest args

--- a/tests/karate/src/test/java/be/rollCall/createRollCall.feature
+++ b/tests/karate/src/test/java/be/rollCall/createRollCall.feature
@@ -1,11 +1,11 @@
 Feature: Create a RollCall
-  # TODO: Add missing test data 
+  # TODO: Add missing test data
   Background:
     * call read('classpath:be/utils/server.feature')
     * def createLAO = read('classpath:be/createLAO/create.feature@name=createLAO')
     * def badMessageDataTest = read('classpath:be/common/badMessageDataRequest.feature')
-    * def valideRollCall = {} /
-    * def success = {"jsonrpc": "2.0","id": 'id here',"result": 0}
+    * def valideRollCall = {} 
+    * def success = {jsonrpc: "2.0", id: #(valideRollCall.id), result: 0}
     * def socket = karate.webSocket(wsURL,handle)
 
   @name=rollcall
@@ -23,19 +23,19 @@ Feature: Create a RollCall
     # First roll call same lao
     And valideRollCall, success
     # Second different rollcall same lao
-    And string createRollCall_2 = ""
-    *   string success_id2 = {"jsonrpc": "2.0","id": 'id here',"result": 0}
+    And string createRollCall_2nd = ""
+    *   json succes_2nd = {"jsonrpc": "2.0","id":  #(valideRollCall.id),"result": 0}
     * karate.log('Creating first rollcall...')
-    When eval socket.send(createRollCall_1)
+    When eval socket.send(valideRollCall)
     * listen timeout
     * karate.log('First response = ' + listenResult')
-    Then match listenResult == expected_1
+    Then match listenResult == success
 
     * karate.log('Creating second rollcall...')
-    When eval socket.send(createLaoReq)
+    When eval socket.send(createRollCall_2nd)
     * karate.log('Second response = ' + listenResult)
     * listen timeout
-    Then match listenResult == expected_2
+    Then match listenResult == success_2nd
 
   Scenario: Creating same/duplicate RollCalls should fail with correct error
     Given call createLAO

--- a/tests/karate/src/test/java/be/utils/server.feature
+++ b/tests/karate/src/test/java/be/utils/server.feature
@@ -59,6 +59,12 @@ Feature: This feature starts a server and stops it after every scenario.
                     server.stop();
                 }
             """
+    * def isServerRunning =
+            """
+                function() {
+                    return server.isRunning();
+                }
+            """
 
         # Start server
     * call startServer


### PR DESCRIPTION
+ Setup common Scenarios and Backgrounds 
   > Start server and create Lao  before testing..
   > In particularly scenarios where to expect error-valued answers
+ Implements test for roll call creation 
 
However the tests are incomplete as they still need adequate test data.
In case of rollcall creation we'll need
   > + 2 different yet valid (same LAO)roll call creation messages with  
   > + Messages with invalid fields : empty name, empty location, invalid timestamps... 