### PR TITLE
Remove ESLint issue in reducer

### DIFF
--- a/fe1-web/store/reducers/.eslintrc
+++ b/fe1-web/store/reducers/.eslintrc
@@ -1,7 +1,0 @@
-{
-  "root": false,
-  "rules": {
-    /* All reducers use the createSlice function, which requires the user to param-reassign */
-    "no-param-reassign": "off"
-  }
-}

--- a/fe1-web/store/reducers/EventsReducer.ts
+++ b/fe1-web/store/reducers/EventsReducer.ts
@@ -1,3 +1,8 @@
+/**
+ * This error is disabled since reducers use the createSlice function, which requires the user to
+ * param-reassign. Please do not disable other errors.
+ */
+/* eslint-disable no-param-reassign */
 import { createSlice, createSelector, PayloadAction } from '@reduxjs/toolkit';
 import {
   Hash, LaoEvent, LaoEventState, eventFromState, RollCall, PublicKey,

--- a/fe1-web/store/reducers/KeyPairReducer.ts
+++ b/fe1-web/store/reducers/KeyPairReducer.ts
@@ -1,3 +1,8 @@
+/**
+ * This error is disabled since reducers use the createSlice function, which requires the user to
+ * param-reassign. Please do not disable other errors.
+ */
+/* eslint-disable no-param-reassign */
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { KeyPairState } from 'model/objects';
 

--- a/fe1-web/store/reducers/LaoReducer.ts
+++ b/fe1-web/store/reducers/LaoReducer.ts
@@ -1,3 +1,8 @@
+/**
+ * This error is disabled since reducers use the createSlice function, which requires the user to
+ * param-reassign. Please do not disable other errors.
+ */
+/* eslint-disable no-param-reassign */
 import {
   createSlice, createSelector, PayloadAction, Draft,
 } from '@reduxjs/toolkit';

--- a/fe1-web/store/reducers/MessageReducer.ts
+++ b/fe1-web/store/reducers/MessageReducer.ts
@@ -1,3 +1,8 @@
+/**
+ * This error is disabled since reducers use the createSlice function, which requires the user to
+ * param-reassign. Please do not disable other errors.
+ */
+/* eslint-disable no-param-reassign */
 import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import {
   ExtendedMessage, ExtendedMessageState, markExtMessageAsProcessed,

--- a/fe1-web/store/reducers/SocialReducer.ts
+++ b/fe1-web/store/reducers/SocialReducer.ts
@@ -1,3 +1,8 @@
+/**
+ * This error is disabled since reducers use the createSlice function, which requires the user to
+ * param-reassign. Please do not disable other errors.
+ */
+/* eslint-disable no-param-reassign */
 import {
   Chirp, ChirpState, Hash, PublicKey, Timestamp,
 } from 'model/objects';

--- a/fe1-web/store/reducers/WalletReducer.ts
+++ b/fe1-web/store/reducers/WalletReducer.ts
@@ -1,3 +1,8 @@
+/**
+ * This error is disabled since reducers use the createSlice function, which requires the user to
+ * param-reassign. Please do not disable other errors.
+ */
+/* eslint-disable no-param-reassign */
 import {
   createSlice, PayloadAction,
 } from '@reduxjs/toolkit';


### PR DESCRIPTION
A `.eslintrc` file was there to disable an eslint error (`no-param-reassign`), but it somehow wasn't recognized by WebStorm and it led to the linter being completely disabled in all files contained in the `reducer` folder.
I disabled the error directly in files that are concerned, and removed the file that was causing issues.