### PR TITLE
SchemaVerifies: invalid JSON requests

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/SchemaVerifier.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/SchemaVerifier.scala
@@ -38,11 +38,9 @@ object SchemaVerifier {
   }
 
   private def verifySchema(schema: JsonSchema, jsonString: JsonString): Try[Unit] = {
-    // creation of a JsonNode containing the information from the input JSON string
     try {
-      //in case of invalid JsonString, we catch the exception thrown by the parser and answer with an error
-      val test = jsonString.parseJson
-
+      //in case of invalid JsonString, we catch the exception thrown by the readTree and answer with an error
+      // creation of a JsonNode containing the information from the input JSON string
       val jsonNode: JsonNode = objectMapper.readTree(jsonString)
       // validation of the input, the result is a set of errors (if no errors, the set is empty)
       // Note: the library is written in Java, thus we convert the Java Set<T> into a Scala Set[T]
@@ -52,7 +50,7 @@ object SchemaVerifier {
         case _ => Failure(new ProtocolException(errors.mkString("; "))) // concatenate all schema validation errors into one
       }
     } catch {
-      case e: Exception => Failure(new ProtocolException("invalid object detected, JSON object expected"))
+      case e: Exception => Failure(new ProtocolException("Invalid object detected, JSON object expected."))
     }
   }
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandler.scala
@@ -39,11 +39,11 @@ object ElectionHandler extends MessageHandler {
     Await.result(ask, duration)
   }
 
-  def handleResultElection(rpcMessage: JsonRpcRequest): GraphMessage = {
+   def handleResultElection(rpcMessage: JsonRpcRequest): GraphMessage = Right(
     PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: ElectionHandler cannot handle ResultElection messages yet", rpcMessage.id)
-  }
+  )
 
-  def handleEndElection(rpcMessage: JsonRpcRequest): GraphMessage = {
-    PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: ElectionHandler cannot handle EndtElection messages yet", rpcMessage.id)
-  }
+  def handleEndElection(rpcMessage: JsonRpcRequest): GraphMessage = Right(
+    PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: ElectionHandler cannot handle EndElection messages yet", rpcMessage.id)
+  )
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandler.scala
@@ -11,6 +11,7 @@ import ch.epfl.pop.storage.DbActor
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success}
+import java.security.Timestamp
 
 object ElectionHandler extends MessageHandler {
 
@@ -38,11 +39,11 @@ object ElectionHandler extends MessageHandler {
     Await.result(ask, duration)
   }
 
-  def handleResultElection(rpcMessage: JsonRpcRequest): GraphMessage = Right(
-    PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: ElectionHandler cannot handle ResultElection messages yet", rpcMessage.id)
-  )
+  def handleResultElection(rpcMessage: JsonRpcRequest): GraphMessage = {
+    Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: ElectionHandler cannot handle ResultElection messages yet", rpcMessage.id))
+  }
 
-  def handleEndElection(rpcMessage: JsonRpcRequest): GraphMessage = Right(
-    PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: ElectionHandler cannot handle EndElection messages yet", rpcMessage.id)
-  )
+  def handleEndElection(rpcMessage: JsonRpcRequest): GraphMessage = {
+    Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: ElectionHandler cannot handle EndtElection messages yet", rpcMessage.id))
+  }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandler.scala
@@ -40,10 +40,10 @@ object ElectionHandler extends MessageHandler {
   }
 
   def handleResultElection(rpcMessage: JsonRpcRequest): GraphMessage = {
-    Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: ElectionHandler cannot handle ResultElection messages yet", rpcMessage.id))
+    PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: ElectionHandler cannot handle ResultElection messages yet", rpcMessage.id)
   }
 
   def handleEndElection(rpcMessage: JsonRpcRequest): GraphMessage = {
-    Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: ElectionHandler cannot handle EndtElection messages yet", rpcMessage.id))
+    PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: ElectionHandler cannot handle EndtElection messages yet", rpcMessage.id)
   }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SchemaVerifierSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SchemaVerifierSuite.scala
@@ -24,17 +24,9 @@ class SchemaVerifierSuite extends FunSuite with Matchers {
 
   /* ----------------------------- Test invalid JSON requests ----------------------------- */
   test("Invalid jsonString - string instead of JSON object") {
-    val stringTest = "hey"
+    val invalidJSON = "wrond JSON string"
 
-    verifyRpcSchema(stringTest) shouldBe a[Right[_, PipelineError]]
-  }
-
-  test("Invalid jsonString - invalid object instead of JSON object") {
-    class hey {}
-    val objectTest = new hey
-    intercept[Exception] {
-      verifyRpcSchema(objectTest.asInstanceOf[String]) 
-    }
+    verifyRpcSchema(invalidJSON) shouldBe a[Right[_, PipelineError]]
   }
 
   /* ----------------------------- High-level (JSON-rpc) tests ----------------------------- */

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SchemaVerifierSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SchemaVerifierSuite.scala
@@ -22,6 +22,21 @@ class SchemaVerifierSuite extends FunSuite with Matchers {
 
   import SchemaVerifierSuite._
 
+  /* ----------------------------- Test invalid JSON requests ----------------------------- */
+  test("Invalid jsonString - string instead of JSON object") {
+    val stringTest = "hey"
+
+    verifyRpcSchema(stringTest) shouldBe a[Right[_, PipelineError]]
+  }
+
+  test("Invalid jsonString - invalid object instead of JSON object") {
+    class hey {}
+    val objectTest = new hey
+    intercept[Exception] {
+      verifyRpcSchema(objectTest.asInstanceOf[String]) 
+    }
+  }
+
   /* ----------------------------- High-level (JSON-rpc) tests ----------------------------- */
   test("Correct subscribe JSON-RPC query") {
     val subscribePath = "../protocol/examples/query/subscribe/subscribe.json"


### PR DESCRIPTION
Whenever a message that is not a valid JSON message is sent, the client gets disconnected and the server spits an exception (i.e. the three characters `hey`,  or `{ "faultyObject }`) 
