### PR TITLE
Fixed most tests

### DIFF
--- a/fe1-web/jest.config.js
+++ b/fe1-web/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
   moduleNameMapper: {
     "^test_data/(.*)$": "<rootDir>/../tests/data/$1",
     "^protocol/(.*)$": "<rootDir>/../protocol/$1",
+    '\\.(css|less)$': '<rootDir>/jest/styleMock.js',
   },
   collectCoverage: true,
   testResultsProcessor: "jest-sonar-reporter",

--- a/fe1-web/jest/styleMock.js
+++ b/fe1-web/jest/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/fe1-web/src/App.tsx
+++ b/fe1-web/src/App.tsx
@@ -11,8 +11,9 @@ import { Provider } from 'react-redux';
 import { store, persist } from 'core/redux';
 
 import AppNavigation from 'core/navigation/AppNavigation';
-import { configureIngestion } from 'core/network/ingestion';
 import { configureFeatures } from 'features';
+import { configureIngestion } from './core/network/ingestion';
+import { configureKeyPair } from './core/keypair';
 
 /*
  * The starting point of the app.
@@ -24,9 +25,9 @@ import { configureFeatures } from 'features';
  * The Platform.OS is to put the statusBar in IOS in black, otherwise it is not readable
  */
 function App() {
+  configureKeyPair();
   const { messageRegistry, navigationOpts } = configureFeatures();
   configureIngestion(messageRegistry);
-  configureNetwork(messageRegistry, keyPairRegistry)
 
   const navigationRef = useNavigationContainerRef();
   useReduxDevToolsExtension(navigationRef);

--- a/fe1-web/src/__tests__/utils/TestFeatures.ts
+++ b/fe1-web/src/__tests__/utils/TestFeatures.ts
@@ -1,7 +1,9 @@
+import { configureKeyPair } from 'core/keypair';
 import { configureMessages } from 'core/network/jsonrpc/messages';
 import { configureFeatures } from 'features';
 
-export function configureTestMessageRegistry() {
+export function configureTestFeatures() {
+  configureKeyPair();
   const { messageRegistry } = configureFeatures();
   messageRegistry.verifyEntries();
 

--- a/fe1-web/src/__tests__/utils/index.ts
+++ b/fe1-web/src/__tests__/utils/index.ts
@@ -1,2 +1,2 @@
-export * from './TestRegistry';
 export * from './TestUtils';
+export * from './TestFeatures';

--- a/fe1-web/src/core/keypair/index.ts
+++ b/fe1-web/src/core/keypair/index.ts
@@ -1,7 +1,11 @@
 import { addReducer } from '../redux/Manage';
 import keyPairReducer from './Reducer';
+import { KeyPairStore } from './KeyPairStore';
 
-export * from './Reducer';
 export * from './KeyPairStore';
+export * from './Reducer';
 
-addReducer(keyPairReducer);
+export function configureKeyPair() {
+  addReducer(keyPairReducer);
+  KeyPairStore.get();
+}

--- a/fe1-web/src/core/network/JsonRpcApi.ts
+++ b/fe1-web/src/core/network/JsonRpcApi.ts
@@ -6,13 +6,8 @@ import { Message, MessageData } from './jsonrpc/messages';
 
 export const AUTO_ASSIGN_ID = -1;
 
-async function getKeyPair(msgData: MessageData): Promise<KeyPair> {
-  msgRegistry.getSigningMaterial(msgData);
-}
-
 export async function publish(channel: Channel, msgData: MessageData): Promise<void> {
-  const keyPair = await getKeyPair(msgData);
-  const message = await Message.fromData(msgData, keyPair);
+  const message = await Message.fromData(msgData);
   const request = new JsonRpcRequest({
     method: JsonRpcMethod.PUBLISH,
     params: new Publish({

--- a/fe1-web/src/core/network/ingestion/Configure.ts
+++ b/fe1-web/src/core/network/ingestion/Configure.ts
@@ -1,8 +1,9 @@
-import { getStore } from 'core/redux';
+import { addReducer, getStore } from 'core/redux';
 import { getNetworkManager } from '../NetworkManager';
 import { MessageRegistry } from '../jsonrpc/messages';
 import { handleRpcRequests, setMessageRegistry } from './Handler';
 import { makeMessageStoreWatcher } from './Watcher';
+import messageReducer from './Reducer';
 
 /**
  * Configures all handlers of the system within a MessageRegistry.
@@ -12,6 +13,9 @@ import { makeMessageStoreWatcher } from './Watcher';
 export function configure(registry: MessageRegistry) {
   // configure the message handlers
   setMessageRegistry(registry);
+
+  // configure the message reducer
+  addReducer(messageReducer);
 
   // setup the handler for incoming messages
   getNetworkManager().setRpcHandler(handleRpcRequests);

--- a/fe1-web/src/core/network/ingestion/__tests__/Reducer.test.ts
+++ b/fe1-web/src/core/network/ingestion/__tests__/Reducer.test.ts
@@ -1,16 +1,16 @@
 import 'jest-extended';
+import { mockPopToken, configureTestFeatures } from '__tests__/utils';
+
 import { AnyAction } from 'redux';
 
 import { channelFromIds, Timestamp } from 'core/objects';
 import { Message } from 'core/network/jsonrpc/messages';
-import { mockPopToken, configureTestMessageRegistry } from '__tests__/utils';
-
 import { AddChirp } from 'features/social/network/messages/chirp';
 
 import { ExtendedMessage, markMessageAsProcessed } from '../ExtendedMessage';
 import { addMessages, getMessage, messageReduce, processMessages } from '../Reducer';
 
-jest.mock('features/wallet/objects/Token.ts', () => ({
+jest.mock('features/wallet/objects/Token', () => ({
   getCurrentPopTokenFromStore: jest.fn(() => Promise.resolve(mockPopToken)),
 }));
 
@@ -30,9 +30,9 @@ const createExtendedMessage = async () => {
   return ExtendedMessage.fromMessage(message, channel);
 };
 
-describe('MessageReducer', () => {
-  beforeAll(configureTestMessageRegistry);
+beforeAll(configureTestFeatures);
 
+describe('MessageReducer', () => {
   it('should return the initial state', () => {
     expect(messageReduce(undefined, {} as AnyAction)).toEqual(initialState);
   });

--- a/fe1-web/src/core/network/ingestion/index.ts
+++ b/fe1-web/src/core/network/ingestion/index.ts
@@ -1,3 +1,4 @@
 export { configure as configureIngestion } from './Configure';
+export { storeMessage } from './Handler';
 export { default as messageReducer } from './Reducer';
 export * from './Reducer';

--- a/fe1-web/src/core/network/jsonrpc/__tests__/FromJsonRpcRequest.test.ts
+++ b/fe1-web/src/core/network/jsonrpc/__tests__/FromJsonRpcRequest.test.ts
@@ -1,16 +1,15 @@
 import 'jest-extended';
-
 import '__tests__/utils/matchers';
+import { configureTestFeatures } from '__tests__/utils';
 import keyPair from 'test_data/keypair.json';
+
 import { OpenedLaoStore } from 'features/lao/store';
 import { CreateLao } from 'features/lao/network/messages';
 import { Lao } from 'features/lao/objects';
 import { Base64UrlData, Hash, PrivateKey, PublicKey } from 'core/objects';
 import { ROOT_CHANNEL } from 'core/objects/Channel';
 
-import { JsonRpcMethod, JsonRpcRequest } from '../index';
-import { MessageRegistry } from '../messages';
-import { configureMessages } from '../messages/Message';
+import { JsonRpcMethod, JsonRpcRequest } from '..';
 import { JsonRpcParamsWithMessage } from '../JsonRpcParamsWithMessage';
 
 const JSON_RPC_FIELDS: string[] = ['method', 'params', 'id', 'jsonrpc'];
@@ -23,9 +22,6 @@ const METHODS = Object.keys(JsonRpcMethod)
 
 export const mockPublicKey = new PublicKey(keyPair.publicKey);
 export const mockSecretKey = new PrivateKey(keyPair.privateKey);
-
-const messageRegistry = new MessageRegistry();
-configureMessages(messageRegistry);
 
 function checkRpcQuery(obj: any): void {
   expect(obj).toBeObject();
@@ -113,6 +109,8 @@ function embeddedMessage(
 
 describe('=== fromJsonJsonRpcRequest checks ===', () => {
   beforeAll(() => {
+    configureTestFeatures();
+
     const sampleLao: Lao = new Lao({
       name: sampleCreateLaoData.name,
       id: Hash.fromStringArray(

--- a/fe1-web/src/core/network/jsonrpc/messages/Message.ts
+++ b/fe1-web/src/core/network/jsonrpc/messages/Message.ts
@@ -7,7 +7,8 @@ import {
   ProtocolError,
   WitnessSignature,
   WitnessSignatureState,
-  PopToken, KeyPair,
+  PopToken,
+  KeyPair,
 } from 'core/objects';
 import { KeyPairStore } from 'core/keypair';
 

--- a/fe1-web/src/core/network/jsonrpc/messages/Message.ts
+++ b/fe1-web/src/core/network/jsonrpc/messages/Message.ts
@@ -170,11 +170,8 @@ export class Message {
   public static async fromData(
     data: MessageData,
     witnessSignatures?: WitnessSignature[],
-    sender: KeyPair,
   ): Promise<Message> {
     const encodedDataJson: Base64UrlData = encodeMessageData(data);
-    let keyPair = KeyPairStore.get();
-    let keyPair = await getPoptoken();
     let publicKey = KeyPairStore.getPublicKey();
     let privateKey = KeyPairStore.getPrivateKey();
 
@@ -194,12 +191,12 @@ export class Message {
         );
       }
     }
-    const signature = sender.privateKey.sign(encodedDataJson);
+    const signature = privateKey.sign(encodedDataJson);
 
     // Send the message with the correct signature
     return new Message({
       data: encodedDataJson,
-      sender: sender.publicKey,
+      sender: publicKey,
       signature: signature,
       message_id: Hash.fromStringArray(encodedDataJson.toString(), signature.toString()),
       witness_signatures: witnessSignatures === undefined ? [] : witnessSignatures,

--- a/fe1-web/src/core/network/jsonrpc/messages/__tests__/Message.test.ts
+++ b/fe1-web/src/core/network/jsonrpc/messages/__tests__/Message.test.ts
@@ -1,5 +1,14 @@
 import 'jest-extended';
 import {
+  mockLao,
+  mockLaoId,
+  mockPopToken,
+  mockPrivateKey,
+  mockPublicKey,
+  configureTestFeatures,
+} from '__tests__/utils';
+
+import {
   Base64UrlData,
   EventTags,
   Hash,
@@ -9,14 +18,6 @@ import {
   Timestamp,
 } from 'core/objects';
 import { KeyPairStore } from 'core/keypair';
-import {
-  mockLao,
-  mockLaoId,
-  mockPopToken,
-  mockPrivateKey,
-  mockPublicKey,
-  configureTestMessageRegistry,
-} from '__tests__/utils';
 
 import { AddChirp } from 'features/social/network/messages/chirp';
 import { EndElection } from 'features/evoting/network/messages';
@@ -33,14 +34,14 @@ const messageRegistry = new MessageRegistry();
 configureMessages(messageRegistry);
 
 beforeAll(() => {
+  configureTestFeatures();
+
   KeyPairStore.store(
     KeyPair.fromState({
       publicKey: mockPublicKey,
       privateKey: mockPrivateKey,
     }),
   );
-
-  configureTestMessageRegistry();
 });
 
 describe('Message', () => {

--- a/fe1-web/src/features/evoting/network/messages/__tests__/SetupElection.test.ts
+++ b/fe1-web/src/features/evoting/network/messages/__tests__/SetupElection.test.ts
@@ -1,11 +1,17 @@
 import 'jest-extended';
-
 import '__tests__/utils/matchers';
+import {
+  mockLao,
+  mockLaoId,
+  mockLaoIdHash,
+  mockLaoName,
+  configureTestFeatures,
+} from '__tests__/utils';
+
 import { EventTags, Hash, Timestamp, ProtocolError } from 'core/objects';
-import STRINGS from 'resources/strings';
-import { mockLao, mockLaoId, mockLaoIdHash, mockLaoName } from '__tests__/utils/TestUtils';
-import { OpenedLaoStore } from 'features/lao/store';
 import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
+import { OpenedLaoStore } from 'features/lao/store';
+import STRINGS from 'resources/strings';
 
 import { Question } from '../../../objects';
 import { SetupElection } from '../SetupElection';
@@ -83,6 +89,7 @@ const initializeData = () => {
 };
 
 beforeAll(() => {
+  configureTestFeatures();
   initializeData();
   OpenedLaoStore.store(mockLao);
 });

--- a/fe1-web/src/features/lao/components/index.ts
+++ b/fe1-web/src/features/lao/components/index.ts
@@ -1,3 +1,9 @@
-export { default as LaoItem } from './LaoItem';
-export { default as LaoProperties } from './LaoProperties';
-export { default as LaoList } from './LaoList';
+import LaoItem from './LaoItem';
+import LaoProperties from './LaoProperties';
+import LaoList from './LaoList';
+
+export { LaoItem, LaoProperties, LaoList };
+
+export const PublicComponents = {
+  LaoList: LaoList,
+};

--- a/fe1-web/src/features/lao/index.ts
+++ b/fe1-web/src/features/lao/index.ts
@@ -3,7 +3,7 @@ import { addReducer } from 'core/redux';
 
 import { configureNetwork } from './network';
 import { laoReducer } from './reducer';
-import * as components from './components';
+import { PublicComponents } from './components';
 import * as hooks from './hooks';
 import * as navigation from './navigation';
 
@@ -17,7 +17,7 @@ export function configure(registry: MessageRegistry) {
   addReducer(laoReducer);
 
   return {
-    components: components,
+    components: PublicComponents,
     hooks: hooks,
     navigation: navigation,
   };

--- a/fe1-web/src/features/lao/network/__tests__/LaoMessageApi.ts
+++ b/fe1-web/src/features/lao/network/__tests__/LaoMessageApi.ts
@@ -1,14 +1,16 @@
 import 'jest-extended';
 import '__tests__/utils/matchers';
-import { ActionType, MessageData, ObjectType } from 'core/network/jsonrpc/messages';
-import { KeyPairStore } from 'core/keypair';
-import { Hash } from 'core/objects';
 import {
   defaultMessageDataFields,
   mockLao,
   mockLaoId,
   mockLaoName,
+  configureTestFeatures,
 } from '__tests__/utils/TestUtils';
+
+import { ActionType, MessageData, ObjectType } from 'core/network/jsonrpc/messages';
+import { KeyPairStore } from 'core/keypair';
+import { Hash } from 'core/objects';
 import { publish as mockPublish } from 'core/network/JsonRpcApi';
 
 import { CreateLao, StateLao, UpdateLao } from '../messages';
@@ -130,6 +132,8 @@ const initializeChecks = () => {
     expect(data.id).toBeJsonEqual(expected);
   };
 };
+
+beforeAll(configureTestFeatures);
 
 beforeEach(() => {
   OpenedLaoStore.store(mockLao);

--- a/fe1-web/src/features/lao/network/messages/__tests__/CreateLao.test.ts
+++ b/fe1-web/src/features/lao/network/messages/__tests__/CreateLao.test.ts
@@ -1,7 +1,5 @@
 import 'jest-extended';
-
 import '__tests__/utils/matchers';
-import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
 import {
   mockLaoCreationTime,
   mockLaoIdHash,
@@ -9,7 +7,10 @@ import {
   mockPublicKey,
   mockPublicKey2,
   org,
-} from '__tests__/utils/TestUtils';
+  configureTestFeatures,
+} from '__tests__/utils';
+
+import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
 import { Hash, PublicKey, ProtocolError } from 'core/objects';
 
 import { CreateLao } from '../CreateLao';
@@ -37,6 +38,8 @@ const createLaoJson = `{
 }`;
 
 describe('CreateLao', () => {
+  beforeAll(configureTestFeatures);
+
   it('should be created correctly from Json', () => {
     expect(new CreateLao(sampleCreateLao)).toBeJsonEqual(sampleCreateLao);
     const temp = {

--- a/fe1-web/src/features/lao/network/messages/__tests__/StateLao.test.ts
+++ b/fe1-web/src/features/lao/network/messages/__tests__/StateLao.test.ts
@@ -1,8 +1,5 @@
 import 'jest-extended';
-
 import '__tests__/utils/matchers';
-import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
-import { Base64UrlData, Hash, PublicKey, Timestamp, ProtocolError } from 'core/objects';
 import {
   mockLaoCreationTime,
   mockLaoIdHash,
@@ -10,7 +7,11 @@ import {
   mockPublicKey,
   mockPublicKey2,
   org,
-} from '__tests__/utils/TestUtils';
+  configureTestFeatures,
+} from '__tests__/utils';
+
+import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
+import { Base64UrlData, Hash, PublicKey, Timestamp, ProtocolError } from 'core/objects';
 
 import { StateLao } from '../StateLao';
 
@@ -45,6 +46,8 @@ const stateLaoJson = `{
 }`;
 
 describe('StateLao', () => {
+  beforeAll(configureTestFeatures);
+
   it('should be created correctly from Json', () => {
     expect(new StateLao(sampleStateLao)).toBeJsonEqual(sampleStateLao);
     const temp = {

--- a/fe1-web/src/features/lao/network/messages/__tests__/UpdateLao.test.ts
+++ b/fe1-web/src/features/lao/network/messages/__tests__/UpdateLao.test.ts
@@ -1,14 +1,15 @@
 import 'jest-extended';
-
 import '__tests__/utils/matchers';
-import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
 import {
   mockLao,
   mockLaoIdHash,
   mockLaoName,
   mockPublicKey,
   mockPublicKey2,
-} from '__tests__/utils/TestUtils';
+  configureTestFeatures,
+} from '__tests__/utils';
+
+import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
 import { Hash, PublicKey, ProtocolError, Timestamp } from 'core/objects';
 
 import { OpenedLaoStore } from '../../../store';
@@ -36,6 +37,7 @@ const updateLaoJson = `{
 }`;
 
 beforeAll(() => {
+  configureTestFeatures();
   OpenedLaoStore.store(mockLao);
 });
 

--- a/fe1-web/src/features/meeting/network/__tests__/MeetingMessageApi.test.ts
+++ b/fe1-web/src/features/meeting/network/__tests__/MeetingMessageApi.test.ts
@@ -1,10 +1,15 @@
 import 'jest-extended';
-
 import '__tests__/utils/matchers';
+import {
+  defaultMessageDataFields,
+  mockLao,
+  mockLaoId,
+  configureTestFeatures,
+} from '__tests__/utils';
+
 import { ActionType, MessageData, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
 import { Hash, Timestamp } from 'core/objects';
 import { OpenedLaoStore } from 'features/lao/store';
-import { defaultMessageDataFields, mockLao, mockLaoId } from '__tests__/utils/TestUtils';
 import { publish as mockPublish } from 'core/network/JsonRpcApi';
 
 import { CreateMeeting } from '../messages';
@@ -66,6 +71,8 @@ const initializeChecks = () => {
     expect(data.id).toEqual(expected);
   };
 };
+
+beforeAll(configureTestFeatures);
 
 beforeEach(() => {
   OpenedLaoStore.store(mockLao);

--- a/fe1-web/src/features/meeting/network/messages/__tests__/CreateMeeting.test.ts
+++ b/fe1-web/src/features/meeting/network/messages/__tests__/CreateMeeting.test.ts
@@ -1,10 +1,11 @@
 import 'jest-extended';
 
-import '__tests__/utils/matchers';
 import { Hash, Timestamp, ProtocolError } from 'core/objects';
 import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
-import { mockLao, mockLaoCreationTime, mockLaoId } from '__tests__/utils/TestUtils';
 import { OpenedLaoStore } from 'features/lao/store';
+
+import '__tests__/utils/matchers';
+import { mockLao, mockLaoId, mockLaoCreationTime, configureTestFeatures } from '__tests__/utils';
 
 import { CreateMeeting } from '../CreateMeeting';
 
@@ -40,6 +41,7 @@ const createMeetingJson = `{
 }`;
 
 beforeAll(() => {
+  configureTestFeatures();
   OpenedLaoStore.store(mockLao);
 });
 

--- a/fe1-web/src/features/meeting/network/messages/__tests__/StateMeeting.test.ts
+++ b/fe1-web/src/features/meeting/network/messages/__tests__/StateMeeting.test.ts
@@ -1,10 +1,11 @@
 import 'jest-extended';
 
-import '__tests__/utils/matchers';
 import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
 import { Base64UrlData, Hash, Timestamp, ProtocolError } from 'core/objects';
-import { mockLao, mockLaoId } from '__tests__/utils/TestUtils';
 import { OpenedLaoStore } from 'features/lao/store';
+
+import '__tests__/utils/matchers';
+import { mockLao, mockLaoId, configureTestFeatures } from '__tests__/utils';
 
 import { StateMeeting } from '../StateMeeting';
 
@@ -49,6 +50,7 @@ const stateMeetingJson = `{
 }`;
 
 beforeAll(() => {
+  configureTestFeatures();
   OpenedLaoStore.store(mockLao);
 });
 

--- a/fe1-web/src/features/rollCall/network/__tests__/RollCallMessageApi.test.ts
+++ b/fe1-web/src/features/rollCall/network/__tests__/RollCallMessageApi.test.ts
@@ -1,15 +1,19 @@
 import 'jest-extended';
-import { beforeEach } from '@jest/globals';
-
 import '__tests__/utils/matchers';
+import {
+  defaultMessageDataFields,
+  mockLao,
+  mockLaoId,
+  configureTestFeatures,
+} from '__tests__/utils';
+
 import { ActionType, MessageData, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
 import { Hash, PublicKey, Timestamp } from 'core/objects';
 import { OpenedLaoStore } from 'features/lao/store';
-import { defaultMessageDataFields, mockLao, mockLaoId } from '__tests__/utils/TestUtils';
 import { publish as mockPublish } from 'core/network/JsonRpcApi';
+import { CloseRollCall, CreateRollCall, OpenRollCall, ReopenRollCall } from '../messages';
 
 import * as msApi from '../RollCallMessageApi';
-import { CloseRollCall, CreateRollCall, OpenRollCall, ReopenRollCall } from '../messages';
 
 jest.mock('core/network/JsonRpcApi');
 const publishMock = mockPublish as jest.Mock;
@@ -143,6 +147,7 @@ const initializeChecks = () => {
 };
 
 beforeEach(() => {
+  configureTestFeatures();
   OpenedLaoStore.store(mockLao);
   publishMock.mockClear();
   initializeChecks();

--- a/fe1-web/src/features/rollCall/network/messages/__tests__/CloseRollCall.test.ts
+++ b/fe1-web/src/features/rollCall/network/messages/__tests__/CloseRollCall.test.ts
@@ -1,14 +1,15 @@
 import 'jest-extended';
-
 import '__tests__/utils/matchers';
-import { Hash, PublicKey, Timestamp, ProtocolError } from 'core/objects';
 import {
   mockLao,
   mockLaoId,
   mockLaoName,
   mockPublicKey,
   mockPublicKey2,
-} from '__tests__/utils/TestUtils';
+  configureTestFeatures,
+} from '__tests__/utils';
+
+import { Hash, PublicKey, Timestamp, ProtocolError } from 'core/objects';
 import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
 import { OpenedLaoStore } from 'features/lao/store';
 
@@ -48,6 +49,7 @@ const closeRollCallJson = `{
 }`;
 
 beforeAll(() => {
+  configureTestFeatures();
   OpenedLaoStore.store(mockLao);
 });
 

--- a/fe1-web/src/features/rollCall/network/messages/__tests__/CreateRollCall.test.ts
+++ b/fe1-web/src/features/rollCall/network/messages/__tests__/CreateRollCall.test.ts
@@ -1,9 +1,9 @@
 import 'jest-extended';
-
 import '__tests__/utils/matchers';
+import { configureTestFeatures, mockLao, mockLaoId } from '__tests__/utils';
+
 import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
 import { Hash, Timestamp, ProtocolError } from 'core/objects';
-import { mockLao, mockLaoId } from '__tests__/utils/TestUtils';
 import { OpenedLaoStore } from 'features/lao/store';
 
 import { CreateRollCall } from '../CreateRollCall';
@@ -41,6 +41,7 @@ const createRollCallJson = `{
 }`;
 
 beforeAll(() => {
+  configureTestFeatures();
   OpenedLaoStore.store(mockLao);
 });
 

--- a/fe1-web/src/features/rollCall/network/messages/__tests__/OpenRollCall.test.ts
+++ b/fe1-web/src/features/rollCall/network/messages/__tests__/OpenRollCall.test.ts
@@ -3,7 +3,7 @@ import 'jest-extended';
 import '__tests__/utils/matchers';
 import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
 import { Hash, Timestamp, ProtocolError } from 'core/objects';
-import { mockLao, mockLaoId, mockLaoName } from '__tests__/utils/TestUtils';
+import { mockLao, mockLaoId, mockLaoName, configureTestFeatures } from '__tests__/utils';
 import { OpenedLaoStore } from 'features/lao/store';
 
 import { OpenRollCall } from '../OpenRollCall';
@@ -34,6 +34,7 @@ const openRollCallJson = `{
 }`;
 
 beforeAll(() => {
+  configureTestFeatures();
   OpenedLaoStore.store(mockLao);
 });
 

--- a/fe1-web/src/features/rollCall/network/messages/__tests__/ReopenRollCall.test.ts
+++ b/fe1-web/src/features/rollCall/network/messages/__tests__/ReopenRollCall.test.ts
@@ -1,8 +1,8 @@
 import 'jest-extended';
-
 import '__tests__/utils/matchers';
+import { mockLao, mockLaoId, mockLaoName, configureTestFeatures } from '__tests__/utils';
+
 import { Hash, Timestamp, ProtocolError } from 'core/objects';
-import { mockLao, mockLaoId, mockLaoName } from '__tests__/utils/TestUtils';
 import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
 import { OpenedLaoStore } from 'features/lao/store';
 
@@ -34,6 +34,7 @@ const reopenRollCallJson = `{
 }`;
 
 beforeAll(() => {
+  configureTestFeatures();
   OpenedLaoStore.store(mockLao);
 });
 

--- a/fe1-web/src/features/social/components/__tests__/ChirpCard.test.tsx
+++ b/fe1-web/src/features/social/components/__tests__/ChirpCard.test.tsx
@@ -46,7 +46,7 @@ const chirp1 = new Chirp({
 jest.mock('features/social/network/SocialMessageApi');
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
-  useSelector: jest.fn().mockImplementation(() => ({ 1234: { '👍': 1, '👎': 0, '❤': 0 } })),
+  useSelector: jest.fn().mockImplementation(() => ({ 1234: { '👍': 1, '👎': 0, '❤️': 0 } })),
 }));
 
 jest.mock('core/components/ProfileIcon', () => () => 'ProfileIcon');
@@ -63,12 +63,12 @@ describe('ChirpCard', () => {
     const getMockLao = jest.spyOn(OpenedLaoStore, 'get');
     getMockLao.mockImplementation(() => mockLao);
 
-    it.skip('renders correctly for sender', () => {
+    it('renders correctly for sender', () => {
       const obj = render(<ChirpCard chirp={chirp} currentUserPublicKey={sender} />);
       expect(obj.toJSON()).toMatchSnapshot();
     });
 
-    it.skip('renders correctly for non-sender', () => {
+    it('renders correctly for non-sender', () => {
       const obj = render(
         <ChirpCard chirp={chirp} currentUserPublicKey={new PublicKey('IAmNotTheSender')} />,
       );
@@ -91,7 +91,7 @@ describe('ChirpCard', () => {
   });
 
   describe('for reaction', () => {
-    it.skip('renders correctly with reaction', () => {
+    it('renders correctly with reaction', () => {
       const obj = render(<ChirpCard chirp={chirp} currentUserPublicKey={sender} />);
       expect(obj.toJSON()).toMatchSnapshot();
     });

--- a/fe1-web/src/features/social/network/__tests__/SocialMessageApi.test.ts
+++ b/fe1-web/src/features/social/network/__tests__/SocialMessageApi.test.ts
@@ -6,7 +6,8 @@ import { ActionType, MessageData, ObjectType } from 'core/network/jsonrpc/messag
 import { Hash, PublicKey } from 'core/objects';
 import { OpenedLaoStore } from 'features/lao/store';
 import { publish as mockPublish } from 'core/network/JsonRpcApi';
-import { mockLao, mockLaoId } from '__tests__/utils/TestUtils';
+
+import { mockLao, mockLaoId, configureTestFeatures } from '__tests__/utils';
 
 import { AddChirp } from '../messages/chirp';
 import * as msApi from '../SocialMessageApi';
@@ -32,6 +33,8 @@ const initializeChecks = () => {
     expect(data.timestamp).toBeNumberObject();
   };
 };
+
+beforeAll(configureTestFeatures);
 
 beforeEach(() => {
   publishMock.mockClear();

--- a/fe1-web/src/features/social/network/messages/chirp/__tests__/AddChirp.test.ts
+++ b/fe1-web/src/features/social/network/messages/chirp/__tests__/AddChirp.test.ts
@@ -1,6 +1,6 @@
 import 'jest-extended';
-
 import '__tests__/utils/matchers';
+
 import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
 import { Hash, Timestamp, ProtocolError } from 'core/objects';
 

--- a/fe1-web/src/features/social/network/messages/chirp/__tests__/DeleteChirp.test.ts
+++ b/fe1-web/src/features/social/network/messages/chirp/__tests__/DeleteChirp.test.ts
@@ -1,6 +1,6 @@
 import 'jest-extended';
-
 import '__tests__/utils/matchers';
+
 import { Base64UrlData, Hash, Timestamp, ProtocolError } from 'core/objects';
 import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
 

--- a/fe1-web/src/features/wallet/objects/__tests__/Seed.test.ts
+++ b/fe1-web/src/features/wallet/objects/__tests__/Seed.test.ts
@@ -1,3 +1,5 @@
+import { configureTestFeatures } from '__tests__/utils';
+
 import { WalletStore } from '../../store';
 import * as Seed from '../Seed';
 
@@ -6,6 +8,8 @@ jest.mock('core/platform/crypto/browser');
 
 const mnemonic: string =
   'garbage effort river orphan negative kind outside quit hat camera approve first';
+
+beforeAll(configureTestFeatures);
 
 beforeEach(() => {
   WalletStore.clear();

--- a/fe1-web/src/features/wallet/objects/__tests__/Token.test.ts
+++ b/fe1-web/src/features/wallet/objects/__tests__/Token.test.ts
@@ -1,3 +1,5 @@
+import { configureTestFeatures } from '__tests__/utils';
+
 import { Base64UrlData, Hash } from 'core/objects';
 
 import { WalletStore } from '../../store';
@@ -11,6 +13,8 @@ const mockId = 'T8grJq7LR9KGjE7741gXMqPny8xsLvsyBiwIFwoF7rg=';
 
 const mnemonic: string =
   'garbage effort river orphan negative kind outside quit hat camera approve first';
+
+beforeAll(configureTestFeatures);
 
 beforeEach(() => {
   WalletStore.clear();

--- a/fe1-web/src/features/wallet/store/__tests__/WalletStore.test.ts
+++ b/fe1-web/src/features/wallet/store/__tests__/WalletStore.test.ts
@@ -6,7 +6,7 @@ import { WalletStore } from '../WalletStore';
 
 jest.mock('core/platform/Storage');
 jest.mock('core/platform/crypto/browser');
-jest.mock('core/redux/ReduxSetUp');
+jest.mock('core/redux/GlobalStore');
 
 const seed = new Uint8Array([0x1, 0x8, 0xf, 0x22, 0xff, 0x33, 0x99]);
 const mnemonic = 'probably insecure definitely memorable';

--- a/fe1-web/src/features/witness/network/messages/__tests__/WitnessMessage.test.ts
+++ b/fe1-web/src/features/witness/network/messages/__tests__/WitnessMessage.test.ts
@@ -1,9 +1,9 @@
 import 'jest-extended';
-import { sign } from 'tweetnacl';
-
 import '__tests__/utils/matchers';
+import { mockPrivateKey } from '__tests__/utils';
+
+import { sign } from 'tweetnacl';
 import { Base64UrlData, KeyPair, PrivateKey, PublicKey, ProtocolError } from 'core/objects';
-import { mockPrivateKey } from '__tests__/utils/TestUtils';
 import { ActionType, ObjectType } from 'core/network/jsonrpc/messages/MessageData';
 
 import { WitnessMessage } from '../WitnessMessage';
@@ -54,7 +54,7 @@ describe('WitnessMessage', () => {
     expect(createWrongObj).toThrow(ProtocolError);
   });
 
-  it.skip('fromJson should throw an error if signature is incorrect', () => {
+  it('fromJson should throw an error if signature is incorrect', () => {
     const generateKeyPair = () => {
       const pair = sign.keyPair();
       return new KeyPair({


### PR DESCRIPTION
Suboptimal solution:
- all tests initialize ALL the features (incl. message registry) before running
- in practice, we should be able to ONLY use a feature's function, but this was more expedient.

-> Once `KeyPairStore` is removed from most intrusive places (e.g. `Message.fromData`), this shouldn't be required anymore