### PR TITLE
changed the return code in tests from -4 to -6 and tests on backend g…

### DIFF
--- a/tests/karate/src/test/java/be/createLAO/create.feature
+++ b/tests/karate/src/test/java/be/createLAO/create.feature
@@ -56,7 +56,7 @@ Feature: Create a pop LAO
     *  karate.log('Sent: '+ karate.pretty(emptyNameReq))
     And  json err = socket.listen(timeout)
     * karate.log('Received: '+ err )
-    Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -4, description: '#string'}}
+    Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -6, description: '#string'}}
 
   Scenario: Create Lao with negative time should fail with an error response
       Given string negTimeLao = read('classpath:data/lao/bad_lao_create_negative.json')
@@ -65,7 +65,7 @@ Feature: Create a pop LAO
       *  karate.log('Sent: '+ karate.pretty(negTimeLao))
       And  json err = socket.listen(timeout)
       *  karate.log('Received: '+ karate.pretty(err) )
-      Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -4, description: '#string'}}
+      Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -6, description: '#string'}}
 
   Scenario: Create Lao with invalid id hash should fail with an error response
       Given string invalidIdLao = read('classpath:data/lao/bad_lao_create_id_invalid_hash.json')
@@ -74,4 +74,4 @@ Feature: Create a pop LAO
       *  karate.log('Sent: '+ karate.pretty(invalidIdLao))
       And  json err = socket.listen(timeout)
       *  karate.log('Received: '+ karate.pretty(err) )
-      Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -4, description: '#string'}}
+      Then match err contains deep {jsonrpc: '2.0', id: 1, error: {code: -6, description: '#string'}}


### PR DESCRIPTION
The return error code seems to be giving -6 instead of the -4 when an invalid lao creation request is issued.