### PR TITLE
Fix Roll Call Organizer Camera Error

### DIFF
--- a/fe1-web/src/features/rollCall/screens/RollCallOpened.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallOpened.tsx
@@ -71,9 +71,9 @@ const RollCallOpened = () => {
     addOwnToken().catch((e) => console.error(e));
   }, [lao, rollCallID, toast]);
 
-  const handleError = (err: string) => {
+  const handleError = (err: any) => {
     console.error(err);
-    toast.show(err, {
+    toast.show(err?.message || err, {
       type: 'danger',
       placement: 'top',
       duration: FOUR_SECONDS,

--- a/fe1-web/src/features/rollCall/screens/RollCallOpened.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallOpened.tsx
@@ -74,7 +74,7 @@ const RollCallOpened = () => {
   const handleError = (err: any) => {
     console.error(err);
     // The "err" object might be an exception, take the message property if it exists
-    toast.show(err?.message || err, {
+    toast.show(err?.message || (typeof err === "string" ? err : "Unkown error, please check the console and report it!"), {
       type: 'danger',
       placement: 'top',
       duration: FOUR_SECONDS,

--- a/fe1-web/src/features/rollCall/screens/RollCallOpened.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallOpened.tsx
@@ -73,6 +73,7 @@ const RollCallOpened = () => {
 
   const handleError = (err: any) => {
     console.error(err);
+    // The "err" object might be an exception, take the message property if it exists
     toast.show(err?.message || err, {
       type: 'danger',
       placement: 'top',

--- a/fe1-web/src/features/rollCall/screens/RollCallOpened.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallOpened.tsx
@@ -74,11 +74,15 @@ const RollCallOpened = () => {
   const handleError = (err: any) => {
     console.error(err);
     // The "err" object might be an exception, take the message property if it exists
-    toast.show(err?.message || (typeof err === "string" ? err : "Unkown error, please check the console and report it!"), {
-      type: 'danger',
-      placement: 'top',
-      duration: FOUR_SECONDS,
-    });
+    toast.show(
+      err?.message ||
+        (typeof err === 'string' ? err : 'Unkown error, please check the console and report it!'),
+      {
+        type: 'danger',
+        placement: 'top',
+        duration: FOUR_SECONDS,
+      },
+    );
   };
 
   const addAttendeeAndShowToast = (attendee: string, toastMessage: string) => {


### PR DESCRIPTION
Fixes an error when declining the access to the camera or when no camera is found => an error popup will appear instead of the whole application crashing.