### PR TITLE
Fix non update of pop.exe file

### DIFF
--- a/be1-go/make.bat
+++ b/be1-go/make.bat
@@ -9,6 +9,7 @@ GOTO error
 :build
 	CALL :protocol
 	go build -o pop ./cli/
+	IF EXIST pop.exe DEL pop.exe
 	REN pop pop.exe
 	GOTO :EOF
 


### PR DESCRIPTION
This fixes an issue where the pop.exe file was not updated. The reason is that if it already existed, the renaming of pop to pop.exe would fail.