### PR TITLE
Refactoring of Chirp and GeneralChirping channels

### DIFF
--- a/be1-go/channel/chirp/mod.go
+++ b/be1-go/channel/chirp/mod.go
@@ -42,6 +42,8 @@ func NewChannel(channelPath string, ownerKey string, hub channel.HubFunctionalit
 	return newChannel
 }
 
+//NewChirpRegistry creates a new registry for a general chirping channel and
+//populates the registry with the actions of the channel.
 func (c *Channel) NewChirpRegistry() registry.MessageRegistry {
 	registry := registry.NewMessageRegistry()
 	registry.Register(messagedata.ChirpAdd{}, c.publishAddChirp)
@@ -88,36 +90,7 @@ func (c *Channel) handleMessage(msg message.Message) error {
 	if err != nil {
 		return xerrors.Errorf("failed to process message: %w", err)
 	}
-	//data := msg.Data
-	//
-	//jsonData, err := base64.URLEncoding.DecodeString(data)
-	//if err != nil {
-	//	return xerrors.Errorf(failedToDecodeData, err)
-	//}
-	//
-	//object, action, err := messagedata.GetObjectAndAction(jsonData)
-	//if err != nil {
-	//	return xerrors.Errorf("failed to get object and action from message data: %v", err)
-	//}
-	//
-	//if object != messagedata.ChirpObject {
-	//	return xerrors.Errorf("object should be 'chirp' but is %s", object)
-	//}
-	//
-	//switch action {
-	//case messagedata.ChirpActionAdd:
-	//	err := c.publishAddChirp(msg)
-	//	if err != nil {
-	//		return xerrors.Errorf("failed to publish chirp: %v", err)
-	//	}
-	//case messagedata.ChirpActionDelete:
-	//	err := c.publishDeleteChirp(msg)
-	//	if err != nil {
-	//		return xerrors.Errorf("failed to delete chirp: %v", err)
-	//	}
-	//default:
-	//	return answer.NewInvalidActionError(action)
-	//}
+
 	c.inbox.StoreMessage(msg)
 
 	err = c.broadcastToAllClients(msg)

--- a/be1-go/channel/chirp/mod.go
+++ b/be1-go/channel/chirp/mod.go
@@ -26,7 +26,7 @@ const failedToDecodeData = "failed to decode message data: %v"
 
 // NewChannel returns a new initialized individual chirping channel
 func NewChannel(channelPath string, ownerKey string, hub channel.HubFunctionalities,
-	generalChannel channel.Broadcastable, log zerolog.Logger) Channel {
+	generalChannel channel.Broadcastable, log zerolog.Logger) channel.Channel {
 
 	log = log.With().Str("channel", "chirp").Logger()
 	newChannel := &Channel{
@@ -39,16 +39,16 @@ func NewChannel(channelPath string, ownerKey string, hub channel.HubFunctionalit
 		log:            log,
 	}
 	newChannel.registry = newChannel.NewChirpRegistry()
-	return *newChannel
+	return newChannel
 }
 
 //NewChirpRegistry creates a new registry for a general chirping channel and
 //populates the registry with the actions of the channel.
 func (c *Channel) NewChirpRegistry() registry.MessageRegistry {
-	registry := registry.NewMessageRegistry()
-	registry.Register(messagedata.ChirpAdd{}, c.publishAddChirp)
-	registry.Register(messagedata.ChirpDelete{}, c.publishDeleteChirp)
-	return registry
+	newRegistry := registry.NewMessageRegistry()
+	newRegistry.Register(messagedata.ChirpAdd{}, c.publishAddChirp)
+	newRegistry.Register(messagedata.ChirpDelete{}, c.publishDeleteChirp)
+	return newRegistry
 }
 
 // Channel is used to handle chirp messages.

--- a/be1-go/channel/chirp/mod.go
+++ b/be1-go/channel/chirp/mod.go
@@ -29,7 +29,7 @@ func NewChannel(channelPath string, ownerKey string, hub channel.HubFunctionalit
 	generalChannel channel.Broadcastable, log zerolog.Logger) Channel {
 
 	log = log.With().Str("channel", "chirp").Logger()
-	newChannel := Channel{
+	newChannel := &Channel{
 		sockets:        channel.NewSockets(),
 		inbox:          inbox.NewInbox(channelPath),
 		channelID:      channelPath,
@@ -39,7 +39,7 @@ func NewChannel(channelPath string, ownerKey string, hub channel.HubFunctionalit
 		log:            log,
 	}
 	newChannel.registry = newChannel.NewChirpRegistry()
-	return newChannel
+	return *newChannel
 }
 
 //NewChirpRegistry creates a new registry for a general chirping channel and

--- a/be1-go/channel/consensus/mod.go
+++ b/be1-go/channel/consensus/mod.go
@@ -439,7 +439,6 @@ func (c *Channel) createConsensusInstance(instanceID string) *ConsensusInstance 
 
 // processConsensusElect processes an elect action.
 func (c *Channel) processConsensusElect(message message.Message, msgData interface{}) error {
-
 	data, ok := msgData.(*messagedata.ConsensusElect)
 	if !ok {
 		return xerrors.Errorf("message %v isn't a consensus#elect message", msgData)

--- a/be1-go/channel/consensus/mod_test.go
+++ b/be1-go/channel/consensus/mod_test.go
@@ -36,7 +36,7 @@ const protocolRelativePath string = "../../../protocol"
 func Test_Consensus_Channel_Subscribe(t *testing.T) {
 	keypair := generateKeyPair(t)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	channel := NewChannel("channel0", fakeHub, nolog)
@@ -64,7 +64,7 @@ func Test_Consensus_Channel_Subscribe(t *testing.T) {
 func Test_Consensus_Channel_Unsubscribe(t *testing.T) {
 	keypair := generateKeyPair(t)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	channel := NewChannel("channel0", fakeHub, nolog)
@@ -93,7 +93,7 @@ func Test_Consensus_Channel_Unsubscribe(t *testing.T) {
 func Test_Consensus_Channel_Wrong_Unsubscribe(t *testing.T) {
 	keypair := generateKeyPair(t)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	channel := NewChannel("channel0", fakeHub, nolog)
@@ -115,7 +115,7 @@ func Test_Consensus_Channel_Catchup(t *testing.T) {
 	// Create the hub
 	keypair := generateKeyPair(t)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the messages
@@ -157,7 +157,7 @@ func Test_Consensus_Channel_Broadcast(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -219,7 +219,7 @@ func Test_Consensus_Publish_Elect(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -292,7 +292,7 @@ func Test_Consensus_Publish_Elect_Accept(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -416,7 +416,7 @@ func Test_Consensus_Publish_Elect_Accept_Failure(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -538,7 +538,7 @@ func Test_Consensus_Publish_Prepare(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -663,7 +663,7 @@ func Test_Consensus_Publish_Promise(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -788,7 +788,7 @@ func Test_Consensus_Publish_Propose(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -912,7 +912,7 @@ func Test_Consensus_Publish_Accept(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -1041,7 +1041,7 @@ func Test_Consensus_Publish_Learn(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -1140,7 +1140,7 @@ func Test_Consensus_Publish_Failure(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -1236,7 +1236,7 @@ func Test_Publish_New_Message(t *testing.T) {
 	// Create the hub
 	keypair := generateKeyPair(t)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -1294,7 +1294,7 @@ func Test_Timeout_Elect(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -1382,7 +1382,7 @@ func Test_Timeout_Prepare(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -1513,7 +1513,7 @@ func Test_Timeout_Promise(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -1644,7 +1644,7 @@ func Test_Timeout_Propose(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -1777,7 +1777,7 @@ func Test_Timeout_Accept(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
 
-	fakeHub, err := NewfakeHub(keypair.public, nolog, nil)
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
 	require.NoError(t, err)
 
 	// Create the channel
@@ -1948,7 +1948,7 @@ type fakeHub struct {
 }
 
 // NewHub returns a Organizer Hub.
-func NewfakeHub(pubKeyOwner kyber.Point, log zerolog.Logger, laoFac channel.LaoFactory) (*fakeHub, error) {
+func NewFakeHub(pubKeyOwner kyber.Point, log zerolog.Logger, laoFac channel.LaoFactory) (*fakeHub, error) {
 
 	schemaValidator, err := validation.NewSchemaValidator(log)
 	if err != nil {

--- a/be1-go/channel/generalChirping/mod.go
+++ b/be1-go/channel/generalChirping/mod.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"popstellar/channel"
+	"popstellar/channel/registry"
 	"popstellar/crypto"
 	"popstellar/inbox"
 	jsonrpc "popstellar/message"
@@ -31,20 +32,30 @@ type Channel struct {
 	// channel path
 	channelPath string
 
-	log zerolog.Logger
+	log      zerolog.Logger
+	registry registry.MessageRegistry
 }
 
 // NewChannel returns a new initialized chirping channel
 func NewChannel(channelPath string, hub channel.HubFunctionalities, log zerolog.Logger) Channel {
 	log = log.With().Str("channel", "general chirp").Logger()
 
-	return Channel{
+	newChannel := Channel{
 		sockets:     channel.NewSockets(),
 		inbox:       inbox.NewInbox(channelPath),
 		channelPath: channelPath,
 		hub:         hub,
 		log:         log,
 	}
+	newChannel.registry = newChannel.NewGeneralChirpingRegistry()
+	return newChannel
+}
+
+func (c *Channel) NewGeneralChirpingRegistry() registry.MessageRegistry {
+	registry := registry.NewMessageRegistry()
+	registry.Register(messagedata.ChirpNotifyAdd{}, c.addChirp)
+	registry.Register(messagedata.ChirpNotifyDelete{}, c.deleteChirp)
+	return registry
 }
 
 // Publish is used to handle a publish message.
@@ -64,35 +75,42 @@ func (c *Channel) Broadcast(broadcast method.Broadcast, _ socket.Socket) error {
 	}
 
 	msg := broadcast.Params.Message
-	data := msg.Data
 
-	jsonData, err := base64.URLEncoding.DecodeString(data)
+	err = c.registry.Process(msg)
 	if err != nil {
-		return xerrors.Errorf("failed to decode message data: %v", err)
+		xerrors.Errorf("failed to process message: %w", err)
 	}
 
-	object, action, err := messagedata.GetObjectAndAction(jsonData)
-	if err != nil {
-		return xerrors.Errorf("failed to get object and action from message data: %v", err)
-	}
+	//data := msg.Data
+	//jsonData, err := base64.URLEncoding.DecodeString(data)
+	//if err != nil {
+	//	return xerrors.Errorf("failed to decode message data: %v", err)
+	//}
+	//
+	//object, action, err := messagedata.GetObjectAndAction(jsonData)
+	//if err != nil {
+	//	return xerrors.Errorf("failed to get object and action from message data: %v", err)
+	//}
+	//
+	//if object == messagedata.ChirpObject {
+	//
+	//	switch action {
+	//	case messagedata.ChirpActionNotifyAdd:
+	//		err := c.addChirp(msg)
+	//		if err != nil {
+	//			return xerrors.Errorf("failed to add a chirp to general: %v", err)
+	//		}
+	//	case messagedata.ChirpActionNotifyDelete:
+	//		err := c.deleteChirp(msg)
+	//		if err != nil {
+	//			return xerrors.Errorf("failed to delete the chirp from general: %v", err)
+	//		}
+	//	default:
+	//		return answer.NewInvalidActionError(action)
+	//	}
+	//}
 
-	if object == messagedata.ChirpObject {
-
-		switch action {
-		case messagedata.ChirpActionNotifyAdd:
-			err := c.addChirp(msg)
-			if err != nil {
-				return xerrors.Errorf("failed to add a chirp to general: %v", err)
-			}
-		case messagedata.ChirpActionNotifyDelete:
-			err := c.deleteChirp(msg)
-			if err != nil {
-				return xerrors.Errorf("failed to delete the chirp from general: %v", err)
-			}
-		default:
-			return answer.NewInvalidActionError(action)
-		}
-	}
+	c.inbox.StoreMessage(msg)
 
 	err = c.broadcastToAllClients(msg)
 	if err != nil {
@@ -196,30 +214,37 @@ func (c *Channel) VerifyBroadcastMessage(broadcast method.Broadcast) error {
 }
 
 // AddChirp checks and stores an add chirp message
-func (c *Channel) addChirp(msg message.Message) error {
-	err := c.verifyChirpBroadcastMessage(msg)
+func (c *Channel) addChirp(msg message.Message, msgData interface{}) error {
+	data, ok := msgData.(*messagedata.ChirpNotifyAdd)
+	if !ok {
+		return xerrors.Errorf("message %v isn't a chirp#notifyAdd message", msgData)
+	}
+
+	err := c.verifyChirpBroadcastMessage(msg, *data)
 	if err != nil {
 		return xerrors.Errorf("failed to get and verify add chirp message: %v", err)
 	}
-	c.inbox.StoreMessage(msg)
 
 	return nil
 }
 
 // DeleteChirp checks and stores a delete chirp message
-func (c *Channel) deleteChirp(msg message.Message) error {
-	err := c.verifyChirpBroadcastMessage(msg)
+func (c *Channel) deleteChirp(msg message.Message, msgData interface{}) error {
+	data, ok := msgData.(*messagedata.ChirpNotifyDelete)
+	if !ok {
+		return xerrors.Errorf("message %v isn't a chirp#notifyDelete message", msgData)
+	}
+
+	err := c.verifyChirpBroadcastMessage(msg, *data)
 	if err != nil {
 		return xerrors.Errorf("failed to get and verify delete chirp message: %v", err)
 	}
-	c.inbox.StoreMessage(msg)
 
 	return nil
 }
 
 // verifyChirpBroadcastMessage verify a chirp broadcast message
-func (c *Channel) verifyChirpBroadcastMessage(msg message.Message) error {
-	var chirpMsg messagedata.ChirpBroadcast
+func (c *Channel) verifyChirpBroadcastMessage(msg message.Message, chirpMsg messagedata.VerifiableMessageData) error {
 
 	err := msg.UnmarshalData(&chirpMsg)
 	if err != nil {

--- a/be1-go/channel/generalChirping/mod.go
+++ b/be1-go/channel/generalChirping/mod.go
@@ -51,6 +51,8 @@ func NewChannel(channelPath string, hub channel.HubFunctionalities, log zerolog.
 	return newChannel
 }
 
+//NewGeneralChirpingRegistry creates a new registry for a general chirping channel and
+//populates the registry with the actions of the channel.
 func (c *Channel) NewGeneralChirpingRegistry() registry.MessageRegistry {
 	registry := registry.NewMessageRegistry()
 	registry.Register(messagedata.ChirpNotifyAdd{}, c.addChirp)
@@ -80,35 +82,6 @@ func (c *Channel) Broadcast(broadcast method.Broadcast, _ socket.Socket) error {
 	if err != nil {
 		xerrors.Errorf("failed to process message: %w", err)
 	}
-
-	//data := msg.Data
-	//jsonData, err := base64.URLEncoding.DecodeString(data)
-	//if err != nil {
-	//	return xerrors.Errorf("failed to decode message data: %v", err)
-	//}
-	//
-	//object, action, err := messagedata.GetObjectAndAction(jsonData)
-	//if err != nil {
-	//	return xerrors.Errorf("failed to get object and action from message data: %v", err)
-	//}
-	//
-	//if object == messagedata.ChirpObject {
-	//
-	//	switch action {
-	//	case messagedata.ChirpActionNotifyAdd:
-	//		err := c.addChirp(msg)
-	//		if err != nil {
-	//			return xerrors.Errorf("failed to add a chirp to general: %v", err)
-	//		}
-	//	case messagedata.ChirpActionNotifyDelete:
-	//		err := c.deleteChirp(msg)
-	//		if err != nil {
-	//			return xerrors.Errorf("failed to delete the chirp from general: %v", err)
-	//		}
-	//	default:
-	//		return answer.NewInvalidActionError(action)
-	//	}
-	//}
 
 	c.inbox.StoreMessage(msg)
 

--- a/be1-go/channel/generalChirping/mod.go
+++ b/be1-go/channel/generalChirping/mod.go
@@ -37,10 +37,10 @@ type Channel struct {
 }
 
 // NewChannel returns a new initialized chirping channel
-func NewChannel(channelPath string, hub channel.HubFunctionalities, log zerolog.Logger) Channel {
+func NewChannel(channelPath string, hub channel.HubFunctionalities, log zerolog.Logger) channel.Channel {
 	log = log.With().Str("channel", "general chirp").Logger()
 
-	newChannel := Channel{
+	newChannel := &Channel{
 		sockets:     channel.NewSockets(),
 		inbox:       inbox.NewInbox(channelPath),
 		channelPath: channelPath,

--- a/be1-go/channel/generalChirping/mod_test.go
+++ b/be1-go/channel/generalChirping/mod_test.go
@@ -34,6 +34,8 @@ func Test_General_Channel_Subscribe(t *testing.T) {
 	require.NoError(t, err)
 
 	channel := NewChannel("channel0", fakeHub, nolog)
+	chirpChannel, ok := channel.(*Channel)
+	require.True(t, ok)
 
 	file := filepath.Join(protocolRelativePath, "examples", "query", "subscribe", "subscribe.json")
 	buf, err := os.ReadFile(file)
@@ -48,7 +50,7 @@ func Test_General_Channel_Subscribe(t *testing.T) {
 	err = channel.Subscribe(socket, message)
 	require.NoError(t, err)
 
-	require.True(t, channel.sockets.Delete("socket"))
+	require.True(t, chirpChannel.sockets.Delete("socket"))
 }
 
 // Tests that the channel works correctly when it receives an unsubscribe
@@ -59,6 +61,8 @@ func Test_General_Channel_Unsubscribe(t *testing.T) {
 	require.NoError(t, err)
 
 	channel := NewChannel("channel0", fakeHub, nolog)
+	chirpChannel, ok := channel.(*Channel)
+	require.True(t, ok)
 
 	file := filepath.Join(protocolRelativePath, "examples", "query", "unsubscribe", "unsubscribe.json")
 	buf, err := os.ReadFile(file)
@@ -69,12 +73,12 @@ func Test_General_Channel_Unsubscribe(t *testing.T) {
 	require.NoError(t, err)
 
 	socket := &fakeSocket{id: "socket"}
-	channel.sockets.Upsert(socket)
+	chirpChannel.sockets.Upsert(socket)
 
 	err = channel.Unsubscribe("socket", message)
 	require.NoError(t, err)
 
-	require.False(t, channel.sockets.Delete("socket"))
+	require.False(t, chirpChannel.sockets.Delete("socket"))
 }
 
 // Test that the channel throws an error when it receives an unsubscribe from a
@@ -113,6 +117,8 @@ func Test_Consensus_Channel_Catchup(t *testing.T) {
 
 	// Create the channel
 	channel := NewChannel("channel0", fakeHub, nolog)
+	chirpChannel, ok := channel.(*Channel)
+	require.True(t, ok)
 
 	for i := 0; i < numMessages; i++ {
 		// Create a new message containing only an id
@@ -120,7 +126,7 @@ func Test_Consensus_Channel_Catchup(t *testing.T) {
 		messages[i] = message
 
 		// Store the message in the inbox
-		channel.inbox.StoreMessage(message)
+		chirpChannel.inbox.StoreMessage(message)
 
 		// Wait before storing a new message to be able to have an unique
 		// timestamp for each message

--- a/be1-go/message/messagedata/chirp_add.go
+++ b/be1-go/message/messagedata/chirp_add.go
@@ -21,3 +21,20 @@ func (message ChirpAdd) Verify() error {
 
 	return nil
 }
+
+//GetObject implements MessageData
+func (ChirpAdd) GetObject() string {
+	return ChirpObject
+
+}
+
+//GetAction implements MessageData
+func (ChirpAdd) GetAction() string {
+	return ChirpActionAdd
+}
+
+//NewEmpty implements MessageData
+func (ChirpAdd) NewEmpty() MessageData {
+	return &ChirpAdd{}
+
+}

--- a/be1-go/message/messagedata/chirp_delete.go
+++ b/be1-go/message/messagedata/chirp_delete.go
@@ -13,6 +13,18 @@ type ChirpDelete struct {
 	Timestamp int64  `json:"timestamp"`
 }
 
+func (ChirpDelete) GetObject() string {
+	return ChirpObject
+}
+
+func (ChirpDelete) GetAction() string {
+	return ChirpActionDelete
+}
+
+func (ChirpDelete) NewEmpty() MessageData {
+	return &ChirpDelete{}
+}
+
 // Verify verifies that the ChirpDelete message is correct
 func (message ChirpDelete) Verify() error {
 	// verify that Timestamp is positive

--- a/be1-go/message/messagedata/chirp_notify_add.go
+++ b/be1-go/message/messagedata/chirp_notify_add.go
@@ -1,0 +1,48 @@
+package messagedata
+
+import (
+	"encoding/base64"
+	"golang.org/x/xerrors"
+)
+
+type ChirpNotifyAdd struct {
+	Object    string `json:"object"`
+	Action    string `json:"action"`
+	ChirpId   string `json:"chirp_id"`
+	Channel   string `json:"channel"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+// Verify verifies that the ChirpNotifyDelete message is correct
+// Verify implements VerifiableMessageData
+func (message ChirpNotifyAdd) Verify() error {
+	// verify that Timestamp is positive
+	if message.Timestamp < 0 {
+		return xerrors.Errorf("timestamp is %d, should be minimum 0", message.Timestamp)
+	}
+
+	// verify that the chirp id is base64URL encoded
+	_, err := base64.URLEncoding.DecodeString(message.ChirpId)
+	if err != nil {
+		return xerrors.Errorf("chirp id is %s, should be base64URL encoded", message.ChirpId)
+	}
+
+	return nil
+}
+
+//GetObject implements MessageData
+func (ChirpNotifyAdd) GetObject() string {
+	return ChirpObject
+
+}
+
+//GetAction implements MessageData
+func (ChirpNotifyAdd) GetAction() string {
+	return ChirpActionNotifyAdd
+}
+
+//NewEmpty implements MessageData
+func (ChirpNotifyAdd) NewEmpty() MessageData {
+	return &ChirpNotifyAdd{}
+
+}

--- a/be1-go/message/messagedata/chirp_notify_delete.go
+++ b/be1-go/message/messagedata/chirp_notify_delete.go
@@ -1,0 +1,48 @@
+package messagedata
+
+import (
+	"encoding/base64"
+	"golang.org/x/xerrors"
+)
+
+type ChirpNotifyDelete struct {
+	Object    string `json:"object"`
+	Action    string `json:"action"`
+	ChirpId   string `json:"chirp_id"`
+	Channel   string `json:"channel"`
+	Timestamp int64  `json:"timestamp"`
+}
+
+// Verify verifies that the ChirpNotifyDelete message is correct
+// Verify implements VerifiableMessageData
+func (message ChirpNotifyDelete) Verify() error {
+	// verify that Timestamp is positive
+	if message.Timestamp < 0 {
+		return xerrors.Errorf("timestamp is %d, should be minimum 0", message.Timestamp)
+	}
+
+	// verify that the chirp id is base64URL encoded
+	_, err := base64.URLEncoding.DecodeString(message.ChirpId)
+	if err != nil {
+		return xerrors.Errorf("chirp id is %s, should be base64URL encoded", message.ChirpId)
+	}
+
+	return nil
+}
+
+//GetObject implements MessageData
+func (ChirpNotifyDelete) GetObject() string {
+	return ChirpObject
+
+}
+
+//GetAction implements MessageData
+func (ChirpNotifyDelete) GetAction() string {
+	return ChirpActionNotifyDelete
+}
+
+//NewEmpty implements MessageData
+func (ChirpNotifyDelete) NewEmpty() MessageData {
+	return &ChirpNotifyDelete{}
+
+}

--- a/be1-go/message/messagedata/mod.go
+++ b/be1-go/message/messagedata/mod.go
@@ -69,6 +69,11 @@ type MessageData interface {
 	NewEmpty() MessageData
 }
 
+type VerifiableMessageData interface {
+	MessageData
+	Verify() error
+}
+
 // GetObjectAndAction returns the object and action of a JSON RPC message.
 func GetObjectAndAction(buf []byte) (string, string, error) {
 	var objmap map[string]json.RawMessage

--- a/be1-go/message/messagedata/mod.go
+++ b/be1-go/message/messagedata/mod.go
@@ -69,6 +69,8 @@ type MessageData interface {
 	NewEmpty() MessageData
 }
 
+// VerifiableMessageData extends MessageData and represents a message that must implement the Verify function
+// for use with registry
 type VerifiableMessageData interface {
 	MessageData
 	Verify() error


### PR DESCRIPTION
-Refactored the Chirp and GeneralChirping channels for handling messages based on the same model as the consensus channel i.e. using a registry. 
-Added a registry to both channels struct and populated it with the actions of each channel i.e. adding and deleting.
-Refactored functions handling incoming messages for each channel, by using the `Process ` function of Registry.
-Defined new `MessageData` objects to represent both notifyAdd and notifyDelete as separate. It was previously done under the same umbrella of the `ChirpBroadcast ` object.
-Defined a new Interface that extends `MessageData`. Purpose is that all message objects implementing it will have the `Verify ` function.