### PR TITLE
Update file for Windows compatibility

### DIFF
--- a/be1-go/README.md
+++ b/be1-go/README.md
@@ -84,6 +84,16 @@ sudo apt-get install build-essential # Ubuntu/Debian
 You may build the `pop` CLI to interact with the server by executing `make
 build` on Linux/OSX or `make.bat build` in Windows.
 
+> Special Note for Windows:
+>
+> To use the command `.\make.bat build`  you should first install GCC compiler 64 bits.
+>
+> After having looked on the internet a while we recommend [TDM-GCC](https://jmeubank.github.io/tdm-gcc/), using the tdm64-gcc-%VERSION%.exe that contains MinGW-w64.
+>
+> Then verify that the path of `gcc` exists (by typing gcc in the terminal)
+>
+> You will be able to compile using `.\make.bat build` which will create `pop.exe` that you will be able to execute from the terminal. 
+
 You can see the CLI usage with the `-h` flag.
 
 ```bash

--- a/be1-go/README.md
+++ b/be1-go/README.md
@@ -71,7 +71,11 @@ the most common git operations without the hassle of using the CLI.
 Please ensure you have Go >= 1.16 installed on your machine. Instructions for
 doing so are available [here](https://golang.org/doc/install).
 
-Linux/OSX users also need to install GNU Make. OSX users may install it using
+#### Build on Unix
+
+To build the `pop` CLI on Unix devices, you need to execute the `make build` command. 
+
+You should first install GNU Make. OSX users may install it using
 homebrew. Linux users may do so using their package manager:
 
 ```bash
@@ -79,20 +83,15 @@ brew install make # OSX
 sudo apt-get install build-essential # Ubuntu/Debian
 ```
 
+#### Build on Windows
+
+To build the `pop.exe` CLI on Windows devices, you need to execute the  `.\make.bat build` command.
+
+You should first install GCC compiler 64 bits. After having looked on the internet for a while we recommend [TDM-GCC](https://jmeubank.github.io/tdm-gcc/), using the tdm64-gcc-%VERSION%.exe that contains MinGW-w64. 
+
+Then, you will be able to compile using `.\make.bat build` which will create `pop.exe` that you will be able to execute from the terminal. 
+
 ### Execution
-
-You may build the `pop` CLI to interact with the server by executing `make
-build` on Linux/OSX or `make.bat build` in Windows.
-
-> Special Note for Windows:
->
-> To use the command `.\make.bat build`  you should first install GCC compiler 64 bits.
->
-> After having looked on the internet a while we recommend [TDM-GCC](https://jmeubank.github.io/tdm-gcc/), using the tdm64-gcc-%VERSION%.exe that contains MinGW-w64.
->
-> Then verify that the path of `gcc` exists (by typing gcc in the terminal)
->
-> You will be able to compile using `.\make.bat build` which will create `pop.exe` that you will be able to execute from the terminal. 
 
 You can see the CLI usage with the `-h` flag.
 

--- a/be1-go/README.md
+++ b/be1-go/README.md
@@ -87,7 +87,7 @@ sudo apt-get install build-essential # Ubuntu/Debian
 
 To build the `pop.exe` CLI on Windows devices, you need to execute the  `.\make.bat build` command.
 
-You should first install GCC compiler 64 bits. After having looked on the internet for a while we recommend [TDM-GCC](https://jmeubank.github.io/tdm-gcc/), using the tdm64-gcc-%VERSION%.exe that contains MinGW-w64. 
+You should first install GCC compiler 64 bits. After having looked on the internet for a while we recommend [TDM-GCC](https://jmeubank.github.io/tdm-gcc/), using the tdm64-gcc-%VERSION%.exe that contains MinGW-w64. (As of March 2022)
 
 Then, you will be able to compile using `.\make.bat build` which will create `pop.exe` that you will be able to execute from the terminal. 
 

--- a/be1-go/make.bat
+++ b/be1-go/make.bat
@@ -39,7 +39,6 @@ GOTO error
 
 :clean
 	RMDIR /S /Q validation\protocol\
-	DEL pop.exe
 	GOTO :EOF
 	
 :error

--- a/be1-go/make.bat
+++ b/be1-go/make.bat
@@ -9,6 +9,7 @@ GOTO error
 :build
 	CALL :protocol
 	go build -o pop ./cli/
+	REN pop pop.exe
 	GOTO :EOF
 
 :lint
@@ -38,6 +39,7 @@ GOTO error
 
 :clean
 	RMDIR /S /Q validation\protocol\
+	DEL pop.exe
 	GOTO :EOF
 	
 :error


### PR DESCRIPTION
This Pull Request contains the following modifications:

README.md:
After having lost a lot of time looking at how to compile the project on windows. 
We finally found a GCC 64 bits compiler that works well.
I added the URL into the documentation to avoid other Windows users losing time.

make.bat:
I've updated the build script to automatically rename pop into pop.exe. Like that, Windows will automatically be able to run it from the terminal.
