### PR TITLE
Fix app crash when trying to launch an LAO without a server running

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/error/ErrorUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/error/ErrorUtils.java
@@ -41,12 +41,8 @@ public class ErrorUtils {
 
     //This makes it so that the toast is run on the UI thread
     //Otherwise it would crash
-    new Handler(context.getMainLooper()).post(new Runnable() {
-      @Override
-      public void run() {
-        Toast.makeText(context, exceptionMsg, Toast.LENGTH_LONG).show();
-      }
-    });
+    new Handler(context.getMainLooper()).post(
+            () -> Toast.makeText(context, exceptionMsg, Toast.LENGTH_LONG).show());
   }
 
   private static String getLocalizedMessage(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/error/ErrorUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/error/ErrorUtils.java
@@ -1,6 +1,7 @@
 package com.github.dedis.popstellar.utility.error;
 
 import android.content.Context;
+import android.os.Handler;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -37,7 +38,15 @@ public class ErrorUtils {
     String exceptionMsg = getLocalizedMessage(context, error, action, actionArgs);
 
     Log.e(tag, exceptionMsg, error);
-    Toast.makeText(context, exceptionMsg, Toast.LENGTH_LONG).show();
+
+    //This makes it so that the toast is run on the UI thread
+    //Otherwise it would crash
+    new Handler(context.getMainLooper()).post(new Runnable() {
+      @Override
+      public void run() {
+        Toast.makeText(context, exceptionMsg, Toast.LENGTH_LONG).show();
+      }
+    });
   }
 
   private static String getLocalizedMessage(


### PR DESCRIPTION
Previous implementation tried to toasts displayed by callback function on the thread the callback was executed on. This cause crashes. Toasts can only be showed by the UI thread. This fixes the bug by forcing the toast only to be executed by the UI thread.

This solves #881 