### PR TITLE
DbActor: fill decodedData

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/Server.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/Server.scala
@@ -45,9 +45,9 @@ object Server {
       val options: Options = new Options()
       options.createIfMissing(true)
 
-      val pubSubMediatorRef: ActorRef = system.actorOf(PubSubMediator.props, "PubSubMediator")
-      val dbActorRef: AskableActorRef = system.actorOf(Props(DbActor(pubSubMediatorRef)), "DbActor")
       val messageRegistry: MessageRegistry = MessageRegistry()
+      val pubSubMediatorRef: ActorRef = system.actorOf(PubSubMediator.props, "PubSubMediator")
+      val dbActorRef: AskableActorRef = system.actorOf(Props(DbActor(pubSubMediatorRef, messageRegistry)), "DbActor")
 
       def publishSubscribeRoute: RequestContext => Future[RouteResult] = path(config.path) {
         handleWebSocketMessages(PublishSubscribe.buildGraph(pubSubMediatorRef, dbActorRef, messageRegistry)(system))

--- a/be2-scala/src/main/scala/ch/epfl/pop/json/MessageDataProtocol.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/json/MessageDataProtocol.scala
@@ -11,9 +11,11 @@ import ch.epfl.pop.model.network.method.message.data.socialMedia._
 import ch.epfl.pop.model.network.method.message.data.witness._
 import ch.epfl.pop.model.network.method.message.data.{ActionType, ObjectType}
 import ch.epfl.pop.model.objects._
+import ch.epfl.pop.pubsub.MessageRegistry
 import spray.json._
 
 import scala.collection.immutable.ListMap
+import scala.util.Try
 
 object MessageDataProtocol extends DefaultJsonProtocol {
 
@@ -36,6 +38,19 @@ object MessageDataProtocol extends DefaultJsonProtocol {
     override def write(obj: ActionType): JsValue = JsString(obj.toString)
   }
 
+
+  // ------------------------------- METADATA UTILITY -------------------------------------- //
+  // retrieve information from the header if it is correct.
+  //
+  // Succeeds if both 'object' and 'action' are present and are strings
+  def parseHeader(data: String): Try[(ObjectType, ActionType)] =
+    Try {
+      data.parseJson.asJsObject.getFields("object", "action") match {
+        case Seq(objectString @ JsString(_), actionString @ JsString(_)) =>
+          (objectString.convertTo[ObjectType], actionString.convertTo[ActionType])
+        case _ => throw new IllegalArgumentException("parseHeader: header fields not found")
+      }
+    }
 
   // ------------------------------- DATA FORMATTERS UTILITY ------------------------------- //
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/MessageDecoder.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/MessageDecoder.scala
@@ -46,13 +46,10 @@ object MessageDecoder {
    */
   def dataParser(registry: MessageRegistry): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map(parseData(_, registry))
 
-  private def populateDataField(rpcRequest: JsonRpcRequest, objectString: JsString, actionString: JsString, dataJsonString: String, registry: MessageRegistry): GraphMessage = {
+  private def populateDataField(rpcRequest: JsonRpcRequest, _object: ObjectType, action: ActionType, dataJsonString: String, registry: MessageRegistry): GraphMessage = {
     var filledRequest = rpcRequest // filler for the typed request
 
     Try {
-      val _object: ObjectType = objectString.convertTo[ObjectType]
-      val action: ActionType = actionString.convertTo[ActionType]
-
       val validated: Try[Unit] = registry.getSchemaVerifier(_object, action) match {
         // validate the data schema if the registry found a mapping
         case Some(schemaVerifier) => schemaVerifier(dataJsonString)
@@ -82,13 +79,13 @@ object MessageDecoder {
     }
   }
 
-  /**
-   * Decides whether a graph message 'data' field should be decoded or not.
-   * If yes, the 'data' field is decoded
-   *
-   * @param graphMessage graph message that should be further decoded
-   * @return the upgraded graph message (with 'data' field decoded) or an error
-   */
+  /** Decides whether a graph message 'data' field should be decoded or not. If yes, the 'data' field is decoded
+    *
+    * @param graphMessage
+    *   graph message that should be further decoded
+    * @return
+    *   the upgraded graph message (with 'data' field decoded) or an error
+    */
   def parseData(graphMessage: GraphMessage, registry: MessageRegistry): GraphMessage = graphMessage match {
     case Left(rpcRequest: JsonRpcRequest) => rpcRequest.getDecodedData match {
       case Some(_) =>
@@ -99,22 +96,15 @@ object MessageDecoder {
         // json string representation of the 'data' field
         val jsonString: JsonString = rpcRequest.getEncodedData.fold("")(_.decodeToString())
 
-        // Try to extract data header from the json string
-        Try(jsonString.parseJson.asJsObject.getFields("object", "action")) match {
-
-          // if the header is correct (both 'object' and 'action' are present and both strings)
-          case Success(Seq(objectString@JsString(_), actionString@JsString(_))) =>
-            populateDataField(rpcRequest, objectString, actionString, jsonString, registry)
-          case Success(_) => Right(PipelineError(
-            ErrorCodes.INVALID_DATA.id,
-            "Invalid data: Unable to parse 'data' field: 'object' or 'action' field is missing/wrongly formatted",
-            rpcRequest.id
-          ))
-          case _ => Right(PipelineError(
-            ErrorCodes.INVALID_DATA.id,
-            "Invalid data: Unable to parse 'data' field: 'data' is not a valid json string",
-            rpcRequest.id
-          ))
+        parseHeader(jsonString) match {
+          case Success((_object, action)) =>
+            populateDataField(rpcRequest, _object, action, jsonString, registry)
+          case Failure(exception) =>
+            Right(PipelineError(
+              ErrorCodes.INVALID_DATA.id,
+              s"Invalid header: ${exception.getMessage()}",
+              rpcRequest.id
+            ))
         }
     }
     case _ => graphMessage

--- a/be2-scala/src/main/scala/ch/epfl/pop/storage/DbActor.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/storage/DbActor.scala
@@ -7,13 +7,14 @@ import ch.epfl.pop.model.network.method.message.Message
 import ch.epfl.pop.model.network.method.message.data.ObjectType
 import ch.epfl.pop.model.objects._
 import ch.epfl.pop.pubsub.graph.ErrorCodes
-import ch.epfl.pop.pubsub.{PubSubMediator, PublishSubscribe}
+import ch.epfl.pop.pubsub.{MessageRegistry, PubSubMediator, PublishSubscribe}
 import ch.epfl.pop.storage.DbActor._
 
 import scala.util.{Failure, Success, Try}
 
 final case class DbActor(
                        private val mediatorRef: ActorRef,
+                       private val registry: MessageRegistry,
                        private val storage: Storage = new DiskStorage()
                      ) extends Actor with ActorLogging {
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/json/MessageDataProtocolSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/json/MessageDataProtocolSuite.scala
@@ -55,7 +55,7 @@ class MessageDataProtocolSuite extends FunSuite with Matchers {
     example
   }
 
-  test("Parser correctly encodes/decodes a CreateLao message data") {
+  test("Parser correctly decodes a CreateLao message data") {
     val example: String = getExampleMessage("messageData/lao_create/lao_create.json")
     val messageData = CreateLao.buildFromJson(example)
 
@@ -65,7 +65,7 @@ class MessageDataProtocolSuite extends FunSuite with Matchers {
     messageData should equal(expected)
   }
 
-  test("Parser correctly encodes/decodes a SetupElection message data") {
+  test("Parser correctly decodes a SetupElection message data") {
     val example: String = getExampleMessage("messageData/election_setup/election_setup.json")
     val messageData = SetupElection.buildFromJson(example)
 
@@ -76,7 +76,7 @@ class MessageDataProtocolSuite extends FunSuite with Matchers {
     messageData should equal(expected)
   }
 
-  test("Parser correctly encodes/decodes a ResultElection message data") {
+  test("Parser correctly decodes a ResultElection message data") {
     val example: String = getExampleMessage("messageData/election_result.json")
 
     val messageData = ResultElection.buildFromJson(example)
@@ -90,7 +90,7 @@ class MessageDataProtocolSuite extends FunSuite with Matchers {
     messageData should equal(expected)
   }
 
-  test("Parser correctly encodes/decodes a EndElection message data") {
+  test("Parser correctly decodes a EndElection message data") {
     val example: String = getExampleMessage("messageData/election_end/election_end.json")
     val messageData = EndElection.buildFromJson(example)
 
@@ -100,7 +100,7 @@ class MessageDataProtocolSuite extends FunSuite with Matchers {
     messageData should equal(expected)
   }
 
-  test("Parser correctly encodes/decodes a CastVoteElection write_in message data") {
+  test("Parser correctly decodes a CastVoteElection write_in message data") {
     val example: String = getExampleMessage("messageData/vote_cast_write_in.json")
     val messageData = CastVoteElection.buildFromJson(example)
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
@@ -7,7 +7,7 @@ import akka.pattern.AskableActorRef
 import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import ch.epfl.pop.pubsub.graph.{GraphMessage, PipelineError}
-import ch.epfl.pop.pubsub.{AskPatternConstants, PubSubMediator}
+import ch.epfl.pop.pubsub.{AskPatternConstants, MessageRegistry, PubSubMediator}
 
 //import util.examples.MessageExample._
 import java.io.File
@@ -28,7 +28,7 @@ class LaoValidatorSuite extends TestKit(ActorSystem("laoValidatorTestActorSystem
   final val DB_TEST_FOLDER: String = "databaseLaoTest"
 
   val pubSubMediatorRef: ActorRef = system.actorOf(PubSubMediator.props, "PubSubMediator")
-  val dbActorRef: AskableActorRef = system.actorOf(Props(DbActor(pubSubMediatorRef, InMemoryStorage())), "DbActor")
+  val dbActorRef: AskableActorRef = system.actorOf(Props(DbActor(pubSubMediatorRef, MessageRegistry(), InMemoryStorage())), "DbActor")
 
   override def afterAll(): Unit = {
     // Stops the test actor system

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SocialMediaValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SocialMediaValidatorSuite.scala
@@ -10,7 +10,7 @@ import akka.util.Timeout
 import ch.epfl.pop.model.network.method.message.data.ObjectType
 import ch.epfl.pop.model.objects._
 import ch.epfl.pop.pubsub.graph.{GraphMessage, PipelineError}
-import ch.epfl.pop.pubsub.{AskPatternConstants, PubSubMediator}
+import ch.epfl.pop.pubsub.{AskPatternConstants, MessageRegistry, PubSubMediator}
 import ch.epfl.pop.storage.{DbActor, InMemoryStorage}
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
 import util.examples.JsonRpcRequestExample._
@@ -26,7 +26,7 @@ class SocialMediaValidatorSuite extends TestKit(ActorSystem("socialMediaValidato
   final val DB_TEST_FOLDER: String = "databaseSocialMediaTest"
 
   val pubSubMediatorRef: ActorRef = system.actorOf(PubSubMediator.props, "PubSubMediator")
-  val dbActorRef: AskableActorRef = system.actorOf(Props(DbActor(pubSubMediatorRef, InMemoryStorage())), "DbActor")
+  val dbActorRef: AskableActorRef = system.actorOf(Props(DbActor(pubSubMediatorRef, MessageRegistry(), InMemoryStorage())), "DbActor")
 
   // Implicit for system actors
   implicit val timeout: Timeout = Timeout(1, TimeUnit.SECONDS)

--- a/be2-scala/src/test/scala/ch/epfl/pop/storage/DbActorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/storage/DbActorSuite.scala
@@ -345,7 +345,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     val readMessage: Message = answer.asInstanceOf[DbActor.DbActorReadAck].message.get
 
-    readMessage should equal(MESSAGE.copy(decodedData = None))
+    readMessage should equal(MESSAGE)
   }
 
   test("read does not fail for non-existing message (returns None)"){
@@ -406,8 +406,8 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     val list: List[Message] = answer.asInstanceOf[DbActor.DbActorCatchupAck].messages
 
     list.size should equal (2)
-    list should contain(MESSAGE.copy(decodedData = None))
-    list should contain(message2.copy(decodedData = None))
+    list should contain(MESSAGE)
+    list should contain(message2)
   }
 
   test("catchup should not fail on a channel with ChannelData containing missing message_ids (and only return valid messages)"){
@@ -433,7 +433,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     val list: List[Message] = answer.asInstanceOf[DbActor.DbActorCatchupAck].messages
 
     list.size should equal(1)
-    list should contain(MESSAGE.copy(decodedData = None))
+    list should contain(MESSAGE)
   }
 
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/storage/DbActorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/storage/DbActorSuite.scala
@@ -6,7 +6,7 @@ import akka.testkit.{ImplicitSender, TestKit}
 import ch.epfl.pop.model.network.method.message.Message
 import ch.epfl.pop.model.network.method.message.data.ObjectType
 import ch.epfl.pop.model.objects._
-import ch.epfl.pop.pubsub.{AskPatternConstants, PubSubMediator}
+import ch.epfl.pop.pubsub.{AskPatternConstants, MessageRegistry, PubSubMediator}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
 import util.examples.MessageExample
@@ -34,7 +34,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
   test("write can WRITE in an existing channel") {
     val storage: InMemoryStorage = InMemoryStorage()
-    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, storage)))
+    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), storage)))
 
     storage.size should equal (0)
 
@@ -54,7 +54,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
   test("write can WRITE in a non-existing channel") {
     val storage: InMemoryStorage = InMemoryStorage()
-    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, storage)))
+    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), storage)))
 
     storage.size should equal (0)
 
@@ -69,7 +69,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
   test("write behaves normally for multiple WRITE requests") {
     val storage: InMemoryStorage = InMemoryStorage()
-    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, storage)))
+    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), storage)))
 
     val channelName1 = CHANNEL_NAME
     val channelName2 = s"${CHANNEL_NAME}2"
@@ -126,7 +126,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
   test("createChannel effectively creates a new channel") {
     val storage: InMemoryStorage = InMemoryStorage()
-    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, storage)), "r")
+    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), storage)), "r")
 
     storage.size should equal (0)
 
@@ -139,7 +139,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
   test("createChannel does not overwrite channels on duplicates") {
     val storage: InMemoryStorage = InMemoryStorage()
-    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, storage)))
+    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), storage)))
 
     storage.size should equal (0)
 
@@ -157,7 +157,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
   test("createChannelsFromList creates multiple channels") {
     val storage: InMemoryStorage = InMemoryStorage()
-    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, storage)))
+    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), storage)))
 
     storage.size should equal (0)
 
@@ -171,7 +171,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
   test("createChannelsFromList does not overwrite channels on duplicates (duplicates already created)") {
     val storage: InMemoryStorage = InMemoryStorage()
-    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, storage)))
+    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), storage)))
 
     storage.size should equal (0)
 
@@ -191,7 +191,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
   test("createChannelsFromList does not overwrite channels on duplicates (duplicates in the list)") {
     val storage: InMemoryStorage = InMemoryStorage()
-    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, storage)))
+    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), storage)))
 
     storage.size should equal (0)
 
@@ -205,7 +205,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
   test("createChannelsFromList works for 0 or 1 element") {
     val storage: InMemoryStorage = InMemoryStorage()
-    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, storage)))
+    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), storage)))
 
     storage.size should equal (0)
 
@@ -224,7 +224,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
   test("checkChannelExistence does not detect a non-existing channel") {
     val storage: InMemoryStorage = InMemoryStorage()
-    val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, storage)))
+    val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), storage)))
 
     storage.size should equal (0)
 
@@ -241,7 +241,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
   test("checkChannelExistence succeeds on the detection of an existing channel") {
     val storage: InMemoryStorage = InMemoryStorage()
-    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, storage)))
+    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), storage)))
 
     storage.size should equal (0)
 
@@ -260,7 +260,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
   test("writeLaoData succeeds for both new and updated data"){
     // arrange
     val storage: InMemoryStorage = InMemoryStorage()
-    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, storage)))
+    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), storage)))
 
     val messageLao: Message = MessageExample.MESSAGE_CREATELAO_SIMPLIFIED
 
@@ -288,7 +288,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     val laoDataKey: String = s"$CHANNEL_NAME${Channel.LAO_DATA_LOCATION}"
     val initialStorage: InMemoryStorage = InMemoryStorage()
     initialStorage.write((laoDataKey, laoData.toJsonString))
-    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, initialStorage)))
+    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 
     // act
     dbActor ! DbActor.WriteLaoData(Channel(CHANNEL_NAME), messageRollCall); sleep()
@@ -313,7 +313,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     val laoDataKey: String = s"$CHANNEL_NAME${Channel.LAO_DATA_LOCATION}"
     val initialStorage: InMemoryStorage = InMemoryStorage()
     initialStorage.write((laoDataKey, laoData.toJsonString))
-    val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, initialStorage)))
+    val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 
     // act
     val ask = dbActor ? DbActor.ReadLaoData(channelName1)
@@ -334,7 +334,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     val channelName1: Channel = Channel(CHANNEL_NAME)
     val initialStorage: InMemoryStorage = InMemoryStorage()
     initialStorage.write((s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}", MESSAGE.toJsonString))
-    val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, initialStorage)))
+    val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 
     // act
     val ask = dbActor ? DbActor.Read(channelName1, MESSAGE.message_id)
@@ -352,7 +352,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     // arrange
     val channelName1: Channel = Channel(CHANNEL_NAME)
     val initialStorage: InMemoryStorage = InMemoryStorage()
-    val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, initialStorage)))
+    val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 
     // act
     val ask = dbActor ? DbActor.Read(channelName1, MESSAGE.message_id)
@@ -369,7 +369,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     val initialStorage: InMemoryStorage = InMemoryStorage()
     val channelData: ChannelData = ChannelData(ObjectType.LAO, Nil)
     initialStorage.write((CHANNEL_NAME, channelData.toJsonString))
-    val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, initialStorage)))
+    val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 
     // act
     val ask = dbActor ? DbActor.ReadChannelData(channelName1)
@@ -394,7 +394,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
       (s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}", MESSAGE.toJsonString),
       (s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${message2.message_id}", message2.toJsonString),
     )
-    val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, initialStorage)))
+    val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 
     // act
     val ask = dbActor ? DbActor.Catchup(Channel(CHANNEL_NAME))
@@ -421,7 +421,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
       (CHANNEL_NAME, channelData.toJsonString),
       (s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}", MESSAGE.toJsonString),
     )
-    val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, initialStorage)))
+    val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 
     // act
     val ask = dbActor ? DbActor.Catchup(channelName1)


### PR DESCRIPTION
Whenever a message is retrieved from the db through the `DbActor` (e.g. by sending a `Read` or `Catchup` signal), the `decodedData` field is not filled.