### PR TITLE
Store election result messages

### DIFF
--- a/be1-go/channel/election/mod.go
+++ b/be1-go/channel/election/mod.go
@@ -428,7 +428,6 @@ func (c *Channel) broadcastElectionResult() error {
 		MessageID:         messagedata.Hash(newData64, signature),
 		WitnessSignatures: []message.WitnessSignature{},
 	}
-	
 	c.inbox.StoreMessage(electionResultMsg)
 	c.broadcastToAllClients(electionResultMsg)
 

--- a/be1-go/channel/election/mod.go
+++ b/be1-go/channel/election/mod.go
@@ -428,7 +428,8 @@ func (c *Channel) broadcastElectionResult() error {
 		MessageID:         messagedata.Hash(newData64, signature),
 		WitnessSignatures: []message.WitnessSignature{},
 	}
-
+	
+	c.inbox.StoreMessage(electionResultMsg)
 	c.broadcastToAllClients(electionResultMsg)
 
 	return nil


### PR DESCRIPTION
When working on https://github.com/dedis/popstellar/issues/703 I noticed that election result messages are not sent to a new client connecting after sending a catchup message. The reason is that the election#result messages are not stored when broadcasting them. This pull request fixes this.

Compare
https://github.com/dedis/popstellar/blob/ab162f1cb2122f10dafbac003979abbfee4ac862/be1-go/channel/election/mod.go#L343-L344

and

https://github.com/dedis/popstellar/blob/ab162f1cb2122f10dafbac003979abbfee4ac862/be1-go/channel/election/mod.go#L384-L385

to

https://github.com/dedis/popstellar/blob/ab162f1cb2122f10dafbac003979abbfee4ac862/be1-go/channel/election/mod.go#L430-L435.