### PR TITLE
Correctly update poptoken in the qr code

### DIFF
--- a/fe1-web/src/features/rollCall/components/EventRollCall.tsx
+++ b/fe1-web/src/features/rollCall/components/EventRollCall.tsx
@@ -34,7 +34,7 @@ const EventRollCall = (props: IPropTypes) => {
   const [popToken, setPopToken] = useState('');
 
   useEffect(() => {
-    if (!lao || !lao.id || !rollCall || !!rollCall.id) {
+    if (!lao || !lao.id || !rollCall || !rollCall.id) {
       return;
     }
 

--- a/fe1-web/src/features/wallet/screens/WalletSetSeed.tsx
+++ b/fe1-web/src/features/wallet/screens/WalletSetSeed.tsx
@@ -29,7 +29,8 @@ const WalletSetSeed = ({ navigation }: IPropTypes) => {
     try {
       await Wallet.importMnemonic(seed);
       navigation.navigate(STRINGS.navigation_synced_wallet);
-    } catch {
+    } catch (e) {
+      console.error(e);
       navigation.navigate(STRINGS.navigation_wallet_error);
     }
   };


### PR DESCRIPTION
This change fixes the bug we encountered during the global meeting where the data encoded in the QR code is invalid (i.e. an empty string).

In a future PR we should also show a nice message when the wallet was not set up first as this results in the same issue and no error is shown in the UI.

The other change (`console.error`) should help as previously a generic error message was shown and the actual error was discarded.