### PR TITLE
Changing the used checkSelfPermissionAccess function to the static one 

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
@@ -1,5 +1,7 @@
 package com.github.dedis.popstellar.ui.home;
 
+import static androidx.core.content.ContextCompat.checkSelfPermission;
+
 import android.Manifest;
 import android.app.Application;
 import android.content.pm.PackageManager;
@@ -312,7 +314,7 @@ public class HomeViewModel extends AndroidViewModel
   }
 
   public void openConnect() {
-    if (ActivityCompat.checkSelfPermission(
+    if (checkSelfPermission(
             getApplication().getApplicationContext(), Manifest.permission.CAMERA)
         == PackageManager.PERMISSION_GRANTED) {
       openQrCodeScanning();

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
@@ -9,7 +9,6 @@ import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.core.app.ActivityCompat;
 import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.LiveDataReactiveStreams;

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/CameraPermissionFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/CameraPermissionFragment.java
@@ -1,5 +1,7 @@
 package com.github.dedis.popstellar.ui.qrcode;
 
+import static androidx.core.content.ContextCompat.checkSelfPermission;
+
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -70,7 +72,7 @@ public final class CameraPermissionFragment extends Fragment {
   public void onResume() {
     super.onResume();
     // If the permission was granted while the app was paused, switch to QRCodeScanningFragment
-    if (ActivityCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA)
+    if (checkSelfPermission(requireContext(), Manifest.permission.CAMERA)
         == PackageManager.PERMISSION_GRANTED) {
       getParentFragmentManager().setFragmentResult(REQUEST_KEY, Bundle.EMPTY);
     }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/CameraPermissionFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/CameraPermissionFragment.java
@@ -14,7 +14,6 @@ import androidx.activity.result.ActivityResultRegistry;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
 
 import com.github.dedis.popstellar.databinding.QrcodeCameraPermFragmentBinding;

--- a/tests/karate/src/test/java/be/createLAO/create.feature
+++ b/tests/karate/src/test/java/be/createLAO/create.feature
@@ -56,7 +56,7 @@ Feature: Create a pop LAO
     *  karate.log('Sent: '+ karate.pretty(emptyNameReq))
     And  json err = socket.listen(timeout)
     * karate.log('Received: '+ err )
-    Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -4, description: '#string'}}
+    Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -6, description: '#string'}}
 
   Scenario: Create Lao with negative time should fail with an error response
       Given string negTimeLao = read('classpath:data/lao/bad_lao_create_negative.json')
@@ -65,7 +65,7 @@ Feature: Create a pop LAO
       *  karate.log('Sent: '+ karate.pretty(negTimeLao))
       And  json err = socket.listen(timeout)
       *  karate.log('Received: '+ karate.pretty(err) )
-      Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -4, description: '#string'}}
+      Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -6, description: '#string'}}
 
   Scenario: Create Lao with invalid id hash should fail with an error response
       Given string invalidIdLao = read('classpath:data/lao/bad_lao_create_id_invalid_hash.json')
@@ -74,4 +74,4 @@ Feature: Create a pop LAO
       *  karate.log('Sent: '+ karate.pretty(invalidIdLao))
       And  json err = socket.listen(timeout)
       *  karate.log('Received: '+ karate.pretty(err) )
-      Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -4, description: '#string'}}
+      Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -6, description: '#string'}}

--- a/tests/karate/src/test/java/be/createLAO/create.feature
+++ b/tests/karate/src/test/java/be/createLAO/create.feature
@@ -56,7 +56,7 @@ Feature: Create a pop LAO
     *  karate.log('Sent: '+ karate.pretty(emptyNameReq))
     And  json err = socket.listen(timeout)
     * karate.log('Received: '+ err )
-    Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -6, description: '#string'}}
+    Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -4, description: '#string'}}
 
   Scenario: Create Lao with negative time should fail with an error response
       Given string negTimeLao = read('classpath:data/lao/bad_lao_create_negative.json')
@@ -65,7 +65,7 @@ Feature: Create a pop LAO
       *  karate.log('Sent: '+ karate.pretty(negTimeLao))
       And  json err = socket.listen(timeout)
       *  karate.log('Received: '+ karate.pretty(err) )
-      Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -6, description: '#string'}}
+      Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -4, description: '#string'}}
 
   Scenario: Create Lao with invalid id hash should fail with an error response
       Given string invalidIdLao = read('classpath:data/lao/bad_lao_create_id_invalid_hash.json')
@@ -74,4 +74,4 @@ Feature: Create a pop LAO
       *  karate.log('Sent: '+ karate.pretty(invalidIdLao))
       And  json err = socket.listen(timeout)
       *  karate.log('Received: '+ karate.pretty(err) )
-      Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -6, description: '#string'}}
+      Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -4, description: '#string'}}


### PR DESCRIPTION
As indicated in this [code smell](https://sonarcloud.io/project/issues?resolved=false&severities=CRITICAL&types=CODE_SMELL&id=dedis_popstellar_fe2&open=AXhvC-zxJfsYgmhMRsCn) this is a critical code smell to be addressed the method used should be the static method defined in the mother class ContextCompat.java rather than the inherited function by ActivityCompat.java this is to avoid confusion and illusion that too such method exist in both classes instead of just one defined in the mother class ContextCompat.java.