### PR TITLE
Create the JSON schema of a Digital Cash transaction

### DIFF
--- a/protocol/query/method/message/data/dataCashTransaction.json
+++ b/protocol/query/method/message/data/dataCashTransaction.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/dedis/popstellar/master/protocol/query/method/message/data/dataPostTransaction.json",
-  "description": "Post a digital cash transaction",
+  "title": "Post a digital cash transaction",
   "type": "object",
   "properties": {
     "object": {
@@ -23,9 +23,9 @@
           "$comment": "Object representing a transaction output to use as an input for this transaction",
           "properties": {
             "TxOutHash": {
-              "type": "bytes",
-              "length": "32",
-              "$comment": "previous (to-be-used) transaction hash"
+              "type": "string",
+              "contentEncoding": "base64",
+              "$comment": "Previous (to-be-used) transaction hash"
             },
             "TxOutIndex": {
               "type": "bytes",
@@ -41,7 +41,8 @@
                   "$comment": "Type of script"
                 },
                 "PubkeyHash": {
-                  "type": "hash",
+                  "type": "string",
+                  "contentEncoding": "base64",
                   "$comment": "Hash of the recipient’s public key"
                 }
               }
@@ -75,11 +76,13 @@
                   "$comment": "Type of script"
                 },
                 "PubkeyHash": {
-                  "type": "hash",
+                  "type": "string",
+                  "contentEncoding": "base64",
                   "$comment": "Hash of the recipient’s public key"
                 },
                 "Sig": {
-                  "type": "??",
+                  "type": "string",
+                  "contentEncoding": "basae64",
                   "$comment": "Signature on all txins and txouts using the recipient's private key"
                 }
               }

--- a/protocol/query/method/message/data/dataCashTransaction.json
+++ b/protocol/query/method/message/data/dataCashTransaction.json
@@ -13,37 +13,37 @@
     "transaction": {
       "Version": {
         "type": "integer",
-        "$comment": "The version of the transaction inputs"
+        "description": "The version of the transaction inputs"
       },
       "TxIn": {
         "type": "array",
-        "$comment": "[Array[Objects]] array of output transactions to use as inputs",
+        "description": "[Array[Objects]] array of output transactions to use as inputs",
         "items": {
           "type": "object",
-          "$comment": "Object representing a transaction output to use as an input for this transaction",
+          "description": "Object representing a transaction output to use as an input for this transaction",
           "properties": {
             "TxOutHash": {
               "type": "string",
               "contentEncoding": "base64",
-              "$comment": "Previous (to-be-used) transaction hash"
+              "description": "Previous (to-be-used) transaction hash"
             },
             "TxOutIndex": {
               "type": "bytes",
               "length": "4",
-              "$comment": "index of the previous to-be-used transaction"
+              "description": "index of the previous to-be-used transaction"
             },
             "Script": {
               "type": "object",
-              "$comment": "The script describing the TxOut unlock mechanism",
+              "description": "The script describing the TxOut unlock mechanism",
               "properties": {
                 "Type": {
                   "type": "string",
-                  "$comment": "Type of script"
+                  "description": "Type of script"
                 },
                 "PubkeyHash": {
                   "type": "string",
                   "contentEncoding": "base64",
-                  "$comment": "Hash of the recipient’s public key"
+                  "description": "Hash of the recipient’s public key"
                 }
               }
             },
@@ -57,33 +57,33 @@
       },
       "TxOut": {
         "type": "array",
-        "$comment": "[Array[Objects]] array of outputs from this transactions",
+        "description": "[Array[Objects]] array of outputs from this transactions",
         "items": {
           "type": "object",
-          "$comment": "Object representing an output of this transaction",
+          "description": "Object representing an output of this transaction",
           "properties": {
             "Value": {
               "type": "bytes",
               "length": "8",
-              "$comment": "the value of the output transaction, expressed in miniLAOs"
+              "description": "the value of the output transaction, expressed in miniLAOs"
             },
             "Script": {
               "type": "object",
-              "$comment": "The script describing the unlock mechanism",
+              "description": "The script describing the unlock mechanism",
               "properties": {
                 "Type": {
                   "type": "string",
-                  "$comment": "Type of script"
+                  "description": "Type of script"
                 },
                 "PubkeyHash": {
                   "type": "string",
                   "contentEncoding": "base64",
-                  "$comment": "Hash of the recipient’s public key"
+                  "description": "Hash of the recipient’s public key"
                 },
                 "Sig": {
                   "type": "string",
                   "contentEncoding": "basae64",
-                  "$comment": "Signature on all txins and txouts using the recipient's private key"
+                  "description": "Signature on all txins and txouts using the recipient's private key"
                 }
               }
             }

--- a/protocol/query/method/message/data/dataCashTransaction.json
+++ b/protocol/query/method/message/data/dataCashTransaction.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/dedis/popstellar/master/protocol/query/method/message/data/dataPostTransaction.json",
+  "description": "Post a digital cash transaction",
+  "type": "object",
+  "properties": {
+    "object": {
+      "const": "transaction"
+    },
+    "action": {
+      "const": "post"
+    },
+    "transaction": {
+      "Version": {
+        "type": "integer",
+        "$comment": "The version of the transaction inputs"
+      },
+      "TxIn": {
+        "type": "array",
+        "$comment": "[Array[Objects]] array of output transactions to use as inputs",
+        "items": {
+          "type": "object",
+          "$comment": "Object representing a transaction output to use as an input for this transaction",
+          "properties": {
+            "TxOutHash": {
+              "type": "bytes",
+              "length": "32",
+              "$comment": "previous (to-be-used) transaction hash"
+            },
+            "TxOutIndex": {
+              "type": "bytes",
+              "length": "4",
+              "$comment": "index of the previous to-be-used transaction"
+            },
+            "Script": {
+              "type": "object",
+              "$comment": "The script describing the TxOut unlock mechanism",
+              "properties": {
+                "Type": {
+                  "type": "string",
+                  "$comment": "Type of script"
+                },
+                "PubkeyHash": {
+                  "type": "hash",
+                  "$comment": "Hash of the recipient’s public key"
+                }
+              }
+            },
+            "Sequence": {
+              "type": "bytes",
+              "length": "4",
+              "$comment": "Set as 0xFFFFFFFF"
+            }
+          }
+        }
+      },
+      "TxOut": {
+        "type": "array",
+        "$comment": "[Array[Objects]] array of outputs from this transactions",
+        "items": {
+          "type": "object",
+          "$comment": "Object representing an output of this transaction",
+          "properties": {
+            "Value": {
+              "type": "bytes",
+              "length": "8",
+              "$comment": "the value of the output transaction, expressed in miniLAOs"
+            },
+            "Script": {
+              "type": "object",
+              "$comment": "The script describing the unlock mechanism",
+              "properties": {
+                "Type": {
+                  "type": "string",
+                  "$comment": "Type of script"
+                },
+                "PubkeyHash": {
+                  "type": "hash",
+                  "$comment": "Hash of the recipient’s public key"
+                },
+                "Sig": {
+                  "type": "??",
+                  "$comment": "Signature on all txins and txouts using the recipient's private key"
+                }
+              }
+            }
+          }
+        }
+      },
+      "LockTime": {
+        "type": "bytes",
+        "length": "4"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": ["object", "action", "lao", "election", "created_at", "votes"]
+}

--- a/protocol/query/method/message/data/dataCashTransaction.json
+++ b/protocol/query/method/message/data/dataCashTransaction.json
@@ -93,6 +93,5 @@
       }
     }
   },
-  "additionalProperties": false,
-  "required": ["object", "action", "lao", "election", "created_at", "votes"]
+  "required": ["object", "action", "transaction"]
 }


### PR DESCRIPTION
Draft schema of a Digital Cash transaction posting.
Each object representation in an array is given by the field `"items"`.
Not sure about fields data types, so some objects are still of `"type"`: `"bytes"` with a length attribute.