### PR TITLE
Coverage badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # POPstellar - Proof-of-Personhood System Demonstrator
 
-[![build]]
+[![Coverage Go](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be1&metric=coverage)]
 
 The main work in this repository is to be done
 in the context of the following folders:
@@ -19,7 +19,7 @@ in the context of the following folders:
 
 * [tests](https://github.com/dedis/popstellar/tree/master/tests): (Future) the system-wide, cross-implementation tests
 
-* [![Coverage Go](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be1&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be1)
+[![Coverage Go](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be1&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be1)
 
 
 ## Branch organization

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # POPstellar - Proof-of-Personhood System Demonstrator
 
+[![build]]
+
 The main work in this repository is to be done
 in the context of the following folders:
 
@@ -36,3 +38,5 @@ if I need a branch to develop the ballot casting feature.
 
 
 This project is licensed under the terms of the AGPL licence. If this license is not suitable for your project, please contact us to discuss licensing terms.
+
+

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ in the context of the following folders:
 
 * [be1-go](https://github.com/dedis/popstellar/tree/master/be1-go): Back-end implementation in Go [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be1&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be1)
 
-* [be2-scala](https://github.com/dedis/popstellar/tree/master/be2-scala): Back-end implementation in Scala [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be2&metric=coverage scala)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be2)
+* [be2-scala](https://github.com/dedis/popstellar/tree/master/be2-scala): Back-end implementation in Scala [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be2&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be2)
 
 * [protocol](https://github.com/dedis/popstellar/tree/master/protocol): The protocol definition in JSON-Schema
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ in the context of the following folders:
 
 * [tests](https://github.com/dedis/popstellar/tree/master/tests): (Future) the system-wide, cross-implementation tests
 
-*[![Coverage Go](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be1&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be1)
+* [![Coverage Go](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be1&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be1)
 
 
 ## Branch organization

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 The main work in this repository is to be done
 in the context of the following folders:
 
-* [fe1-web](https://github.com/dedis/popstellar/tree/master/fe1-web): Web-based front-end implementation in TypeScript/ReactJS
+* [fe1-web](https://github.com/dedis/popstellar/tree/master/fe1-web): Web-based front-end implementation in TypeScript/ReactJS [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_fe1&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_fe1)
 
-* [fe2-android](https://github.com/dedis/popstellar/tree/master/fe2-android): Android native front-end implementation in Java
+* [fe2-android](https://github.com/dedis/popstellar/tree/master/fe2-android): Android native front-end implementation in Java [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_fe2&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_fe2)
 
-* [![Coverage Go](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be1&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be1)[be1-go](https://github.com/dedis/popstellar/tree/master/be1-go): Back-end implementation in Go
+* [be1-go](https://github.com/dedis/popstellar/tree/master/be1-go): Back-end implementation in Go [![Coverage Go](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be1&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be1)
 
-* [be2-scala](https://github.com/dedis/popstellar/tree/master/be2-scala): Back-end implementation in Scala
+* [be2-scala](https://github.com/dedis/popstellar/tree/master/be2-scala): Back-end implementation in Scala [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be2&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be2)
 
 * [protocol](https://github.com/dedis/popstellar/tree/master/protocol): The protocol definition in JSON-Schema
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ in the context of the following folders:
 
 * [tests](https://github.com/dedis/popstellar/tree/master/tests): (Future) the system-wide, cross-implementation tests
 
+*[![Coverage Go](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be1&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be1)
+
+
 ## Branch organization
 Everyone working on the project,
 please create your own private "working" branches as needed

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ in the context of the following folders:
 
 * [fe2-android](https://github.com/dedis/popstellar/tree/master/fe2-android): Android native front-end implementation in Java [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_fe2&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_fe2)
 
-* [be1-go](https://github.com/dedis/popstellar/tree/master/be1-go): Back-end implementation in Go [![Coverage Go](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be1&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be1)
+* [be1-go](https://github.com/dedis/popstellar/tree/master/be1-go): Back-end implementation in Go [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be1&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be1)
 
-* [be2-scala](https://github.com/dedis/popstellar/tree/master/be2-scala): Back-end implementation in Scala [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be2&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be2)
+* [be2-scala](https://github.com/dedis/popstellar/tree/master/be2-scala): Back-end implementation in Scala [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be2&metric=coverage scala)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be2)
 
 * [protocol](https://github.com/dedis/popstellar/tree/master/protocol): The protocol definition in JSON-Schema
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # POPstellar - Proof-of-Personhood System Demonstrator
 
-[![Coverage Go](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be1&metric=coverage)]
+
 
 The main work in this repository is to be done
 in the context of the following folders:
@@ -9,7 +9,7 @@ in the context of the following folders:
 
 * [fe2-android](https://github.com/dedis/popstellar/tree/master/fe2-android): Android native front-end implementation in Java
 
-* [be1-go](https://github.com/dedis/popstellar/tree/master/be1-go): Back-end implementation in Go
+* [![Coverage Go](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be1&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be1)[be1-go](https://github.com/dedis/popstellar/tree/master/be1-go): Back-end implementation in Go
 
 * [be2-scala](https://github.com/dedis/popstellar/tree/master/be2-scala): Back-end implementation in Scala
 
@@ -19,7 +19,7 @@ in the context of the following folders:
 
 * [tests](https://github.com/dedis/popstellar/tree/master/tests): (Future) the system-wide, cross-implementation tests
 
-[![Coverage Go](https://sonarcloud.io/api/project_badges/measure?project=dedis_popstellar_be1&metric=coverage)](https://sonarcloud.io/summary/new_code?id=dedis_popstellar_be1)
+
 
 
 ## Branch organization


### PR DESCRIPTION
For now if you want to check what coverage is achieved for each subsystem you would have to go to sonar cloud and check the coverage for each. Introducing badges on the read Me file would allow us to see the evolution of coverage overall instantly right on the front page.