### PR TITLE
Fixed the writing of the public keys of attendees in LAO

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandler.scala
@@ -87,7 +87,7 @@ class RollCallHandler(dbRef: => AskableActorRef) extends MessageHandler {
               case Some(_) =>
                 val combined = for {
                   _ <- dbActor ? DbActor.ReadLaoData(rpcRequest.getParamsChannel)
-                  _ <- dbActor ? DbActor.Write(rpcRequest.getParamsChannel, message)
+                  _ <- dbActor ? DbActor.WriteLaoData(rpcRequest.getParamsChannel, message)
                 } yield ()
 
                 Await.ready(combined, duration).value match {


### PR DESCRIPTION
The previous implementation of the handler of CloseRollCall did not write the public keys of the attendees in the LAO data. Hence, when we tried to retrieve the public keys of the attendees of the Roll Call, the correct public keys were not registered. 