### PR TITLE
Work be1 rgoumaz reorganize channels

### DIFF
--- a/be1-go/channel/chirp/mod.go
+++ b/be1-go/channel/chirp/mod.go
@@ -142,7 +142,6 @@ func (c *Channel) Broadcast(broadcast method.Broadcast, socket socket.Socket) er
 
 // handleMessage handles a message received in a broadcast or publish method
 func (c *Channel) handleMessage(msg message.Message, socket socket.Socket) error {
-
 	err := c.registry.Process(msg, socket)
 	if err != nil {
 		return xerrors.Errorf("failed to process message: %w", err)
@@ -174,7 +173,9 @@ func (c *Channel) NewChirpRegistry() registry.MessageRegistry {
 	return newRegistry
 }
 
-func (c *Channel) processAddChirp(msg message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processAddChirp(msg message.Message, msgData interface{},
+	_ socket.Socket) error {
+
 	data, ok := msgData.(*messagedata.ChirpAdd)
 	if !ok {
 		return xerrors.Errorf("message %v isn't a chirp#add message", msgData)
@@ -184,11 +185,13 @@ func (c *Channel) processAddChirp(msg message.Message, msgData interface{}, _ so
 	if err != nil {
 		return xerrors.Errorf("failed to verify add chirp message: %v", err)
 	}
-	
+
 	return nil
 }
 
-func (c *Channel) processDeleteChirp(msg message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processDeleteChirp(msg message.Message, msgData interface{},
+	_ socket.Socket) error {
+
 	data, ok := msgData.(*messagedata.ChirpDelete)
 	if !ok {
 		return xerrors.Errorf("message %v isn't a chirp#delete message", msgData)
@@ -209,7 +212,6 @@ func (c *Channel) processDeleteChirp(msg message.Message, msgData interface{}, _
 
 // verifyMessage checks if a message in a Publish or Broadcast method is valid
 func (c *Channel) verifyMessage(msg message.Message) error {
-
 	jsonData, err := base64.URLEncoding.DecodeString(msg.Data)
 	if err != nil {
 		return xerrors.Errorf(failedToDecodeData, err)
@@ -284,7 +286,6 @@ func (c *Channel) broadcastToAllClients(msg message.Message) error {
 }
 
 func (c *Channel) broadcastViaGeneral(msg message.Message) error {
-
 	jsonData, err := base64.URLEncoding.DecodeString(msg.Data)
 	if err != nil {
 		return xerrors.Errorf("failed to decode the data: %v", err)

--- a/be1-go/channel/chirp/mod.go
+++ b/be1-go/channel/chirp/mod.go
@@ -184,6 +184,7 @@ func (c *Channel) processAddChirp(msg message.Message, msgData interface{}, _ so
 	if err != nil {
 		return xerrors.Errorf("failed to verify add chirp message: %v", err)
 	}
+	
 	return nil
 }
 

--- a/be1-go/channel/chirp/mod.go
+++ b/be1-go/channel/chirp/mod.go
@@ -21,8 +21,23 @@ import (
 	"golang.org/x/xerrors"
 )
 
-const msgID = "msg id"
-const failedToDecodeData = "failed to decode message data: %v"
+const (
+	msgID              = "msg id"
+	failedToDecodeData = "failed to decode message data: %v"
+)
+
+// Channel is used to handle chirp messages.
+type Channel struct {
+	sockets        channel.Sockets
+	inbox          *inbox.Inbox
+	generalChannel channel.Broadcastable
+	// channel path
+	channelID string
+	owner     string
+	hub       channel.HubFunctionalities
+	log       zerolog.Logger
+	registry  registry.MessageRegistry
+}
 
 // NewChannel returns a new initialized individual chirping channel
 func NewChannel(channelPath string, ownerKey string, hub channel.HubFunctionalities,
@@ -45,28 +60,33 @@ func NewChannel(channelPath string, ownerKey string, hub channel.HubFunctionalit
 	return newChannel
 }
 
-// NewChirpRegistry creates a new registry for a general chirping channel and
-// populates the registry with the actions of the channel.
-func (c *Channel) NewChirpRegistry() registry.MessageRegistry {
-	newRegistry := registry.NewMessageRegistry()
+// ---
+// Publish-subscribe / channel.Channel implementation
+// ---
 
-	newRegistry.Register(messagedata.ChirpAdd{}, c.publishAddChirp)
-	newRegistry.Register(messagedata.ChirpDelete{}, c.publishDeleteChirp)
+// Subscribe is used to handle a subscribe message from the client.
+func (c *Channel) Subscribe(socket socket.Socket, msg method.Subscribe) error {
+	c.log.Info().
+		Str(msgID, strconv.Itoa(msg.ID)).
+		Msg("received a subscribe")
+	c.sockets.Upsert(socket)
 
-	return newRegistry
+	return nil
 }
 
-// Channel is used to handle chirp messages.
-type Channel struct {
-	sockets        channel.Sockets
-	inbox          *inbox.Inbox
-	generalChannel channel.Broadcastable
-	// channel path
-	channelID string
-	owner     string
-	hub       channel.HubFunctionalities
-	log       zerolog.Logger
-	registry  registry.MessageRegistry
+// Unsubscribe is used to handle an unsubscribe message.
+func (c *Channel) Unsubscribe(socketID string, msg method.Unsubscribe) error {
+	c.log.Info().
+		Str(msgID, strconv.Itoa(msg.ID)).
+		Msg("received an unsubscribe")
+
+	ok := c.sockets.Delete(socketID)
+
+	if !ok {
+		return answer.NewError(-2, "client is not subscribed to this channel")
+	}
+
+	return nil
 }
 
 // Publish is used to handle publish messages in the chirp channel.
@@ -89,6 +109,37 @@ func (c *Channel) Publish(publish method.Publish, socket socket.Socket) error {
 	return nil
 }
 
+// Catchup is used to handle a catchup message.
+func (c *Channel) Catchup(catchup method.Catchup) []message.Message {
+	c.log.Info().
+		Str(msgID, strconv.Itoa(catchup.ID)).
+		Msg("received a catchup")
+
+	return c.inbox.GetSortedMessages()
+}
+
+// Broadcast is used to handle a broadcast message.
+func (c *Channel) Broadcast(broadcast method.Broadcast, socket socket.Socket) error {
+	c.log.Info().Msg("received a broadcast")
+
+	err := c.verifyMessage(broadcast.Params.Message)
+	if err != nil {
+		return xerrors.Errorf("failed to verify broadcast message on a "+
+			"chirping channel: %w", err)
+	}
+
+	err = c.handleMessage(broadcast.Params.Message, socket)
+	if err != nil {
+		return xerrors.Errorf("failed to handle broadcast message: %v", err)
+	}
+
+	return nil
+}
+
+// ---
+// Message handling
+// ---
+
 // handleMessage handles a message received in a broadcast or publish method
 func (c *Channel) handleMessage(msg message.Message, socket socket.Socket) error {
 
@@ -108,6 +159,125 @@ func (c *Channel) handleMessage(msg message.Message, socket socket.Socket) error
 	if err != nil {
 		return xerrors.Errorf("failed to broadcast the chirp message via general : %v", err)
 	}
+
+	return nil
+}
+
+// NewChirpRegistry creates a new registry for a general chirping channel and
+// populates the registry with the actions of the channel.
+func (c *Channel) NewChirpRegistry() registry.MessageRegistry {
+	newRegistry := registry.NewMessageRegistry()
+
+	newRegistry.Register(messagedata.ChirpAdd{}, c.processAddChirp)
+	newRegistry.Register(messagedata.ChirpDelete{}, c.processDeleteChirp)
+
+	return newRegistry
+}
+
+func (c *Channel) processAddChirp(msg message.Message, msgData interface{}, _ socket.Socket) error {
+	data, ok := msgData.(*messagedata.ChirpAdd)
+	if !ok {
+		return xerrors.Errorf("message %v isn't a chirp#add message", msgData)
+	}
+
+	err := c.verifyChirpMessage(msg, data)
+	if err != nil {
+		return xerrors.Errorf("failed to verify add chirp message: %v", err)
+	}
+	return nil
+}
+
+func (c *Channel) processDeleteChirp(msg message.Message, msgData interface{}, _ socket.Socket) error {
+	data, ok := msgData.(*messagedata.ChirpDelete)
+	if !ok {
+		return xerrors.Errorf("message %v isn't a chirp#delete message", msgData)
+	}
+
+	err := c.verifyChirpMessage(msg, data)
+	if err != nil {
+		return xerrors.Errorf("failed to verify delete chirp message: %v", err)
+	}
+
+	_, b := c.inbox.GetMessage(data.ChirpID)
+	if !b {
+		return xerrors.Errorf("the message to be deleted was not found")
+	}
+
+	return nil
+}
+
+// verifyMessage checks if a message in a Publish or Broadcast method is valid
+func (c *Channel) verifyMessage(msg message.Message) error {
+
+	jsonData, err := base64.URLEncoding.DecodeString(msg.Data)
+	if err != nil {
+		return xerrors.Errorf(failedToDecodeData, err)
+	}
+
+	// Verify the data
+	err = c.hub.GetSchemaValidator().VerifyJSON(jsonData, validation.Data)
+	if err != nil {
+		return xerrors.Errorf("failed to verify json schema: %w", err)
+	}
+
+	// Check if the message already exists
+	_, ok := c.inbox.GetMessage(msg.MessageID)
+	if ok {
+		return answer.NewError(-3, "message already exists")
+	}
+
+	return nil
+}
+
+func (c *Channel) verifyChirpMessage(msg message.Message, chirpMsg messagedata.Verifiable) error {
+	err := chirpMsg.Verify()
+	if err != nil {
+		return xerrors.Errorf("invalid chirp message: %v", err)
+	}
+
+	senderBuf, err := base64.URLEncoding.DecodeString(msg.Sender)
+	if err != nil {
+		return xerrors.Errorf("failed to decode sender key: %v", err)
+	}
+
+	senderPoint := crypto.Suite.Point()
+	err = senderPoint.UnmarshalBinary(senderBuf)
+	if err != nil {
+		return answer.NewError(-4, "invalid sender public key")
+	}
+
+	if msg.Sender != c.owner {
+		return answer.NewError(-4, "only the owner of the channel can post chirps")
+	}
+
+	return nil
+}
+
+// broadcastToAllClients is a helper message to broadcast a message to all
+// subscribers.
+func (c *Channel) broadcastToAllClients(msg message.Message) error {
+	rpcMessage := method.Broadcast{
+		Base: query.Base{
+			JSONRPCBase: jsonrpc.JSONRPCBase{
+				JSONRPC: "2.0",
+			},
+			Method: query.MethodBroadcast,
+		},
+		Params: struct {
+			Channel string          `json:"channel"`
+			Message message.Message `json:"message"`
+		}{
+			c.channelID,
+			msg,
+		},
+	}
+
+	buf, err := json.Marshal(&rpcMessage)
+	if err != nil {
+		return xerrors.Errorf("failed to marshal broadcast: %v", err)
+	}
+
+	c.sockets.SendToAll(buf)
 
 	return nil
 }
@@ -133,7 +303,7 @@ func (c *Channel) broadcastViaGeneral(msg message.Message) error {
 	newData := messagedata.ChirpBroadcast{
 		Object:    object,
 		Action:    action,
-		ChirpId:   msg.MessageID,
+		ChirpID:   msg.MessageID,
 		Channel:   c.generalChannel.GetChannelPath(),
 		Timestamp: time,
 	}
@@ -184,166 +354,6 @@ func (c *Channel) broadcastViaGeneral(msg message.Message) error {
 	err = c.generalChannel.Broadcast(rpcMessage, nil)
 	if err != nil {
 		return xerrors.Errorf("the general channel failed to broadcast the chirp message: %v", err)
-	}
-
-	return nil
-}
-
-// Subscribe is used to handle a subscribe message from the client.
-func (c *Channel) Subscribe(socket socket.Socket, msg method.Subscribe) error {
-	c.log.Info().
-		Str(msgID, strconv.Itoa(msg.ID)).
-		Msg("received a subscribe")
-	c.sockets.Upsert(socket)
-
-	return nil
-}
-
-// Unsubscribe is used to handle an unsubscribe message.
-func (c *Channel) Unsubscribe(socketID string, msg method.Unsubscribe) error {
-	c.log.Info().
-		Str(msgID, strconv.Itoa(msg.ID)).
-		Msg("received an unsubscribe")
-
-	ok := c.sockets.Delete(socketID)
-
-	if !ok {
-		return answer.NewError(-2, "client is not subscribed to this channel")
-	}
-
-	return nil
-}
-
-// Catchup is used to handle a catchup message.
-func (c *Channel) Catchup(catchup method.Catchup) []message.Message {
-	c.log.Info().
-		Str(msgID, strconv.Itoa(catchup.ID)).
-		Msg("received a catchup")
-
-	return c.inbox.GetSortedMessages()
-}
-
-// Broadcast is used to handle a broadcast message.
-func (c *Channel) Broadcast(broadcast method.Broadcast, socket socket.Socket) error {
-	c.log.Info().Msg("received a broadcast")
-
-	err := c.verifyMessage(broadcast.Params.Message)
-	if err != nil {
-		return xerrors.Errorf("failed to verify broadcast message on a "+
-			"chirping channel: %w", err)
-	}
-
-	err = c.handleMessage(broadcast.Params.Message, socket)
-	if err != nil {
-		return xerrors.Errorf("failed to handle broadcast message: %v", err)
-	}
-
-	return nil
-}
-
-// broadcastToAllClients is a helper message to broadcast a message to all
-// subscribers.
-func (c *Channel) broadcastToAllClients(msg message.Message) error {
-	rpcMessage := method.Broadcast{
-		Base: query.Base{
-			JSONRPCBase: jsonrpc.JSONRPCBase{
-				JSONRPC: "2.0",
-			},
-			Method: query.MethodBroadcast,
-		},
-		Params: struct {
-			Channel string          `json:"channel"`
-			Message message.Message `json:"message"`
-		}{
-			c.channelID,
-			msg,
-		},
-	}
-
-	buf, err := json.Marshal(&rpcMessage)
-	if err != nil {
-		return xerrors.Errorf("failed to marshal broadcast: %v", err)
-	}
-
-	c.sockets.SendToAll(buf)
-
-	return nil
-}
-
-// verifyMessage checks if a message in a Publish or Broadcast method is valid
-func (c *Channel) verifyMessage(msg message.Message) error {
-
-	jsonData, err := base64.URLEncoding.DecodeString(msg.Data)
-	if err != nil {
-		return xerrors.Errorf(failedToDecodeData, err)
-	}
-
-	// Verify the data
-	err = c.hub.GetSchemaValidator().VerifyJSON(jsonData, validation.Data)
-	if err != nil {
-		return xerrors.Errorf("failed to verify json schema: %w", err)
-	}
-
-	// Check if the message already exists
-	_, ok := c.inbox.GetMessage(msg.MessageID)
-	if ok {
-		return answer.NewError(-3, "message already exists")
-	}
-
-	return nil
-}
-
-func (c *Channel) publishAddChirp(msg message.Message, msgData interface{}, _ socket.Socket) error {
-	data, ok := msgData.(*messagedata.ChirpAdd)
-	if !ok {
-		return xerrors.Errorf("message %v isn't a chirp#add message", msgData)
-	}
-
-	err := c.verifyChirpMessage(msg, data)
-	if err != nil {
-		return xerrors.Errorf("failed to verify add chirp message: %v", err)
-	}
-	return nil
-}
-
-func (c *Channel) publishDeleteChirp(msg message.Message, msgData interface{}, _ socket.Socket) error {
-	data, ok := msgData.(*messagedata.ChirpDelete)
-	if !ok {
-		return xerrors.Errorf("message %v isn't a chirp#delete message", msgData)
-	}
-
-	err := c.verifyChirpMessage(msg, data)
-	if err != nil {
-		return xerrors.Errorf("failed to verify delete chirp message: %v", err)
-	}
-
-	_, b := c.inbox.GetMessage(data.ChirpId)
-	if !b {
-		return xerrors.Errorf("the message to be deleted was not found")
-	}
-
-	return nil
-}
-
-func (c *Channel) verifyChirpMessage(msg message.Message, chirpMsg messagedata.Verifiable) error {
-	err := chirpMsg.Verify()
-	if err != nil {
-		return xerrors.Errorf("invalid chirp message: %v", err)
-	}
-
-	senderBuf, err := base64.URLEncoding.DecodeString(msg.Sender)
-	if err != nil {
-		return xerrors.Errorf("failed to decode sender key: %v", err)
-	}
-
-	senderPoint := crypto.Suite.Point()
-	err = senderPoint.UnmarshalBinary(senderBuf)
-	if err != nil {
-		return answer.NewError(-4, "invalid sender public key")
-	}
-
-	if msg.Sender != c.owner {
-		return answer.NewError(-4, "only the owner of the channel can post chirps")
 	}
 
 	return nil

--- a/be1-go/channel/chirp/mod_test.go
+++ b/be1-go/channel/chirp/mod_test.go
@@ -279,7 +279,7 @@ func Test_Send_Chirp(t *testing.T) {
 	checkData := messagedata.ChirpBroadcast{
 		Object:    "chirp",
 		Action:    "notify_add",
-		ChirpId:   messagedata.Hash(buf64, "h"),
+		ChirpID:   messagedata.Hash(buf64, "h"),
 		Channel:   generalName,
 		Timestamp: 1634760180,
 	}
@@ -329,7 +329,7 @@ func Test_Delete_Chirp(t *testing.T) {
 		WitnessSignatures: []message.WitnessSignature{},
 	}
 
-	addChirpId := m.MessageID
+	addChirpID := m.MessageID
 
 	relativePathCreatePub := filepath.Join(relativeQueryExamplePath, "publish")
 
@@ -359,7 +359,7 @@ func Test_Delete_Chirp(t *testing.T) {
 	err = json.Unmarshal(buf, &chirpDel)
 	require.NoError(t, err)
 
-	chirpDel.ChirpId = addChirpId
+	chirpDel.ChirpID = addChirpID
 
 	buf, err = json.Marshal(chirpDel)
 	require.NoError(t, err)
@@ -385,7 +385,7 @@ func Test_Delete_Chirp(t *testing.T) {
 	checkDataAdd := messagedata.ChirpBroadcast{
 		Object:    "chirp",
 		Action:    "notify_add",
-		ChirpId:   messagedata.Hash(buf64add, "h"),
+		ChirpID:   messagedata.Hash(buf64add, "h"),
 		Channel:   generalName,
 		Timestamp: 1634760180,
 	}
@@ -396,7 +396,7 @@ func Test_Delete_Chirp(t *testing.T) {
 	checkDataDelete := messagedata.ChirpBroadcast{
 		Object:    "chirp",
 		Action:    "notify_delete",
-		ChirpId:   messagedata.Hash(buf64delete, "h"),
+		ChirpID:   messagedata.Hash(buf64delete, "h"),
 		Channel:   generalName,
 		Timestamp: 1634760180,
 	}

--- a/be1-go/channel/consensus/message_creation.go
+++ b/be1-go/channel/consensus/message_creation.go
@@ -8,7 +8,8 @@ import (
 )
 
 // createPrepareMessage creates the data for a new prepare message
-func (c *Channel) createPrepareMessage(consensusInstance *ConsensusInstance, messageID string) ([]byte, error) {
+func (c *Channel) createPrepareMessage(consensusInstance *ConsensusInstance,
+	messageID string) ([]byte, error) {
 
 	newData := messagedata.ConsensusPrepare{
 		Object:     "consensus",
@@ -32,7 +33,8 @@ func (c *Channel) createPrepareMessage(consensusInstance *ConsensusInstance, mes
 }
 
 // createPromiseMessage creates the data for a new promise message
-func (c *Channel) createPromiseMessage(consensusInstance *ConsensusInstance, messageID string) ([]byte, error) {
+func (c *Channel) createPromiseMessage(consensusInstance *ConsensusInstance,
+	messageID string) ([]byte, error) {
 
 	newData := messagedata.ConsensusPromise{
 		Object:     "consensus",
@@ -95,7 +97,8 @@ func (c *Channel) createProposeMessage(consensusInstance *ConsensusInstance, mes
 }
 
 // createAcceptMessage creates the data for a new accept message
-func (c *Channel) createAcceptMessage(consensusInstance *ConsensusInstance, messageID string) ([]byte, error) {
+func (c *Channel) createAcceptMessage(consensusInstance *ConsensusInstance,
+	messageID string) ([]byte, error) {
 
 	newData := messagedata.ConsensusAccept{
 		Object:     "consensus",
@@ -120,7 +123,8 @@ func (c *Channel) createAcceptMessage(consensusInstance *ConsensusInstance, mess
 }
 
 // createLearnMessage creates the data for a learn message
-func (c *Channel) createLearnMessage(consensusInstance *ConsensusInstance, messageID string) ([]byte, error) {
+func (c *Channel) createLearnMessage(consensusInstance *ConsensusInstance,
+	messageID string) ([]byte, error) {
 
 	newData := messagedata.ConsensusLearn{
 		Object:     "consensus",
@@ -150,11 +154,13 @@ func (c *Channel) createLearnMessage(consensusInstance *ConsensusInstance, messa
 }
 
 // createFailureMessage creates the data for a failure message
-func (c *Channel) createFailureMessage(consensusInstance *ConsensusInstance, messageID string) ([]byte, error) {
+func (c *Channel) createFailureMessage(consensusInstance *ConsensusInstance,
+	messageID string) ([]byte, error) {
 
 	electInstance, ok := consensusInstance.electInstances[messageID]
 	if !ok {
-		return nil, xerrors.Errorf("message Id doesn't correspond to any previously received message")
+		return nil, xerrors.Errorf("message Id doesn't correspond to any" +
+			"previously received message")
 	}
 
 	if electInstance.failed {

--- a/be1-go/channel/consensus/message_creation.go
+++ b/be1-go/channel/consensus/message_creation.go
@@ -159,7 +159,7 @@ func (c *Channel) createFailureMessage(consensusInstance *ConsensusInstance,
 
 	electInstance, ok := consensusInstance.electInstances[messageID]
 	if !ok {
-		return nil, xerrors.Errorf("message Id doesn't correspond to any" +
+		return nil, xerrors.Errorf("message Id doesn't correspond to any " +
 			"previously received message")
 	}
 

--- a/be1-go/channel/consensus/mod.go
+++ b/be1-go/channel/consensus/mod.go
@@ -109,7 +109,9 @@ type ElectInstance struct {
 }
 
 // NewChannel returns a new initialized consensus channel
-func NewChannel(channelID string, hub channel.HubFunctionalities, log zerolog.Logger) channel.Channel {
+func NewChannel(channelID string, hub channel.HubFunctionalities,
+	log zerolog.Logger) channel.Channel {
+
 	inbox := inbox.NewInbox(channelID)
 
 	log = log.With().Str("channel", "consensus").Logger()
@@ -210,7 +212,6 @@ func (c *Channel) Broadcast(broadcast method.Broadcast, socket socket.Socket) er
 
 // handleMessage handles a message received in a broadcast or publish method
 func (c *Channel) handleMessage(msg message.Message, socket socket.Socket) error {
-
 	err := c.registry.Process(msg, socket)
 	if err != nil {
 		return xerrors.Errorf("failed to process message: %w", err)
@@ -243,7 +244,9 @@ func (c *Channel) NewConsensusRegistry() registry.MessageRegistry {
 }
 
 // processConsensusElect processes an elect action.
-func (c *Channel) processConsensusElect(message message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processConsensusElect(message message.Message, msgData interface{},
+	_ socket.Socket) error {
+
 	data, ok := msgData.(*messagedata.ConsensusElect)
 	if !ok {
 		return xerrors.Errorf("message %v isn't a consensus#elect message", msgData)
@@ -287,7 +290,8 @@ func (c *Channel) processConsensusElect(message message.Message, msgData interfa
 }
 
 // processConsensusElectAccept processes an elect accept action.
-func (c *Channel) processConsensusElectAccept(message message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processConsensusElectAccept(message message.Message, msgData interface{},
+	_ socket.Socket) error {
 
 	data, ok := msgData.(*messagedata.ConsensusElectAccept)
 	if !ok {
@@ -361,7 +365,8 @@ func (c *Channel) processConsensusElectAccept(message message.Message, msgData i
 }
 
 // processConsensusPrepare processes a prepare action.
-func (c *Channel) processConsensusPrepare(_ message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processConsensusPrepare(_ message.Message, msgData interface{},
+	_ socket.Socket) error {
 
 	data, ok := msgData.(*messagedata.ConsensusPrepare)
 	if !ok {
@@ -421,7 +426,8 @@ func (c *Channel) processConsensusPrepare(_ message.Message, msgData interface{}
 }
 
 // processConsensusPromise processes a promise action.
-func (c *Channel) processConsensusPromise(msg message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processConsensusPromise(msg message.Message, msgData interface{},
+	_ socket.Socket) error {
 
 	data, ok := msgData.(*messagedata.ConsensusPromise)
 	if !ok {
@@ -497,7 +503,8 @@ func (c *Channel) processConsensusPromise(msg message.Message, msgData interface
 }
 
 // processConsensusPropose processes a propose action.
-func (c *Channel) processConsensusPropose(_ message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processConsensusPropose(_ message.Message, msgData interface{},
+	_ socket.Socket) error {
 
 	data, ok := msgData.(*messagedata.ConsensusPropose)
 	if !ok {
@@ -564,7 +571,8 @@ func (c *Channel) processConsensusPropose(_ message.Message, msgData interface{}
 }
 
 // processConsensusAccept proccesses an accept action.
-func (c *Channel) processConsensusAccept(msg message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processConsensusAccept(msg message.Message, msgData interface{},
+	_ socket.Socket) error {
 
 	data, ok := msgData.(*messagedata.ConsensusAccept)
 	if !ok {
@@ -639,7 +647,8 @@ func (c *Channel) processConsensusAccept(msg message.Message, msgData interface{
 }
 
 // processConsensusLearn processes a learn action.
-func (c *Channel) processConsensusLearn(_ message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processConsensusLearn(_ message.Message, msgData interface{},
+	_ socket.Socket) error {
 
 	data, ok := msgData.(*messagedata.ConsensusLearn)
 	if !ok {
@@ -681,7 +690,8 @@ func (c *Channel) processConsensusLearn(_ message.Message, msgData interface{}, 
 }
 
 // processConsensusFailure processes a failure action
-func (c *Channel) processConsensusFailure(_ message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processConsensusFailure(_ message.Message, msgData interface{},
+	_ socket.Socket) error {
 
 	data, ok := msgData.(*messagedata.ConsensusFailure)
 	if !ok {
@@ -724,7 +734,6 @@ func (c *Channel) processConsensusFailure(_ message.Message, msgData interface{}
 
 // verifyMessage checks if a message in a Publish or Broadcast method is valid
 func (c *Channel) verifyMessage(msg message.Message) error {
-
 	jsonData, err := base64.URLEncoding.DecodeString(msg.Data)
 	if err != nil {
 		return xerrors.Errorf("failed to decode message data: %v", err)
@@ -771,7 +780,7 @@ func (c *Channel) broadcastToAllClients(msg message.Message) error {
 	}
 
 	c.sockets.SendToAll(buf)
-	
+
 	return nil
 }
 
@@ -794,7 +803,6 @@ func getSender(msg message.Message) (kyber.Point, error) {
 
 // nextMessage verifies if a prepare or failure message should be sent
 func (c *Channel) nextMessage(i *ConsensusInstance, messageID string) string {
-
 	electInstance := i.electInstances[messageID]
 
 	if i.role != proposerRole {
@@ -816,7 +824,6 @@ func (c *Channel) nextMessage(i *ConsensusInstance, messageID string) string {
 
 // publishNewMessage send a publish message on the current channel
 func (c *Channel) publishNewMessage(byteMsg []byte) error {
-
 	encryptedMsg := base64.URLEncoding.EncodeToString(byteMsg)
 
 	publicKey := c.hub.GetPubKeyServ()
@@ -955,7 +962,6 @@ func (c *Channel) electAcceptFailure(instance *ConsensusInstance, messageID stri
 
 // startTimer starts the timeout logic for the consensus
 func (c *Channel) startTimer(instance *ConsensusInstance, messageID string) {
-
 	timeoutChan := instance.electInstances[messageID].timeoutChan
 
 	for {

--- a/be1-go/channel/consensus/mod.go
+++ b/be1-go/channel/consensus/mod.go
@@ -771,6 +771,7 @@ func (c *Channel) broadcastToAllClients(msg message.Message) error {
 	}
 
 	c.sockets.SendToAll(buf)
+	
 	return nil
 }
 

--- a/be1-go/channel/consensus/mod.go
+++ b/be1-go/channel/consensus/mod.go
@@ -71,7 +71,7 @@ type Channel struct {
 	}
 }
 
-// Save the state of a consensus instance
+// ConsensusInstance saves the state of a consensus instance
 type ConsensusInstance struct {
 	sync.RWMutex
 	id string
@@ -108,21 +108,6 @@ type ElectInstance struct {
 	negativeAcceptors map[string]int
 }
 
-// createElectInstance creates the state of the consensus for a specific elect
-// message
-func (i *ConsensusInstance) createElectInstance(messageID string, acceptorNumber int) {
-	i.electInstances[messageID] = &ElectInstance{
-		timeoutChan: make(chan string),
-
-		failed: false,
-
-		positiveAcceptors: make(map[string]int),
-		negativeAcceptors: make(map[string]int),
-
-		acceptorNumber: acceptorNumber,
-	}
-}
-
 // NewChannel returns a new initialized consensus channel
 func NewChannel(channelID string, hub channel.HubFunctionalities, log zerolog.Logger) channel.Channel {
 	inbox := inbox.NewInbox(channelID)
@@ -151,108 +136,9 @@ func NewChannel(channelID string, hub channel.HubFunctionalities, log zerolog.Lo
 	return newChannel
 }
 
-// NewConsensusRegistry creates a new registry for the consensus channel
-func (c *Channel) NewConsensusRegistry() registry.MessageRegistry {
-	registry := registry.NewMessageRegistry()
-
-	registry.Register(messagedata.ConsensusElect{}, c.processConsensusElect)
-	registry.Register(messagedata.ConsensusElectAccept{}, c.processConsensusElectAccept)
-	registry.Register(messagedata.ConsensusPrepare{}, c.processConsensusPrepare)
-	registry.Register(messagedata.ConsensusPromise{}, c.processConsensusPromise)
-	registry.Register(messagedata.ConsensusPropose{}, c.processConsensusPropose)
-	registry.Register(messagedata.ConsensusAccept{}, c.processConsensusAccept)
-	registry.Register(messagedata.ConsensusLearn{}, c.processConsensusLearn)
-	registry.Register(messagedata.ConsensusFailure{}, c.processConsensusFailure)
-
-	return registry
-}
-
-// timeoutFailure sends a failure message during a timeout
-func (c *Channel) timeoutFailure(instance *ConsensusInstance, messageID string) {
-	byteMsg, err := c.createFailureMessage(instance, messageID)
-	if err != nil {
-		c.log.Err(err).Msg(failedFailureCreation)
-		return
-	}
-
-	err = c.publishNewMessage(byteMsg)
-	if err != nil {
-		c.log.Err(err).Msg(failedFailureSending)
-	}
-}
-
-// startTimer starts the timeout logic for the consensus
-func (c *Channel) startTimer(instance *ConsensusInstance, messageID string) {
-
-	timeoutChan := instance.electInstances[messageID].timeoutChan
-
-	for {
-		select {
-		case action := <-timeoutChan:
-			switch action {
-			// Stop the timer when receiving one action finishing it
-			case messagedata.ConsensusActionLearn,
-				messagedata.ConsensusActionFailure:
-				return
-
-			case messagedata.ConsensusActionElectAccept,
-				messagedata.ConsensusActionPrepare,
-				messagedata.ConsensusActionPromise,
-				messagedata.ConsensusActionPropose,
-				messagedata.ConsensusActionAccept:
-
-			default:
-				c.log.Error().Msgf("action %s isn't a recognised action", action)
-				return
-			}
-
-		case <-c.clock.After(fastTimeout):
-			switch instance.lastSent {
-			case messagedata.ConsensusActionElectAccept:
-				select {
-				case action := <-timeoutChan:
-					// Stop the timer when receiving one action finishing it
-					if action == messagedata.ConsensusActionLearn ||
-						action == messagedata.ConsensusActionFailure {
-						return
-					}
-
-				case <-c.clock.After(slowTimeout):
-					c.timeoutFailure(instance, messageID)
-					return
-				}
-
-			case messagedata.ConsensusActionPrepare,
-				messagedata.ConsensusActionPropose:
-
-				instance.role = acceptorRole
-
-				select {
-				case action := <-timeoutChan:
-					// Stop the timer when receiving one action finishing it
-					if action == messagedata.ConsensusActionLearn ||
-						action == messagedata.ConsensusActionFailure {
-						return
-					}
-
-				case <-c.clock.After(fastTimeout):
-					c.timeoutFailure(instance, messageID)
-					return
-				}
-
-			case messagedata.ConsensusActionPromise,
-				messagedata.ConsensusActionAccept:
-
-				c.timeoutFailure(instance, messageID)
-				return
-
-			case messagedata.ConsensusActionLearn,
-				messagedata.ConsensusActionFailure:
-				return
-			}
-		}
-	}
-}
+// ---
+// Publish-subscribe / channel.Channel implementation
+// ---
 
 // Subscribe is used to handle a subscribe message from the client
 func (c *Channel) Subscribe(sock socket.Socket, msg method.Subscribe) error {
@@ -270,6 +156,25 @@ func (c *Channel) Unsubscribe(socketID string, msg method.Unsubscribe) error {
 	ok := c.sockets.Delete(socketID)
 	if !ok {
 		return answer.NewError(-2, "client is not subscribed to this channel")
+	}
+
+	return nil
+}
+
+// Publish handles publish messages for the consensus channel
+func (c *Channel) Publish(publish method.Publish, socket socket.Socket) error {
+	c.log.Info().
+		Str(msgID, strconv.Itoa(publish.ID)).
+		Msg("received a publish")
+
+	err := c.verifyMessage(publish.Params.Message)
+	if err != nil {
+		return xerrors.Errorf("failed to verify publish message: %w", err)
+	}
+
+	err = c.handleMessage(publish.Params.Message, socket)
+	if err != nil {
+		return xerrors.Errorf("failed to handle publish message: %v", err)
 	}
 
 	return nil
@@ -299,6 +204,10 @@ func (c *Channel) Broadcast(broadcast method.Broadcast, socket socket.Socket) er
 	return nil
 }
 
+// ---
+// Message handling
+// ---
+
 // handleMessage handles a message received in a broadcast or publish method
 func (c *Channel) handleMessage(msg message.Message, socket socket.Socket) error {
 
@@ -317,124 +226,20 @@ func (c *Channel) handleMessage(msg message.Message, socket socket.Socket) error
 	return nil
 }
 
-// broadcastToAllClients is a helper message to broadcast a message to all
-// clients.
-func (c *Channel) broadcastToAllClients(msg message.Message) error {
-	c.log.Info().Str(msgID, msg.MessageID).Msg("broadcasting message to all witnesses")
+// NewConsensusRegistry creates a new registry for the consensus channel
+func (c *Channel) NewConsensusRegistry() registry.MessageRegistry {
+	registry := registry.NewMessageRegistry()
 
-	rpcMessage := method.Broadcast{
-		Base: query.Base{
-			JSONRPCBase: jsonrpc.JSONRPCBase{
-				JSONRPC: "2.0",
-			},
-			Method: "broadcast",
-		},
-		Params: struct {
-			Channel string          `json:"channel"`
-			Message message.Message `json:"message"`
-		}{
-			c.channelID,
-			msg,
-		},
-	}
+	registry.Register(messagedata.ConsensusElect{}, c.processConsensusElect)
+	registry.Register(messagedata.ConsensusElectAccept{}, c.processConsensusElectAccept)
+	registry.Register(messagedata.ConsensusPrepare{}, c.processConsensusPrepare)
+	registry.Register(messagedata.ConsensusPromise{}, c.processConsensusPromise)
+	registry.Register(messagedata.ConsensusPropose{}, c.processConsensusPropose)
+	registry.Register(messagedata.ConsensusAccept{}, c.processConsensusAccept)
+	registry.Register(messagedata.ConsensusLearn{}, c.processConsensusLearn)
+	registry.Register(messagedata.ConsensusFailure{}, c.processConsensusFailure)
 
-	buf, err := json.Marshal(&rpcMessage)
-	if err != nil {
-		return xerrors.Errorf("failed to marshal broadcast query: %v", err)
-	}
-
-	c.sockets.SendToAll(buf)
-	return nil
-}
-
-// Publish handles publish messages for the consensus channel
-func (c *Channel) Publish(publish method.Publish, socket socket.Socket) error {
-	c.log.Info().
-		Str(msgID, strconv.Itoa(publish.ID)).
-		Msg("received a publish")
-
-	err := c.verifyMessage(publish.Params.Message)
-	if err != nil {
-		return xerrors.Errorf("failed to verify publish message: %w", err)
-	}
-
-	err = c.handleMessage(publish.Params.Message, socket)
-	if err != nil {
-		return xerrors.Errorf("failed to handle publish message: %v", err)
-	}
-
-	return nil
-}
-
-// verifyMessage checks if a message in a Publish or Broadcast method is valid
-func (c *Channel) verifyMessage(msg message.Message) error {
-
-	jsonData, err := base64.URLEncoding.DecodeString(msg.Data)
-	if err != nil {
-		return xerrors.Errorf("failed to decode message data: %v", err)
-	}
-
-	// Verify the data
-	err = c.hub.GetSchemaValidator().VerifyJSON(jsonData, validation.Data)
-	if err != nil {
-		return xerrors.Errorf("failed to verify json schema: %w", err)
-	}
-
-	// Check if the message already exists
-	if _, ok := c.inbox.GetMessage(msg.MessageID); ok {
-		return answer.NewError(-3, "message already exists")
-	}
-
-	return nil
-}
-
-// getSender unmarshal the sender from a message.Message
-func getSender(msg message.Message) (kyber.Point, error) {
-	senderBuf, err := base64.URLEncoding.DecodeString(msg.Sender)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to decode sender key: %v", err)
-	}
-
-	// Unmarshal sender of the message, used to know who is the propose
-	senderPoint := crypto.Suite.Point()
-	err = senderPoint.UnmarshalBinary(senderBuf)
-	if err != nil {
-		return nil, answer.NewErrorf(-4, "failed to unmarshal public key of the sender: %v", err)
-	}
-
-	return senderPoint, nil
-}
-
-// createConsensusInstance adds a new consensus instance to the
-// consensusInstances array
-func (c *Channel) createConsensusInstance(instanceID string) *ConsensusInstance {
-	consensusInstance := &ConsensusInstance{
-
-		id: instanceID,
-
-		role: acceptorRole,
-
-		lastSent: "",
-
-		proposedTry: 0,
-		promisedTry: -1,
-		acceptedTry: -1,
-
-		acceptedValue: false,
-		proposedValue: false,
-
-		decided:  false,
-		decision: false,
-
-		promises: make(map[string]messagedata.ConsensusPromise),
-		accepts:  make(map[string]messagedata.ConsensusAccept),
-
-		electInstances: make(map[string]*ElectInstance),
-	}
-
-	c.consensusInstances.m[instanceID] = consensusInstance
-
-	return consensusInstance
+	return registry
 }
 
 // processConsensusElect processes an elect action.
@@ -477,65 +282,6 @@ func (c *Channel) processConsensusElect(message message.Message, msgData interfa
 
 	// Start a channel linked to the message id
 	go c.startTimer(consensusInstance, message.MessageID)
-
-	return nil
-}
-
-// nextMessage verify if a prepare or failure message should be sent
-func (c *Channel) nextMessage(i *ConsensusInstance, messageID string) string {
-
-	electInstance := i.electInstances[messageID]
-
-	if i.role != proposerRole {
-		return ""
-	}
-
-	// If enough rejection, failure of the consensus
-	if len(electInstance.negativeAcceptors) >= (electInstance.acceptorNumber/2 + 1) {
-		return messagedata.ConsensusActionFailure
-	}
-
-	// If enough acception, go to next step of the consensus
-	if len(electInstance.positiveAcceptors) >= (electInstance.acceptorNumber/2 + 1) {
-		return messagedata.ConsensusActionPrepare
-	}
-
-	return ""
-}
-
-// updateAcceptors updates the acceptors of an electInstance
-func (e *ElectInstance) updateAcceptors(sender string, accept bool) error {
-	_, ok := e.positiveAcceptors[sender]
-	if ok {
-		return xerrors.Errorf("Acceptor %s already accepted this value", sender)
-	}
-
-	_, ok = e.negativeAcceptors[sender]
-	if ok {
-		return xerrors.Errorf("Acceptor %s already refused this value", sender)
-	}
-
-	// Update the elect state
-	if accept {
-		e.positiveAcceptors[sender] = 0
-	} else {
-		e.negativeAcceptors[sender] = 0
-	}
-
-	return nil
-}
-
-// electAcceptFailure sends a failure message when consensus is refused
-func (c *Channel) electAcceptFailure(instance *ConsensusInstance, messageID string) error {
-	byteMsg, err := c.createFailureMessage(instance, messageID)
-	if err != nil {
-		return xerrors.Errorf("failed to create consensus#failure message: %v", err)
-	}
-
-	err = c.publishNewMessage(byteMsg)
-	if err != nil {
-		return xerrors.Errorf("failed to send new consensus#failure message: %v", err)
-	}
 
 	return nil
 }
@@ -976,6 +722,97 @@ func (c *Channel) processConsensusFailure(_ message.Message, msgData interface{}
 	return nil
 }
 
+// verifyMessage checks if a message in a Publish or Broadcast method is valid
+func (c *Channel) verifyMessage(msg message.Message) error {
+
+	jsonData, err := base64.URLEncoding.DecodeString(msg.Data)
+	if err != nil {
+		return xerrors.Errorf("failed to decode message data: %v", err)
+	}
+
+	// Verify the data
+	err = c.hub.GetSchemaValidator().VerifyJSON(jsonData, validation.Data)
+	if err != nil {
+		return xerrors.Errorf("failed to verify json schema: %w", err)
+	}
+
+	// Check if the message already exists
+	if _, ok := c.inbox.GetMessage(msg.MessageID); ok {
+		return answer.NewError(-3, "message already exists")
+	}
+
+	return nil
+}
+
+// broadcastToAllClients is a helper message to broadcast a message to all
+// clients.
+func (c *Channel) broadcastToAllClients(msg message.Message) error {
+	c.log.Info().Str(msgID, msg.MessageID).Msg("broadcasting message to all witnesses")
+
+	rpcMessage := method.Broadcast{
+		Base: query.Base{
+			JSONRPCBase: jsonrpc.JSONRPCBase{
+				JSONRPC: "2.0",
+			},
+			Method: "broadcast",
+		},
+		Params: struct {
+			Channel string          `json:"channel"`
+			Message message.Message `json:"message"`
+		}{
+			c.channelID,
+			msg,
+		},
+	}
+
+	buf, err := json.Marshal(&rpcMessage)
+	if err != nil {
+		return xerrors.Errorf("failed to marshal broadcast query: %v", err)
+	}
+
+	c.sockets.SendToAll(buf)
+	return nil
+}
+
+// getSender unmarshal the sender from a message.Message
+func getSender(msg message.Message) (kyber.Point, error) {
+	senderBuf, err := base64.URLEncoding.DecodeString(msg.Sender)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to decode sender key: %v", err)
+	}
+
+	// Unmarshal sender of the message, used to know who is the propose
+	senderPoint := crypto.Suite.Point()
+	err = senderPoint.UnmarshalBinary(senderBuf)
+	if err != nil {
+		return nil, answer.NewErrorf(-4, "failed to unmarshal public key of the sender: %v", err)
+	}
+
+	return senderPoint, nil
+}
+
+// nextMessage verifies if a prepare or failure message should be sent
+func (c *Channel) nextMessage(i *ConsensusInstance, messageID string) string {
+
+	electInstance := i.electInstances[messageID]
+
+	if i.role != proposerRole {
+		return ""
+	}
+
+	// If enough rejection, failure of the consensus
+	if len(electInstance.negativeAcceptors) >= (electInstance.acceptorNumber/2 + 1) {
+		return messagedata.ConsensusActionFailure
+	}
+
+	// If enough acception, go to next step of the consensus
+	if len(electInstance.positiveAcceptors) >= (electInstance.acceptorNumber/2 + 1) {
+		return messagedata.ConsensusActionPrepare
+	}
+
+	return ""
+}
+
 // publishNewMessage send a publish message on the current channel
 func (c *Channel) publishNewMessage(byteMsg []byte) error {
 
@@ -1029,4 +866,175 @@ func (c *Channel) publishNewMessage(byteMsg []byte) error {
 	}
 
 	return nil
+}
+
+// createElectInstance creates the state of the consensus for a specific elect
+// message
+func (i *ConsensusInstance) createElectInstance(messageID string, acceptorNumber int) {
+	i.electInstances[messageID] = &ElectInstance{
+		timeoutChan: make(chan string),
+
+		failed: false,
+
+		positiveAcceptors: make(map[string]int),
+		negativeAcceptors: make(map[string]int),
+
+		acceptorNumber: acceptorNumber,
+	}
+}
+
+// createConsensusInstance adds a new consensus instance to the
+// consensusInstances array
+func (c *Channel) createConsensusInstance(instanceID string) *ConsensusInstance {
+	consensusInstance := &ConsensusInstance{
+
+		id: instanceID,
+
+		role: acceptorRole,
+
+		lastSent: "",
+
+		proposedTry: 0,
+		promisedTry: -1,
+		acceptedTry: -1,
+
+		acceptedValue: false,
+		proposedValue: false,
+
+		decided:  false,
+		decision: false,
+
+		promises: make(map[string]messagedata.ConsensusPromise),
+		accepts:  make(map[string]messagedata.ConsensusAccept),
+
+		electInstances: make(map[string]*ElectInstance),
+	}
+
+	c.consensusInstances.m[instanceID] = consensusInstance
+
+	return consensusInstance
+}
+
+// updateAcceptors updates the acceptors of an electInstance
+func (e *ElectInstance) updateAcceptors(sender string, accept bool) error {
+	_, ok := e.positiveAcceptors[sender]
+	if ok {
+		return xerrors.Errorf("Acceptor %s already accepted this value", sender)
+	}
+
+	_, ok = e.negativeAcceptors[sender]
+	if ok {
+		return xerrors.Errorf("Acceptor %s already refused this value", sender)
+	}
+
+	// Update the elect state
+	if accept {
+		e.positiveAcceptors[sender] = 0
+	} else {
+		e.negativeAcceptors[sender] = 0
+	}
+
+	return nil
+}
+
+// electAcceptFailure sends a failure message when consensus is refused
+func (c *Channel) electAcceptFailure(instance *ConsensusInstance, messageID string) error {
+	byteMsg, err := c.createFailureMessage(instance, messageID)
+	if err != nil {
+		return xerrors.Errorf("failed to create consensus#failure message: %v", err)
+	}
+
+	err = c.publishNewMessage(byteMsg)
+	if err != nil {
+		return xerrors.Errorf("failed to send new consensus#failure message: %v", err)
+	}
+
+	return nil
+}
+
+// startTimer starts the timeout logic for the consensus
+func (c *Channel) startTimer(instance *ConsensusInstance, messageID string) {
+
+	timeoutChan := instance.electInstances[messageID].timeoutChan
+
+	for {
+		select {
+		case action := <-timeoutChan:
+			switch action {
+			// Stop the timer when receiving one action finishing it
+			case messagedata.ConsensusActionLearn,
+				messagedata.ConsensusActionFailure:
+				return
+
+			case messagedata.ConsensusActionElectAccept,
+				messagedata.ConsensusActionPrepare,
+				messagedata.ConsensusActionPromise,
+				messagedata.ConsensusActionPropose,
+				messagedata.ConsensusActionAccept:
+
+			default:
+				c.log.Error().Msgf("action %s isn't a recognised action", action)
+				return
+			}
+
+		case <-c.clock.After(fastTimeout):
+			switch instance.lastSent {
+			case messagedata.ConsensusActionElectAccept:
+				select {
+				case action := <-timeoutChan:
+					// Stop the timer when receiving one action finishing it
+					if action == messagedata.ConsensusActionLearn ||
+						action == messagedata.ConsensusActionFailure {
+						return
+					}
+
+				case <-c.clock.After(slowTimeout):
+					c.timeoutFailure(instance, messageID)
+					return
+				}
+
+			case messagedata.ConsensusActionPrepare,
+				messagedata.ConsensusActionPropose:
+
+				instance.role = acceptorRole
+
+				select {
+				case action := <-timeoutChan:
+					// Stop the timer when receiving one action finishing it
+					if action == messagedata.ConsensusActionLearn ||
+						action == messagedata.ConsensusActionFailure {
+						return
+					}
+
+				case <-c.clock.After(fastTimeout):
+					c.timeoutFailure(instance, messageID)
+					return
+				}
+
+			case messagedata.ConsensusActionPromise,
+				messagedata.ConsensusActionAccept:
+
+				c.timeoutFailure(instance, messageID)
+				return
+
+			case messagedata.ConsensusActionLearn,
+				messagedata.ConsensusActionFailure:
+				return
+			}
+		}
+	}
+}
+
+// timeoutFailure sends a failure message during a timeout
+func (c *Channel) timeoutFailure(instance *ConsensusInstance, messageID string) {
+	byteMsg, err := c.createFailureMessage(instance, messageID)
+	if err != nil {
+		c.log.Err(err).Msg(failedFailureCreation)
+		return
+	}
+
+	err = c.publishNewMessage(byteMsg)
+	if err != nil {
+		c.log.Err(err).Msg(failedFailureSending)
+	}
 }

--- a/be1-go/channel/election/mod.go
+++ b/be1-go/channel/election/mod.go
@@ -247,7 +247,8 @@ func (c *Channel) NewElectionRegistry() registry.MessageRegistry {
 	return registry
 }
 
-func (c *Channel) processElectionOpen(msg message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processElectionOpen(msg message.Message, msgData interface{},
+	_ socket.Socket) error {
 
 	data, ok := msgData.(*messagedata.ElectionOpen)
 	if !ok {
@@ -296,7 +297,8 @@ func (c *Channel) processElectionOpen(msg message.Message, msgData interface{}, 
 }
 
 // processCastVote is the callback that processes election#cast_vote messages
-func (c *Channel) processCastVote(msg message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processCastVote(msg message.Message, msgData interface{},
+	_ socket.Socket) error {
 
 	_, ok := msgData.(*messagedata.VoteCastVote)
 	if !ok {
@@ -348,7 +350,8 @@ func (c *Channel) processCastVote(msg message.Message, msgData interface{}, _ so
 }
 
 // processElectionEnd is the callback that processes election#end messages
-func (c *Channel) processElectionEnd(msg message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processElectionEnd(msg message.Message, msgData interface{},
+	_ socket.Socket) error {
 
 	_, ok := msgData.(*messagedata.ElectionEnd)
 	if !ok {
@@ -408,7 +411,9 @@ func (c *Channel) processElectionEnd(msg message.Message, msgData interface{}, _
 }
 
 // processElectionResult is the callback that processes election#result messages
-func (c *Channel) processElectionResult(msg message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processElectionResult(msg message.Message, msgData interface{},
+	_ socket.Socket) error {
+
 	data, ok := msgData.(*messagedata.ElectionResult)
 	if !ok {
 		return xerrors.Errorf("message '%T' isn't a election#result message", msgData)
@@ -430,7 +435,6 @@ func (c *Channel) processElectionResult(msg message.Message, msgData interface{}
 
 // verifyMessage checks if a message in a Publish or Broadcast method is valid
 func (c *Channel) verifyMessage(msg message.Message) error {
-
 	jsonData, err := base64.URLEncoding.DecodeString(msg.Data)
 	if err != nil {
 		return xerrors.Errorf(failedToDecodeData, err)
@@ -497,7 +501,6 @@ func (a *attendees) isPresent(key string) bool {
 
 // broadcastElectionResult gathers and broadcasts the results of an election
 func (c *Channel) broadcastElectionResult() error {
-
 	resultElection, err := gatherResults(c.questions, c.log)
 	if err != nil {
 		return xerrors.Errorf("failed to gather results: %v", err)
@@ -537,7 +540,9 @@ func (c *Channel) broadcastElectionResult() error {
 	return nil
 }
 
-func gatherResults(questions map[string]*question, log zerolog.Logger) (messagedata.ElectionResult, error) {
+func gatherResults(questions map[string]*question,
+	log zerolog.Logger) (messagedata.ElectionResult, error) {
+
 	log.Info().Msgf("gathering results for the election")
 
 	resultElection := messagedata.ElectionResult{
@@ -549,7 +554,8 @@ func gatherResults(questions map[string]*question, log zerolog.Logger) (messaged
 	for id := range questions {
 		question, ok := questions[id]
 		if !ok {
-			return resultElection, xerrors.Errorf("no question with this questionId '%s' was recorded", id)
+			return resultElection, xerrors.Errorf("no question with this"+
+				"questionId '%s' was recorded", id)
 		}
 
 		votes := question.validVotes
@@ -596,13 +602,16 @@ func checkMethodProperties(method string, length int) error {
 		return answer.NewError(-4, "No ballot option was chosen for plurality voting method")
 	}
 	if method == "Approval" && length != 1 {
-		return answer.NewError(-4, "Cannot choose multiple ballot options on approval voting method")
+		return answer.NewError(-4, "Cannot choose multiple ballot options"+
+			"on approval voting method")
 	}
 
 	return nil
 }
 
-func updateVote(msgID string, sender string, castVote messagedata.VoteCastVote, questions map[string]*question) error {
+func updateVote(msgID string, sender string, castVote messagedata.VoteCastVote,
+	questions map[string]*question) error {
+
 	// this should update any previously set vote if the message ids are the same
 	for _, vote := range castVote.Votes {
 
@@ -640,7 +649,6 @@ func updateVote(msgID string, sender string, castVote messagedata.VoteCastVote, 
 }
 
 func getAllQuestionsForElectionChannel(questions []messagedata.ElectionSetupQuestion) map[string]*question {
-
 	qs := make(map[string]*question)
 	for _, q := range questions {
 		ballotOpts := make([]string, len(q.BallotOptions))

--- a/be1-go/channel/election/mod.go
+++ b/be1-go/channel/election/mod.go
@@ -554,7 +554,7 @@ func gatherResults(questions map[string]*question,
 	for id := range questions {
 		question, ok := questions[id]
 		if !ok {
-			return resultElection, xerrors.Errorf("no question with this"+
+			return resultElection, xerrors.Errorf("no question with this "+
 				"questionId '%s' was recorded", id)
 		}
 
@@ -602,7 +602,7 @@ func checkMethodProperties(method string, length int) error {
 		return answer.NewError(-4, "No ballot option was chosen for plurality voting method")
 	}
 	if method == "Approval" && length != 1 {
-		return answer.NewError(-4, "Cannot choose multiple ballot options"+
+		return answer.NewError(-4, "Cannot choose multiple ballot options "+
 			"on approval voting method")
 	}
 

--- a/be1-go/channel/election/mod.go
+++ b/be1-go/channel/election/mod.go
@@ -29,72 +29,6 @@ const (
 	failedToBroadcast  = "failed to broadcast message: %v"
 )
 
-// attendees represents the attendees in an election.
-type attendees struct {
-	sync.Mutex
-	store map[string]struct{}
-}
-
-// isPresent checks if a key representing a user is present in
-// the list of attendees.
-func (a *attendees) isPresent(key string) bool {
-	a.Lock()
-	defer a.Unlock()
-
-	_, ok := a.store[key]
-
-	return ok
-}
-
-// NewChannel returns a new initialized election channel
-func NewChannel(channelPath string, msgData messagedata.ElectionSetup,
-	attendeesMap map[string]struct{}, hub channel.HubFunctionalities,
-	log zerolog.Logger, organizerPubKey kyber.Point) channel.Channel {
-
-	log = log.With().Str("channel", "election").Logger()
-
-	// Saving on election channel too so it self-contains the entire election history
-	// electionCh.inbox.storeMessage(msg)
-
-	newChannel := &Channel{
-		sockets:   channel.NewSockets(),
-		inbox:     inbox.NewInbox(channelPath),
-		channelID: channelPath,
-
-		start:      msgData.StartTime,
-		end:        msgData.EndTime,
-		started:    false,
-		terminated: false,
-		questions:  getAllQuestionsForElectionChannel(msgData.Questions),
-
-		attendees: &attendees{
-			store: attendeesMap,
-		},
-
-		hub: hub,
-
-		log: log,
-
-		organiserPubKey: organizerPubKey,
-	}
-
-	newChannel.registry = newChannel.NewElectionRegistry()
-
-	return newChannel
-}
-
-// NewElectionRegistry creates a new registry for the election channel
-func (c *Channel) NewElectionRegistry() registry.MessageRegistry {
-	registry := registry.NewMessageRegistry()
-
-	registry.Register(messagedata.ElectionOpen{}, c.processElectionOpen)
-	registry.Register(messagedata.VoteCastVote{}, c.processCastVote)
-	registry.Register(messagedata.ElectionEnd{}, c.processElectionEnd)
-	registry.Register(messagedata.ElectionResult{}, c.processElectionResult)
-
-	return registry
-}
-
 // Channel is used to handle election messages.
 type Channel struct {
 	sockets   channel.Sockets
@@ -165,25 +99,52 @@ type validVote struct {
 	indexes []int
 }
 
-// Publish is used to handle publish messages in the election channel.
-func (c *Channel) Publish(publish method.Publish, socket socket.Socket) error {
-	c.log.Info().
-		Str(msgID, strconv.Itoa(publish.ID)).
-		Msg("received a publish")
-
-	err := c.verifyMessage(publish.Params.Message)
-	if err != nil {
-		return xerrors.Errorf("failed to verify publish message on an "+
-			"election channel: %w", err)
-	}
-
-	err = c.handleMessage(publish.Params.Message, socket)
-	if err != nil {
-		return xerrors.Errorf("failed to handle a publish message: %v", err)
-	}
-
-	return nil
+// attendees represents the attendees in an election.
+type attendees struct {
+	sync.Mutex
+	store map[string]struct{}
 }
+
+// NewChannel returns a new initialized election channel
+func NewChannel(channelPath string, msgData messagedata.ElectionSetup,
+	attendeesMap map[string]struct{}, hub channel.HubFunctionalities,
+	log zerolog.Logger, organizerPubKey kyber.Point) channel.Channel {
+
+	log = log.With().Str("channel", "election").Logger()
+
+	// Saving on election channel too so it self-contains the entire election history
+	// electionCh.inbox.storeMessage(msg)
+
+	newChannel := &Channel{
+		sockets:   channel.NewSockets(),
+		inbox:     inbox.NewInbox(channelPath),
+		channelID: channelPath,
+
+		start:      msgData.StartTime,
+		end:        msgData.EndTime,
+		started:    false,
+		terminated: false,
+		questions:  getAllQuestionsForElectionChannel(msgData.Questions),
+
+		attendees: &attendees{
+			store: attendeesMap,
+		},
+
+		hub: hub,
+
+		log: log,
+
+		organiserPubKey: organizerPubKey,
+	}
+
+	newChannel.registry = newChannel.NewElectionRegistry()
+
+	return newChannel
+}
+
+// ---
+// Publish-subscribe / channel.Channel implementation
+// ---
 
 // Subscribe is used to handle a subscribe message from the client.
 func (c *Channel) Subscribe(socket socket.Socket, msg method.Subscribe) error {
@@ -205,6 +166,26 @@ func (c *Channel) Unsubscribe(socketID string, msg method.Unsubscribe) error {
 
 	if !ok {
 		return answer.NewError(-2, "client is not subscribed to this channel")
+	}
+
+	return nil
+}
+
+// Publish is used to handle publish messages in the election channel.
+func (c *Channel) Publish(publish method.Publish, socket socket.Socket) error {
+	c.log.Info().
+		Str(msgID, strconv.Itoa(publish.ID)).
+		Msg("received a publish")
+
+	err := c.verifyMessage(publish.Params.Message)
+	if err != nil {
+		return xerrors.Errorf("failed to verify publish message on an "+
+			"election channel: %w", err)
+	}
+
+	err = c.handleMessage(publish.Params.Message, socket)
+	if err != nil {
+		return xerrors.Errorf("failed to handle a publish message: %v", err)
 	}
 
 	return nil
@@ -237,6 +218,10 @@ func (c *Channel) Broadcast(broadcast method.Broadcast, socket socket.Socket) er
 	return nil
 }
 
+// ---
+// Message handling
+// ---
+
 // handleMessage handles a message received in a broadcast or publish method
 func (c *Channel) handleMessage(msg message.Message, socket socket.Socket) error {
 
@@ -250,60 +235,16 @@ func (c *Channel) handleMessage(msg message.Message, socket socket.Socket) error
 	return nil
 }
 
-// broadcastToAllClients is a helper message to broadcast a message to all
-// subscribers.
-func (c *Channel) broadcastToAllClients(msg message.Message) error {
-	c.log.Info().
-		Str(msgID, msg.MessageID).
-		Msg("broadcasting message to all clients")
+// NewElectionRegistry creates a new registry for the election channel
+func (c *Channel) NewElectionRegistry() registry.MessageRegistry {
+	registry := registry.NewMessageRegistry()
 
-	rpcMessage := method.Broadcast{
-		Base: query.Base{
-			JSONRPCBase: jsonrpc.JSONRPCBase{
-				JSONRPC: "2.0",
-			},
-			Method: query.MethodBroadcast,
-		},
-		Params: struct {
-			Channel string          `json:"channel"`
-			Message message.Message `json:"message"`
-		}{
-			c.channelID,
-			msg,
-		},
-	}
+	registry.Register(messagedata.ElectionOpen{}, c.processElectionOpen)
+	registry.Register(messagedata.VoteCastVote{}, c.processCastVote)
+	registry.Register(messagedata.ElectionEnd{}, c.processElectionEnd)
+	registry.Register(messagedata.ElectionResult{}, c.processElectionResult)
 
-	buf, err := json.Marshal(&rpcMessage)
-	if err != nil {
-		return xerrors.Errorf("failed to marshal broadcast query: %v", err)
-	}
-
-	c.sockets.SendToAll(buf)
-
-	return nil
-}
-
-// verifyMessage checks if a message in a Publish or Broadcast method is valid
-func (c *Channel) verifyMessage(msg message.Message) error {
-
-	jsonData, err := base64.URLEncoding.DecodeString(msg.Data)
-	if err != nil {
-		return xerrors.Errorf(failedToDecodeData, err)
-	}
-
-	// Verify the data
-	err = c.hub.GetSchemaValidator().VerifyJSON(jsonData, validation.Data)
-	if err != nil {
-		return xerrors.Errorf("failed to verify json schema: %w", err)
-	}
-
-	// Check if the message already exists
-	_, ok := c.inbox.GetMessage(msg.MessageID)
-	if ok {
-		return answer.NewError(-3, "message already exists")
-	}
-
-	return nil
+	return registry
 }
 
 func (c *Channel) processElectionOpen(msg message.Message, msgData interface{}, _ socket.Socket) error {
@@ -485,6 +426,73 @@ func (c *Channel) processElectionResult(msg message.Message, msgData interface{}
 	}
 
 	return nil
+}
+
+// verifyMessage checks if a message in a Publish or Broadcast method is valid
+func (c *Channel) verifyMessage(msg message.Message) error {
+
+	jsonData, err := base64.URLEncoding.DecodeString(msg.Data)
+	if err != nil {
+		return xerrors.Errorf(failedToDecodeData, err)
+	}
+
+	// Verify the data
+	err = c.hub.GetSchemaValidator().VerifyJSON(jsonData, validation.Data)
+	if err != nil {
+		return xerrors.Errorf("failed to verify json schema: %w", err)
+	}
+
+	// Check if the message already exists
+	_, ok := c.inbox.GetMessage(msg.MessageID)
+	if ok {
+		return answer.NewError(-3, "message already exists")
+	}
+
+	return nil
+}
+
+// broadcastToAllClients is a helper message to broadcast a message to all
+// subscribers.
+func (c *Channel) broadcastToAllClients(msg message.Message) error {
+	c.log.Info().
+		Str(msgID, msg.MessageID).
+		Msg("broadcasting message to all clients")
+
+	rpcMessage := method.Broadcast{
+		Base: query.Base{
+			JSONRPCBase: jsonrpc.JSONRPCBase{
+				JSONRPC: "2.0",
+			},
+			Method: query.MethodBroadcast,
+		},
+		Params: struct {
+			Channel string          `json:"channel"`
+			Message message.Message `json:"message"`
+		}{
+			c.channelID,
+			msg,
+		},
+	}
+
+	buf, err := json.Marshal(&rpcMessage)
+	if err != nil {
+		return xerrors.Errorf("failed to marshal broadcast query: %v", err)
+	}
+
+	c.sockets.SendToAll(buf)
+
+	return nil
+}
+
+// isPresent checks if a key representing a user is present in
+// the list of attendees.
+func (a *attendees) isPresent(key string) bool {
+	a.Lock()
+	defer a.Unlock()
+
+	_, ok := a.store[key]
+
+	return ok
 }
 
 // broadcastElectionResult gathers and broadcasts the results of an election

--- a/be1-go/channel/election/verification.go
+++ b/be1-go/channel/election/verification.go
@@ -124,8 +124,8 @@ func (c *Channel) verifyMessageCastVote(castVote messagedata.VoteCastVote) error
 
 	// verify created at is after start of election
 	if castVote.CreatedAt < c.start {
-		return xerrors.Errorf("cast vote created at is %d, should be greater or"+
-			" equal to defined start time %d",
+		return xerrors.Errorf("cast vote created at is %d, should be greater or "+
+			"equal to defined start time %d",
 			castVote.CreatedAt, c.start)
 	}
 
@@ -133,8 +133,8 @@ func (c *Channel) verifyMessageCastVote(castVote messagedata.VoteCastVote) error
 	if castVote.CreatedAt > c.end {
 		// note that CreatedAt is provided by the client and can't be fully trusted.
 		// We leave this check as is until we have a better solution.
-		return xerrors.Errorf("cast vote created at is %d, should be smaller or"+
-			" equal to defined end time %d",
+		return xerrors.Errorf("cast vote created at is %d, should be smaller or "+
+			"equal to defined end time %d",
 			castVote.CreatedAt, c.end)
 	}
 

--- a/be1-go/channel/election/verification.go
+++ b/be1-go/channel/election/verification.go
@@ -19,7 +19,8 @@ const (
 )
 
 func (c *Channel) verifyMessageElectionOpen(electionOpen messagedata.ElectionOpen) error {
-	c.log.Info().Msgf("verifying election#open message of election with id %s", electionOpen.Election)
+	c.log.Info().Msgf("verifying election#open message of election with id %s",
+		electionOpen.Election)
 
 	// verify lao id is base64URL encoded
 	_, err := base64.URLEncoding.DecodeString(electionOpen.Lao)
@@ -56,7 +57,8 @@ func (c *Channel) verifyMessageElectionOpen(electionOpen messagedata.ElectionOpe
 
 	// verify opened at is positive
 	if electionOpen.OpenedAt < 0 {
-		return xerrors.Errorf("election open created at is %d, should be minimum 0", electionOpen.OpenedAt)
+		return xerrors.Errorf("election open created at is %d, should be minimum 0",
+			electionOpen.OpenedAt)
 	}
 
 	// verify if the election was already started or terminated
@@ -69,7 +71,8 @@ func (c *Channel) verifyMessageElectionOpen(electionOpen messagedata.ElectionOpe
 
 // verifyMessageCastVote checks the election#cast_vote message data is valid.
 func (c *Channel) verifyMessageCastVote(castVote messagedata.VoteCastVote) error {
-	c.log.Info().Msgf("verifying election#cast_vote message of election with id %s", castVote.Election)
+	c.log.Info().Msgf("verifying election#cast_vote message of election with id %s",
+		castVote.Election)
 
 	// verify lao id is base64URL encoded
 	_, err := base64.URLEncoding.DecodeString(castVote.Lao)
@@ -104,12 +107,14 @@ func (c *Channel) verifyMessageCastVote(castVote messagedata.VoteCastVote) error
 
 	//verify if election is terminated
 	if c.terminated {
-		return xerrors.Errorf("cast vote created at is %d, but the election is terminated", castVote.CreatedAt)
+		return xerrors.Errorf("cast vote created at is %d, but the election is terminated",
+			castVote.CreatedAt)
 	}
 
 	// verify if election is not open
 	if !c.started {
-		return xerrors.Errorf("cast vote created at is %d, but the election is not started", castVote.CreatedAt)
+		return xerrors.Errorf("cast vote created at is %d, but the election is not started",
+			castVote.CreatedAt)
 	}
 
 	// verify created at is positive
@@ -119,7 +124,8 @@ func (c *Channel) verifyMessageCastVote(castVote messagedata.VoteCastVote) error
 
 	// verify created at is after start of election
 	if castVote.CreatedAt < c.start {
-		return xerrors.Errorf("cast vote created at is %d, should be greater or equal to defined start time %d",
+		return xerrors.Errorf("cast vote created at is %d, should be greater or"+
+			" equal to defined start time %d",
 			castVote.CreatedAt, c.start)
 	}
 
@@ -127,7 +133,8 @@ func (c *Channel) verifyMessageCastVote(castVote messagedata.VoteCastVote) error
 	if castVote.CreatedAt > c.end {
 		// note that CreatedAt is provided by the client and can't be fully trusted.
 		// We leave this check as is until we have a better solution.
-		return xerrors.Errorf("cast vote created at is %d, should be smaller or equal to defined end time %d",
+		return xerrors.Errorf("cast vote created at is %d, should be smaller or"+
+			" equal to defined end time %d",
 			castVote.CreatedAt, c.end)
 	}
 
@@ -136,7 +143,8 @@ func (c *Channel) verifyMessageCastVote(castVote messagedata.VoteCastVote) error
 
 // verifyMessageElectionEnd checks the election#end message data is valid.
 func (c *Channel) verifyMessageElectionEnd(electionEnd messagedata.ElectionEnd) error {
-	c.log.Info().Msgf("verifying election#end message of election with id %s", electionEnd.Election)
+	c.log.Info().Msgf("verifying election#end message of election with id %s",
+		electionEnd.Election)
 
 	// verify lao id is base64URL encoded
 	_, err := base64.URLEncoding.DecodeString(electionEnd.Lao)
@@ -171,7 +179,8 @@ func (c *Channel) verifyMessageElectionEnd(electionEnd messagedata.ElectionEnd) 
 
 	// verify created at is positive
 	if electionEnd.CreatedAt < 0 {
-		return xerrors.Errorf("election end created at is %d, should be minimum 0", electionEnd.CreatedAt)
+		return xerrors.Errorf("election end created at is %d, should be minimum 0",
+			electionEnd.CreatedAt)
 	}
 
 	// verify if the election is not terminated
@@ -186,7 +195,8 @@ func (c *Channel) verifyMessageElectionEnd(electionEnd messagedata.ElectionEnd) 
 
 	// verify registered votes are base64URL encoded
 	if _, err := base64.URLEncoding.DecodeString(electionEnd.RegisteredVotes); err != nil {
-		return xerrors.Errorf("election registered votes is %s, should be base64URL encoded", electionEnd.RegisteredVotes)
+		return xerrors.Errorf("election registered votes is %s, should be base64URL encoded",
+			electionEnd.RegisteredVotes)
 	}
 
 	// verify order of registered votes
@@ -202,7 +212,9 @@ func (c *Channel) verifyMessageElectionEnd(electionEnd messagedata.ElectionEnd) 
 }
 
 // verifyRegisteredVotes checks the registered votes of an election end message are valid.
-func verifyRegisteredVotes(electionEnd messagedata.ElectionEnd, questions *map[string]*question) error {
+func verifyRegisteredVotes(electionEnd messagedata.ElectionEnd,
+	questions *map[string]*question) error {
+
 	// get hashed ID of valid votes sorted by msg ID
 	validVotes := make(map[string]string)
 	validVotesSorted := make([]string, 0)

--- a/be1-go/channel/generalChirping/mod.go
+++ b/be1-go/channel/generalChirping/mod.go
@@ -53,15 +53,32 @@ func NewChannel(channelPath string, hub channel.HubFunctionalities, log zerolog.
 	return newChannel
 }
 
-// NewGeneralChirpingRegistry creates a new registry for a general chirping
-// channel and populates the registry with the actions of the channel.
-func (c *Channel) NewGeneralChirpingRegistry() registry.MessageRegistry {
-	newRegistry := registry.NewMessageRegistry()
+// ---
+// Publish-subscribe / channel.Channel implementation
+// ---
 
-	newRegistry.Register(messagedata.ChirpNotifyAdd{}, c.addChirp)
-	newRegistry.Register(messagedata.ChirpNotifyDelete{}, c.deleteChirp)
+// Subscribe is used to handle a subscribe message from the client.
+func (c *Channel) Subscribe(socket socket.Socket, msg method.Subscribe) error {
+	c.log.Info().
+		Str(msgID, strconv.Itoa(msg.ID)).
+		Msg("received a subscribe")
+	c.sockets.Upsert(socket)
 
-	return newRegistry
+	return nil
+}
+
+// Unsubscribe is used to handle an unsubscribe message.
+func (c *Channel) Unsubscribe(socketID string, msg method.Unsubscribe) error {
+	c.log.Info().
+		Str(msgID, strconv.Itoa(msg.ID)).
+		Msg("received a unsubscribe")
+
+	ok := c.sockets.Delete(socketID)
+	if !ok {
+		return answer.NewError(-2, "client is not subscribed to this channel")
+	}
+
+	return nil
 }
 
 // Publish is used to handle a publish message.
@@ -70,6 +87,14 @@ func (c *Channel) Publish(msg method.Publish, socket socket.Socket) error {
 		Str(msgID, strconv.Itoa(msg.ID)).
 		Msg("nothing should be published in the general")
 	return xerrors.Errorf("nothing should be directly published in the general")
+}
+
+// Catchup is used to handle a catchup message.
+func (c *Channel) Catchup(msg method.Catchup) []message.Message {
+	c.log.Info().
+		Str(msgID, strconv.Itoa(msg.ID)).
+		Msg("received a catchup")
+	return c.inbox.GetSortedMessages()
 }
 
 // Broadcast is used to handle broadcast messages.
@@ -97,36 +122,101 @@ func (c *Channel) Broadcast(broadcast method.Broadcast, socket socket.Socket) er
 	return nil
 }
 
-// Subscribe is used to handle a subscribe message from the client.
-func (c *Channel) Subscribe(socket socket.Socket, msg method.Subscribe) error {
-	c.log.Info().
-		Str(msgID, strconv.Itoa(msg.ID)).
-		Msg("received a subscribe")
-	c.sockets.Upsert(socket)
+// ---
+// Message handling
+// ---
 
-	return nil
+// NewGeneralChirpingRegistry creates a new registry for a general chirping
+// channel and populates the registry with the actions of the channel.
+func (c *Channel) NewGeneralChirpingRegistry() registry.MessageRegistry {
+	newRegistry := registry.NewMessageRegistry()
+
+	newRegistry.Register(messagedata.ChirpNotifyAdd{}, c.processAddChirp)
+	newRegistry.Register(messagedata.ChirpNotifyDelete{}, c.processDeleteChirp)
+
+	return newRegistry
 }
 
-// Unsubscribe is used to handle an unsubscribe message.
-func (c *Channel) Unsubscribe(socketID string, msg method.Unsubscribe) error {
-	c.log.Info().
-		Str(msgID, strconv.Itoa(msg.ID)).
-		Msg("received a unsubscribe")
-
-	ok := c.sockets.Delete(socketID)
+// processAddChirp checks an add chirp message
+func (c *Channel) processAddChirp(msg message.Message, msgData interface{}, _ socket.Socket) error {
+	data, ok := msgData.(*messagedata.ChirpNotifyAdd)
 	if !ok {
-		return answer.NewError(-2, "client is not subscribed to this channel")
+		return xerrors.Errorf("message %v isn't a chirp#notifyAdd message", msgData)
+	}
+
+	err := c.verifyNotifyChirp(msg, data)
+	if err != nil {
+		return xerrors.Errorf("failed to get and verify add chirp message: %v", err)
 	}
 
 	return nil
 }
 
-// Catchup is used to handle a catchup message.
-func (c *Channel) Catchup(msg method.Catchup) []message.Message {
-	c.log.Info().
-		Str(msgID, strconv.Itoa(msg.ID)).
-		Msg("received a catchup")
-	return c.inbox.GetSortedMessages()
+// processDeleteChirp checks a delete chirp message
+func (c *Channel) processDeleteChirp(msg message.Message, msgData interface{}, _ socket.Socket) error {
+	data, ok := msgData.(*messagedata.ChirpNotifyDelete)
+	if !ok {
+		return xerrors.Errorf("message %v isn't a chirp#notifyDelete message", msgData)
+	}
+
+	err := c.verifyNotifyChirp(msg, data)
+	if err != nil {
+		return xerrors.Errorf("failed to get and verify delete chirp message: %v", err)
+	}
+
+	return nil
+}
+
+// VerifyBroadcastMessage checks if a Broadcast message is valid
+func (c *Channel) VerifyBroadcastMessage(broadcast method.Broadcast) error {
+	c.log.Info().Msg("received broadcast")
+
+	// Check if the structure of the message is correct
+	msg := broadcast.Params.Message
+
+	jsonData, err := base64.URLEncoding.DecodeString(msg.Data)
+	if err != nil {
+		return xerrors.Errorf("failed to decode message data: %v", err)
+	}
+
+	// Verify the data
+	err = c.hub.GetSchemaValidator().VerifyJSON(jsonData, validation.Data)
+	if err != nil {
+		return xerrors.Errorf("failed to verify json schema: %w", err)
+	}
+
+	// Check if the message already exists
+	_, ok := c.inbox.GetMessage(msg.MessageID)
+	if ok {
+		return answer.NewError(-3, "message already exists")
+	}
+
+	return nil
+}
+
+func (c *Channel) verifyNotifyChirp(msg message.Message, chirpMsg messagedata.Verifiable) error {
+	err := chirpMsg.Verify()
+	if err != nil {
+		return xerrors.Errorf("invalid chirp broadcast message: %v", err)
+	}
+
+	senderBuf, err := base64.URLEncoding.DecodeString(msg.Sender)
+	if err != nil {
+		return xerrors.Errorf("failed to decode sender key: %v", err)
+	}
+
+	senderPoint := crypto.Suite.Point()
+	err = senderPoint.UnmarshalBinary(senderBuf)
+	if err != nil {
+		return answer.NewError(-4, "invalid sender public key")
+	}
+
+	ok := c.hub.GetPubKeyServ().Equal(senderPoint)
+	if !ok {
+		return answer.NewError(-4, "only the server can broadcast the chirp messages")
+	}
+
+	return nil
 }
 
 // broadcastToAllClients is a helper message to broadcast a message to all
@@ -159,88 +249,6 @@ func (c *Channel) broadcastToAllClients(msg message.Message) error {
 	}
 
 	c.sockets.SendToAll(buf)
-
-	return nil
-}
-
-// VerifyBroadcastMessage checks if a Broadcast message is valid
-func (c *Channel) VerifyBroadcastMessage(broadcast method.Broadcast) error {
-	c.log.Info().Msg("received broadcast")
-
-	// Check if the structure of the message is correct
-	msg := broadcast.Params.Message
-
-	jsonData, err := base64.URLEncoding.DecodeString(msg.Data)
-	if err != nil {
-		return xerrors.Errorf("failed to decode message data: %v", err)
-	}
-
-	// Verify the data
-	err = c.hub.GetSchemaValidator().VerifyJSON(jsonData, validation.Data)
-	if err != nil {
-		return xerrors.Errorf("failed to verify json schema: %w", err)
-	}
-
-	// Check if the message already exists
-	_, ok := c.inbox.GetMessage(msg.MessageID)
-	if ok {
-		return answer.NewError(-3, "message already exists")
-	}
-
-	return nil
-}
-
-// addChirp checks an add chirp message
-func (c *Channel) addChirp(msg message.Message, msgData interface{}, _ socket.Socket) error {
-	data, ok := msgData.(*messagedata.ChirpNotifyAdd)
-	if !ok {
-		return xerrors.Errorf("message %v isn't a chirp#notifyAdd message", msgData)
-	}
-
-	err := c.verifyNotifyChirp(msg, data)
-	if err != nil {
-		return xerrors.Errorf("failed to get and verify add chirp message: %v", err)
-	}
-
-	return nil
-}
-
-// deleteChirp checks a delete chirp message
-func (c *Channel) deleteChirp(msg message.Message, msgData interface{}, _ socket.Socket) error {
-	data, ok := msgData.(*messagedata.ChirpNotifyDelete)
-	if !ok {
-		return xerrors.Errorf("message %v isn't a chirp#notifyDelete message", msgData)
-	}
-
-	err := c.verifyNotifyChirp(msg, data)
-	if err != nil {
-		return xerrors.Errorf("failed to get and verify delete chirp message: %v", err)
-	}
-
-	return nil
-}
-
-func (c *Channel) verifyNotifyChirp(msg message.Message, chirpMsg messagedata.Verifiable) error {
-	err := chirpMsg.Verify()
-	if err != nil {
-		return xerrors.Errorf("invalid chirp broadcast message: %v", err)
-	}
-
-	senderBuf, err := base64.URLEncoding.DecodeString(msg.Sender)
-	if err != nil {
-		return xerrors.Errorf("failed to decode sender key: %v", err)
-	}
-
-	senderPoint := crypto.Suite.Point()
-	err = senderPoint.UnmarshalBinary(senderBuf)
-	if err != nil {
-		return answer.NewError(-4, "invalid sender public key")
-	}
-
-	ok := c.hub.GetPubKeyServ().Equal(senderPoint)
-	if !ok {
-		return answer.NewError(-4, "only the server can broadcast the chirp messages")
-	}
 
 	return nil
 }

--- a/be1-go/channel/generalChirping/mod.go
+++ b/be1-go/channel/generalChirping/mod.go
@@ -153,7 +153,9 @@ func (c *Channel) processAddChirp(msg message.Message, msgData interface{}, _ so
 }
 
 // processDeleteChirp checks a delete chirp message
-func (c *Channel) processDeleteChirp(msg message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processDeleteChirp(msg message.Message, msgData interface{},
+	_ socket.Socket) error {
+
 	data, ok := msgData.(*messagedata.ChirpNotifyDelete)
 	if !ok {
 		return xerrors.Errorf("message %v isn't a chirp#notifyDelete message", msgData)
@@ -222,7 +224,6 @@ func (c *Channel) verifyNotifyChirp(msg message.Message, chirpMsg messagedata.Ve
 // broadcastToAllClients is a helper message to broadcast a message to all
 // subscribers.
 func (c *Channel) broadcastToAllClients(msg message.Message) error {
-
 	c.log.Info().
 		Str(msgID, msg.MessageID).
 		Msg("broadcast new chirp to all clients")

--- a/be1-go/channel/lao/mod.go
+++ b/be1-go/channel/lao/mod.go
@@ -338,8 +338,8 @@ func (c *Channel) processRollCallCreate(msg message.Message, msgData interface{}
 
 	// Check that the ProposedEnd is greater than the ProposedStart
 	if data.ProposedStart > data.ProposedEnd {
-		return answer.NewErrorf(-4, "The field `proposed_start` is greater than the field"+
-			" `proposed_end`: %d > %d", data.ProposedStart, data.ProposedEnd)
+		return answer.NewErrorf(-4, "The field `proposed_start` is greater than the field "+
+			"`proposed_end`: %d > %d", data.ProposedStart, data.ProposedEnd)
 	}
 
 	c.rollCall.id = string(data.ID)
@@ -376,7 +376,7 @@ func (c *Channel) processRollCallOpen(msg message.Message, msgData interface{},
 	}
 
 	if !c.rollCall.checkPrevID([]byte(rollCallOpen.Opens)) {
-		return answer.NewError(-1, "The field `opens` does not correspond to the id of"+
+		return answer.NewError(-1, "The field `opens` does not correspond to the id of "+
 			"the previous roll call message")
 	}
 
@@ -406,7 +406,7 @@ func (c *Channel) processRollCallClose(msg message.Message, msgData interface{},
 	}
 
 	if !c.rollCall.checkPrevID([]byte(data.Closes)) {
-		return answer.NewError(-4, "The field `closes` does not correspond to the id of"+
+		return answer.NewError(-4, "The field `closes` does not correspond to the id of "+
 			"the previous roll call message")
 	}
 
@@ -609,7 +609,7 @@ func (c *Channel) createElection(msg message.Message,
 	// Check if the Lao ID of the message corresponds to the channel ID
 	channelID := c.channelID[6:]
 	if channelID != setupMsg.Lao {
-		return answer.NewErrorf(-4, "Lao ID of the message is %s, should be"+
+		return answer.NewErrorf(-4, "Lao ID of the message is %s, should be "+
 			"equal to the channel ID %s", setupMsg.Lao, channelID)
 	}
 
@@ -659,7 +659,7 @@ func compareLaoUpdateAndState(update messagedata.LaoUpdate, state messagedata.La
 	}
 
 	if match != M {
-		return answer.NewErrorf(-4, "mismatch between witness keys: expected %d keys to"+
+		return answer.NewErrorf(-4, "mismatch between witness keys: expected %d keys to "+
 			"match but %d matched", M, match)
 	}
 

--- a/be1-go/channel/lao/mod.go
+++ b/be1-go/channel/lao/mod.go
@@ -338,6 +338,7 @@ func (c *Channel) processRollCallCreate(msg message.Message, msgData interface{}
 
 	c.rollCall.id = string(data.ID)
 	c.rollCall.state = Created
+
 	return nil
 }
 
@@ -373,6 +374,7 @@ func (c *Channel) processRollCallOpen(msg message.Message, msgData interface{}, 
 
 	c.rollCall.id = rollCallOpen.UpdateID
 	c.rollCall.state = Open
+
 	return nil
 }
 
@@ -476,6 +478,7 @@ func (c *Channel) processElectionObject(msg message.Message, msgData interface{}
 	}
 
 	c.log.Info().Msg("election created with success")
+	
 	return nil
 }
 

--- a/be1-go/channel/lao/verification.go
+++ b/be1-go/channel/lao/verification.go
@@ -80,8 +80,8 @@ func (c *Channel) verifyMessageLaoState(laoState messagedata.LaoState) error {
 	for _, mod := range laoState.ModificationSignatures {
 		_, err := base64.URLEncoding.DecodeString(mod.Witness)
 		if err != nil {
-			return xerrors.Errorf("lao modification signature witness is %s,"+
-				" should be base64URL encoded", mod.Witness)
+			return xerrors.Errorf("lao modification signature witness is %s, "+
+				"should be base64URL encoded", mod.Witness)
 		}
 	}
 
@@ -159,7 +159,7 @@ func (c *Channel) verifyMessageRollCallOpen(rollCallOpen messagedata.RollCallOpe
 	// verify update id is base64URL encoded
 	_, err := base64.URLEncoding.DecodeString(rollCallOpen.UpdateID)
 	if err != nil {
-		return xerrors.Errorf("roll call update id is %s, "+"should be base64URL encoded",
+		return xerrors.Errorf("roll call update id is %s, should be base64URL encoded",
 			rollCallOpen.UpdateID)
 	}
 

--- a/be1-go/channel/lao/verification.go
+++ b/be1-go/channel/lao/verification.go
@@ -2,10 +2,11 @@ package lao
 
 import (
 	"encoding/base64"
-	"golang.org/x/xerrors"
 	"popstellar/message/messagedata"
 	"strconv"
 	"strings"
+
+	"golang.org/x/xerrors"
 )
 
 // rollCallFlag for the RollCall ID
@@ -231,9 +232,9 @@ func (c *Channel) verifyMessageElectionSetup(electionSetup messagedata.ElectionS
 	}
 
 	// verify lao id is channel's lao id
-	laoId := strings.ReplaceAll(c.channelID, messagedata.RootPrefix, "")
-	if electionSetup.Lao != laoId {
-		return xerrors.Errorf("lao id is %s, should be %s", electionSetup.Lao, laoId)
+	laoID := strings.ReplaceAll(c.channelID, messagedata.RootPrefix, "")
+	if electionSetup.Lao != laoID {
+		return xerrors.Errorf("lao id is %s, should be %s", electionSetup.Lao, laoID)
 	}
 
 	// verify election id is base64URL encoded
@@ -245,7 +246,7 @@ func (c *Channel) verifyMessageElectionSetup(electionSetup messagedata.ElectionS
 	// verify election setup message id
 	expectedID := messagedata.Hash(
 		electionFlag,
-		laoId,
+		laoID,
 		strconv.Itoa(int(electionSetup.CreatedAt)),
 		electionSetup.Name,
 	)

--- a/be1-go/channel/lao/verification.go
+++ b/be1-go/channel/lao/verification.go
@@ -72,14 +72,16 @@ func (c *Channel) verifyMessageLaoState(laoState messagedata.LaoState) error {
 	// verify modification id is base64URL encoded
 	_, err = base64.URLEncoding.DecodeString(laoState.ModificationID)
 	if err != nil {
-		return xerrors.Errorf("lao modification id is %s, should be base64URL encoded", laoState.ModificationID)
+		return xerrors.Errorf("lao modification id is %s, should be base64URL encoded",
+			laoState.ModificationID)
 	}
 
 	// verify all witnesses in modification signatures are base64URL encoded
 	for _, mod := range laoState.ModificationSignatures {
 		_, err := base64.URLEncoding.DecodeString(mod.Witness)
 		if err != nil {
-			return xerrors.Errorf("lao modification signature witness is %s, should be base64URL encoded", mod.Witness)
+			return xerrors.Errorf("lao modification signature witness is %s,"+
+				" should be base64URL encoded", mod.Witness)
 		}
 	}
 
@@ -109,34 +111,40 @@ func (c *Channel) verifyMessageRollCallCreate(rollCallCreate *messagedata.RollCa
 
 	// verify creation is positive
 	if rollCallCreate.Creation < 0 {
-		return xerrors.Errorf("roll call creation is %d, should be minimum 0", rollCallCreate.Creation)
+		return xerrors.Errorf("roll call creation is %d, should be minimum 0",
+			rollCallCreate.Creation)
 	}
 
 	// verify proposed start is positive
 	if rollCallCreate.ProposedStart < 0 {
-		return xerrors.Errorf("roll call proposed start is %d, should be minimum 0", rollCallCreate.ProposedStart)
+		return xerrors.Errorf("roll call proposed start is %d, should be minimum 0",
+			rollCallCreate.ProposedStart)
 	}
 
 	// verify proposed end is positive
 	if rollCallCreate.ProposedEnd < 0 {
-		return xerrors.Errorf("roll call proposed end is %d, should be minimum 0", rollCallCreate.ProposedEnd)
+		return xerrors.Errorf("roll call proposed end is %d, should be minimum 0",
+			rollCallCreate.ProposedEnd)
 	}
 
 	// verify proposed start after creation
 	if rollCallCreate.ProposedStart < rollCallCreate.Creation {
-		return xerrors.Errorf("roll call proposed start is %d, should be greater or equal to creation %d",
+		return xerrors.Errorf("roll call proposed start is %d, "+
+			"should be greater or equal to creation %d",
 			rollCallCreate.ProposedStart, rollCallCreate.Creation)
 	}
 
 	// verify proposed end after creation
 	if rollCallCreate.ProposedEnd < rollCallCreate.Creation {
-		return xerrors.Errorf("roll call proposed end is %d, should be greater or equal to creation %d",
+		return xerrors.Errorf("roll call proposed end is %d, "+
+			"should be greater or equal to creation %d",
 			rollCallCreate.ProposedEnd, rollCallCreate.Creation)
 	}
 
 	// verify proposed end after proposed start
 	if rollCallCreate.ProposedEnd < rollCallCreate.ProposedStart {
-		return xerrors.Errorf("roll call proposed end is %d, should be greater or equal to proposed start %d",
+		return xerrors.Errorf("roll call proposed end is %d, "+
+			"should be greater or equal to proposed start %d",
 			rollCallCreate.ProposedEnd, rollCallCreate.ProposedStart)
 	}
 
@@ -145,12 +153,14 @@ func (c *Channel) verifyMessageRollCallCreate(rollCallCreate *messagedata.RollCa
 
 // verifyMessageRollCallOpen checks the roll_call#open message data is valid.
 func (c *Channel) verifyMessageRollCallOpen(rollCallOpen messagedata.RollCallOpen) error {
-	c.log.Info().Msgf("verifying roll_call#open message of roll call with update id %s", rollCallOpen.UpdateID)
+	c.log.Info().Msgf("verifying roll_call#open message of "+
+		"roll call with update id %s", rollCallOpen.UpdateID)
 
 	// verify update id is base64URL encoded
 	_, err := base64.URLEncoding.DecodeString(rollCallOpen.UpdateID)
 	if err != nil {
-		return xerrors.Errorf("roll call update id is %s, should be base64URL encoded", rollCallOpen.UpdateID)
+		return xerrors.Errorf("roll call update id is %s, "+"should be base64URL encoded",
+			rollCallOpen.UpdateID)
 	}
 
 	// verify roll call open message update id
@@ -161,18 +171,21 @@ func (c *Channel) verifyMessageRollCallOpen(rollCallOpen messagedata.RollCallOpe
 		strconv.Itoa(int(rollCallOpen.OpenedAt)),
 	)
 	if rollCallOpen.UpdateID != expectedID {
-		return xerrors.Errorf("roll call update id is %s, should be %s", rollCallOpen.UpdateID, expectedID)
+		return xerrors.Errorf("roll call update id is %s, should be %s",
+			rollCallOpen.UpdateID, expectedID)
 	}
 
 	// verify opens is base64URL encoded
 	_, err = base64.URLEncoding.DecodeString(rollCallOpen.Opens)
 	if err != nil {
-		return xerrors.Errorf("roll call opens is %s, should be base64URL encoded", rollCallOpen.Opens)
+		return xerrors.Errorf("roll call opens is %s, should be base64URL encoded",
+			rollCallOpen.Opens)
 	}
 
 	// verify opened at is positive
 	if rollCallOpen.OpenedAt < 0 {
-		return xerrors.Errorf("roll call opened at is %d, should be minimum 0", rollCallOpen.OpenedAt)
+		return xerrors.Errorf("roll call opened at is %d, should be minimum 0",
+			rollCallOpen.OpenedAt)
 	}
 
 	return nil
@@ -181,12 +194,14 @@ func (c *Channel) verifyMessageRollCallOpen(rollCallOpen messagedata.RollCallOpe
 //TODO modif Noemien ??
 // verifyMessageRollCallClose checks the roll_call#close message data is valid.
 func (c *Channel) verifyMessageRollCallClose(rollCallClose *messagedata.RollCallClose) error {
-	c.log.Info().Msgf("verifying roll_call#close message of roll call with update id %s", rollCallClose.UpdateID)
+	c.log.Info().Msgf("verifying roll_call#close message of roll call with update id %s",
+		rollCallClose.UpdateID)
 
 	// verify update id is base64URL encoded
 	_, err := base64.URLEncoding.DecodeString(rollCallClose.UpdateID)
 	if err != nil {
-		return xerrors.Errorf("roll call update id is %s, should be base64URL encoded", rollCallClose.UpdateID)
+		return xerrors.Errorf("roll call update id is %s, should be base64URL encoded",
+			rollCallClose.UpdateID)
 	}
 
 	// verify roll call close message update id
@@ -197,25 +212,29 @@ func (c *Channel) verifyMessageRollCallClose(rollCallClose *messagedata.RollCall
 		strconv.Itoa(int(rollCallClose.ClosedAt)),
 	)
 	if rollCallClose.UpdateID != expectedID {
-		return xerrors.Errorf("roll call update id is %s, should be %s", rollCallClose.UpdateID, expectedID)
+		return xerrors.Errorf("roll call update id is %s, should be %s",
+			rollCallClose.UpdateID, expectedID)
 	}
 
 	// verify closes is base64URL encoded
 	_, err = base64.URLEncoding.DecodeString(rollCallClose.Closes)
 	if err != nil {
-		return xerrors.Errorf("roll call closes is %s, should be base64URL encoded", rollCallClose.Closes)
+		return xerrors.Errorf("roll call closes is %s, should be base64URL encoded",
+			rollCallClose.Closes)
 	}
 
 	// verify closed at is positive
 	if rollCallClose.ClosedAt < 0 {
-		return xerrors.Errorf("roll call closed at is %d, should be minimum 0", rollCallClose.ClosedAt)
+		return xerrors.Errorf("roll call closed at is %d, should be minimum 0",
+			rollCallClose.ClosedAt)
 	}
 
 	// verify all attendees are base64URL encoded
 	for _, attendee := range rollCallClose.Attendees {
 		_, err := base64.URLEncoding.DecodeString(attendee)
 		if err != nil {
-			return xerrors.Errorf("roll call attendee is %s, should be base64URL encoded", attendee)
+			return xerrors.Errorf("roll call attendee is %s, should be base64URL encoded",
+				attendee)
 		}
 	}
 
@@ -261,34 +280,40 @@ func (c *Channel) verifyMessageElectionSetup(electionSetup messagedata.ElectionS
 
 	// verify created at is positive
 	if electionSetup.CreatedAt < 0 {
-		return xerrors.Errorf("election setup created at is %d, should be minimum 0", electionSetup.CreatedAt)
+		return xerrors.Errorf("election setup created at is %d, should be minimum 0",
+			electionSetup.CreatedAt)
 	}
 
 	// verify start time is positive
 	if electionSetup.StartTime < 0 {
-		return xerrors.Errorf("election setup start time is %d, should be minimum 0", electionSetup.StartTime)
+		return xerrors.Errorf("election setup start time is %d, should be minimum 0",
+			electionSetup.StartTime)
 	}
 
 	// verify end time is positive
 	if electionSetup.EndTime < 0 {
-		return xerrors.Errorf("election setup end time is %d, should be minimum 0", electionSetup.EndTime)
+		return xerrors.Errorf("election setup end time is %d, should be minimum 0",
+			electionSetup.EndTime)
 	}
 
 	// verify start time after created at
 	if electionSetup.StartTime < electionSetup.CreatedAt {
-		return xerrors.Errorf("election setup start time is %d, should be greater or equal to created at %d",
+		return xerrors.Errorf("election setup start time is %d, "+
+			"should be greater or equal to created at %d",
 			electionSetup.StartTime, electionSetup.CreatedAt)
 	}
 
 	// verify end time after created at
 	if electionSetup.EndTime < electionSetup.CreatedAt {
-		return xerrors.Errorf("election setup end time is %d, should be greater or equal to created at %d",
+		return xerrors.Errorf("election setup end time is %d, "+
+			"should be greater or equal to created at %d",
 			electionSetup.EndTime, electionSetup.CreatedAt)
 	}
 
 	// verify end time after start time
 	if electionSetup.EndTime < electionSetup.StartTime {
-		return xerrors.Errorf("election end time is %d, should be greater or equal to start time %d",
+		return xerrors.Errorf("election end time is %d, "+
+			"should be greater or equal to start time %d",
 			electionSetup.EndTime, electionSetup.StartTime)
 	}
 
@@ -304,7 +329,9 @@ func (c *Channel) verifyMessageElectionSetup(electionSetup messagedata.ElectionS
 }
 
 // verifyElectionSetupQuestion checks the question of an election setup message is valid.
-func verifyElectionSetupQuestion(question messagedata.ElectionSetupQuestion, electionID string) error {
+func verifyElectionSetupQuestion(question messagedata.ElectionSetupQuestion,
+	electionID string) error {
+
 	// verify question id is base64URL encoded
 	_, err := base64.URLEncoding.DecodeString(question.ID)
 	if err != nil {
@@ -328,7 +355,8 @@ func verifyElectionSetupQuestion(question messagedata.ElectionSetupQuestion, ele
 
 	// verify voting method
 	if question.VotingMethod != "Plurality" && question.VotingMethod != "Approval" {
-		return xerrors.Errorf("voting method is %s, should be either Plurality or Approval", question.VotingMethod)
+		return xerrors.Errorf("voting method is %s, should be either Plurality or Approval",
+			question.VotingMethod)
 	}
 
 	return nil

--- a/be1-go/channel/mod.go
+++ b/be1-go/channel/mod.go
@@ -86,7 +86,7 @@ func (s *Sockets) Delete(ID string) bool {
 	}
 
 	delete(s.store, ID)
-	
+
 	return true
 }
 

--- a/be1-go/channel/mod.go
+++ b/be1-go/channel/mod.go
@@ -86,6 +86,7 @@ func (s *Sockets) Delete(ID string) bool {
 	}
 
 	delete(s.store, ID)
+	
 	return true
 }
 

--- a/be1-go/channel/reaction/mod.go
+++ b/be1-go/channel/reaction/mod.go
@@ -142,7 +142,6 @@ func (c *Channel) Broadcast(broadcast method.Broadcast, socket socket.Socket) er
 
 // handleMessage handles a message received in a broadcast or publish method
 func (c *Channel) handleMessage(msg message.Message, socket socket.Socket) error {
-
 	err := c.registry.Process(msg, socket)
 	if err != nil {
 		return xerrors.Errorf("failed to process message: %w", err)
@@ -169,7 +168,9 @@ func (c *Channel) NewReactionRegistry() registry.MessageRegistry {
 }
 
 // processReactionAdd is the callback that processes reaction#add messages
-func (c *Channel) processReactionAdd(msg message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processReactionAdd(msg message.Message, msgData interface{},
+	_ socket.Socket) error {
+
 	err := c.verifyAddReactionMessage(msg)
 	if err != nil {
 		return xerrors.Errorf("failed to verify add reaction message: %v", err)
@@ -179,7 +180,9 @@ func (c *Channel) processReactionAdd(msg message.Message, msgData interface{}, _
 }
 
 // processReactionDelete is the callback that processes reaction#delete messages
-func (c *Channel) processReactionDelete(msg message.Message, msgData interface{}, _ socket.Socket) error {
+func (c *Channel) processReactionDelete(msg message.Message, msgData interface{},
+	_ socket.Socket) error {
+
 	err := c.verifyDeleteReactionMessage(msg)
 	if err != nil {
 		return xerrors.Errorf("failed to verify delete reaction message: %v", err)
@@ -190,7 +193,6 @@ func (c *Channel) processReactionDelete(msg message.Message, msgData interface{}
 
 // verifyMessage checks if a message in a Publish or Broadcast method is valid
 func (c *Channel) verifyMessage(msg message.Message) error {
-
 	jsonData, err := base64.URLEncoding.DecodeString(msg.Data)
 	if err != nil {
 		return xerrors.Errorf(failedToDecodeData, err)
@@ -336,6 +338,7 @@ func (a *attendees) isPresent(key string) bool {
 	defer a.Unlock()
 
 	_, ok := a.store[key]
+
 	return ok
 }
 

--- a/be1-go/channel/reaction/mod.go
+++ b/be1-go/channel/reaction/mod.go
@@ -22,8 +22,25 @@ import (
 	"golang.org/x/xerrors"
 )
 
-const msgID = "msg id"
-const failedToDecodeData = "failed to decode message data: %v"
+const (
+	msgID              = "msg id"
+	failedToDecodeData = "failed to decode message data: %v"
+)
+
+// Channel is used to handle reaction messages.
+type Channel struct {
+	sockets   channel.Sockets
+	inbox     *inbox.Inbox
+	attendees *attendees
+
+	// channel path
+	channelID string
+
+	hub channel.HubFunctionalities
+	log zerolog.Logger
+
+	registry registry.MessageRegistry
+}
 
 // NewChannel returns a new initialized reaction channel
 func NewChannel(channelPath string, hub channel.HubFunctionalities, log zerolog.Logger) *Channel {
@@ -43,50 +60,9 @@ func NewChannel(channelPath string, hub channel.HubFunctionalities, log zerolog.
 	return newChannel
 }
 
-// NewReactionRegistry creates a new registry for the consensus channel
-func (c *Channel) NewReactionRegistry() registry.MessageRegistry {
-	registry := registry.NewMessageRegistry()
-
-	registry.Register(messagedata.ReactionAdd{}, c.processReactionAdd)
-	registry.Register(messagedata.ReactionDelete{}, c.processReactionDelete)
-
-	return registry
-}
-
-// Channel is used to handle reaction messages.
-type Channel struct {
-	sockets   channel.Sockets
-	inbox     *inbox.Inbox
-	attendees *attendees
-
-	// channel path
-	channelID string
-
-	hub channel.HubFunctionalities
-	log zerolog.Logger
-
-	registry registry.MessageRegistry
-}
-
-// Publish is used to handle publish messages in the reaction channel.
-func (c *Channel) Publish(publish method.Publish, socket socket.Socket) error {
-	c.log.Info().
-		Str(msgID, strconv.Itoa(publish.ID)).
-		Msg("received a publish")
-
-	err := c.verifyMessage(publish.Params.Message)
-	if err != nil {
-		return xerrors.Errorf("failed to verify publish message on a "+
-			"reaction channel: %w", err)
-	}
-
-	err = c.handleMessage(publish.Params.Message, socket)
-	if err != nil {
-		return xerrors.Errorf("failed to handle publish message: %v", err)
-	}
-
-	return nil
-}
+// ---
+// Publish-subscribe / channel.Channel implementation
+// ---
 
 // Subscribe is used to handle a subscribe message from the client.
 func (c *Channel) Subscribe(socket socket.Socket, msg method.Subscribe) error {
@@ -108,6 +84,26 @@ func (c *Channel) Unsubscribe(socketID string, msg method.Unsubscribe) error {
 
 	if !ok {
 		return answer.NewError(-2, "client is not subscribed to this channel")
+	}
+
+	return nil
+}
+
+// Publish is used to handle publish messages in the reaction channel.
+func (c *Channel) Publish(publish method.Publish, socket socket.Socket) error {
+	c.log.Info().
+		Str(msgID, strconv.Itoa(publish.ID)).
+		Msg("received a publish")
+
+	err := c.verifyMessage(publish.Params.Message)
+	if err != nil {
+		return xerrors.Errorf("failed to verify publish message on a "+
+			"reaction channel: %w", err)
+	}
+
+	err = c.handleMessage(publish.Params.Message, socket)
+	if err != nil {
+		return xerrors.Errorf("failed to handle publish message: %v", err)
 	}
 
 	return nil
@@ -140,6 +136,10 @@ func (c *Channel) Broadcast(broadcast method.Broadcast, socket socket.Socket) er
 	return nil
 }
 
+// ---
+// Message handling
+// ---
+
 // handleMessage handles a message received in a broadcast or publish method
 func (c *Channel) handleMessage(msg message.Message, socket socket.Socket) error {
 
@@ -158,31 +158,32 @@ func (c *Channel) handleMessage(msg message.Message, socket socket.Socket) error
 	return nil
 }
 
-// broadcastToAllClients is a helper message to broadcast a message to all
-// subscribers.
-func (c *Channel) broadcastToAllClients(msg message.Message) error {
-	rpcMessage := method.Broadcast{
-		Base: query.Base{
-			JSONRPCBase: jsonrpc.JSONRPCBase{
-				JSONRPC: "2.0",
-			},
-			Method: query.MethodBroadcast,
-		},
-		Params: struct {
-			Channel string          `json:"channel"`
-			Message message.Message `json:"message"`
-		}{
-			c.channelID,
-			msg,
-		},
-	}
+// NewReactionRegistry creates a new registry for the consensus channel
+func (c *Channel) NewReactionRegistry() registry.MessageRegistry {
+	registry := registry.NewMessageRegistry()
 
-	buf, err := json.Marshal(&rpcMessage)
+	registry.Register(messagedata.ReactionAdd{}, c.processReactionAdd)
+	registry.Register(messagedata.ReactionDelete{}, c.processReactionDelete)
+
+	return registry
+}
+
+// processReactionAdd is the callback that processes reaction#add messages
+func (c *Channel) processReactionAdd(msg message.Message, msgData interface{}, _ socket.Socket) error {
+	err := c.verifyAddReactionMessage(msg)
 	if err != nil {
-		return xerrors.Errorf("failed to marshal broadcast: %v", err)
+		return xerrors.Errorf("failed to verify add reaction message: %v", err)
 	}
 
-	c.sockets.SendToAll(buf)
+	return nil
+}
+
+// processReactionDelete is the callback that processes reaction#delete messages
+func (c *Channel) processReactionDelete(msg message.Message, msgData interface{}, _ socket.Socket) error {
+	err := c.verifyDeleteReactionMessage(msg)
+	if err != nil {
+		return xerrors.Errorf("failed to verify delete reaction message: %v", err)
+	}
 
 	return nil
 }
@@ -205,26 +206,6 @@ func (c *Channel) verifyMessage(msg message.Message) error {
 	_, ok := c.inbox.GetMessage(msg.MessageID)
 	if ok {
 		return answer.NewError(-3, "message already exists")
-	}
-
-	return nil
-}
-
-// processReactionAdd is the callback that processes reaction#add messages
-func (c *Channel) processReactionAdd(msg message.Message, msgData interface{}, _ socket.Socket) error {
-	err := c.verifyAddReactionMessage(msg)
-	if err != nil {
-		return xerrors.Errorf("failed to verify add reaction message: %v", err)
-	}
-
-	return nil
-}
-
-// processReactionDelete is the callback that processes reaction#delete messages
-func (c *Channel) processReactionDelete(msg message.Message, msgData interface{}, _ socket.Socket) error {
-	err := c.verifyDeleteReactionMessage(msg)
-	if err != nil {
-		return xerrors.Errorf("failed to verify delete reaction message: %v", err)
 	}
 
 	return nil
@@ -296,6 +277,39 @@ func (c *Channel) verifyDeleteReactionMessage(msg message.Message) error {
 
 	return nil
 }
+
+// broadcastToAllClients is a helper message to broadcast a message to all
+// subscribers.
+func (c *Channel) broadcastToAllClients(msg message.Message) error {
+	rpcMessage := method.Broadcast{
+		Base: query.Base{
+			JSONRPCBase: jsonrpc.JSONRPCBase{
+				JSONRPC: "2.0",
+			},
+			Method: query.MethodBroadcast,
+		},
+		Params: struct {
+			Channel string          `json:"channel"`
+			Message message.Message `json:"message"`
+		}{
+			c.channelID,
+			msg,
+		},
+	}
+
+	buf, err := json.Marshal(&rpcMessage)
+	if err != nil {
+		return xerrors.Errorf("failed to marshal broadcast: %v", err)
+	}
+
+	c.sockets.SendToAll(buf)
+
+	return nil
+}
+
+// ---
+// Others
+// ---
 
 // AddAttendee adds an attendee to the reaction channel.
 func (c *Channel) AddAttendee(key string) {

--- a/be1-go/channel/registry/mod.go
+++ b/be1-go/channel/registry/mod.go
@@ -44,7 +44,9 @@ func NewMessageRegistry() MessageRegistry {
 //   // when we need to process a message we call "processMsg"
 //   err = registry.processMsg(msg)
 //
-func (m MessageRegistry) Register(msg messagedata.MessageData, f func(message.Message, interface{}, socket.Socket) error) {
+func (m MessageRegistry) Register(msg messagedata.MessageData, f func(message.Message,
+	interface{}, socket.Socket) error) {
+
 	m.registry[msg.GetObject()+"#"+msg.GetAction()] = CallbackData{
 		Callback:     f,
 		ConcreteType: msg,

--- a/be1-go/cli/mod.go
+++ b/be1-go/cli/mod.go
@@ -5,7 +5,6 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/gorilla/websocket"
 	"net/url"
 	be1_go "popstellar"
 	"popstellar/channel/lao"
@@ -16,6 +15,8 @@ import (
 	"popstellar/network/socket"
 	"sync"
 	"time"
+
+	"github.com/gorilla/websocket"
 
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"

--- a/be1-go/cli/mod.go
+++ b/be1-go/cli/mod.go
@@ -65,7 +65,8 @@ func Serve(cliCtx *cli.Context, user string) error {
 	var hubType = hub.HubType(user)
 
 	// create user hub
-	h, err := standard_hub.NewHub(point, log.With().Str("role", user).Logger(), lao.NewChannel, hubType)
+	h, err := standard_hub.NewHub(point, log.With().Str("role", user).Logger(),
+		lao.NewChannel, hubType)
 	if err != nil {
 		return xerrors.Errorf("failed create the %s hub: %v", user, err)
 	}
@@ -136,7 +137,9 @@ func Serve(cliCtx *cli.Context, user string) error {
 
 // connectToSocket establishes a connection to another server's witness
 // endpoint.
-func connectToSocket(otherHubType hub.HubType, address string, h hub.Hub, wg *sync.WaitGroup, done chan struct{}) error {
+func connectToSocket(otherHubType hub.HubType, address string, h hub.Hub,
+	wg *sync.WaitGroup, done chan struct{}) error {
+
 	log := be1_go.Logger
 
 	urlString := fmt.Sprintf("ws://%s/%s/witness", address, otherHubType)

--- a/be1-go/cli/pop.go
+++ b/be1-go/cli/pop.go
@@ -22,9 +22,10 @@ package main
 
 import (
 	"context"
-	"github.com/urfave/cli/v2"
 	"log"
 	"os"
+
+	"github.com/urfave/cli/v2"
 )
 
 func main() {

--- a/be1-go/hub/standard_hub/message_handling.go
+++ b/be1-go/hub/standard_hub/message_handling.go
@@ -271,12 +271,12 @@ func (h *Hub) handlePublish(socket socket.Socket, byteMessage []byte) (int, erro
 	}
 
 	signature := publish.Params.Message.Signature
-	messageId := publish.Params.Message.MessageID
+	messageID := publish.Params.Message.MessageID
 	data := publish.Params.Message.Data
 
-	expectedMessageId := messagedata.Hash(data, signature)
-	if expectedMessageId != messageId {
-		return publish.ID, xerrors.Errorf("message_id is wrong: expected %q found %q", expectedMessageId, messageId)
+	expectedMessageID := messagedata.Hash(data, signature)
+	if expectedMessageID != messageID {
+		return publish.ID, xerrors.Errorf("message_id is wrong: expected %q found %q", expectedMessageID, messageID)
 	}
 
 	alreadyReceived, err := h.broadcastToServers(publish.Params.Message, publish.Params.Channel)
@@ -319,12 +319,12 @@ func (h *Hub) handleBroadcast(socket socket.Socket, byteMessage []byte) error {
 	}
 
 	signature := broadcast.Params.Message.Signature
-	messageId := broadcast.Params.Message.MessageID
+	messageID := broadcast.Params.Message.MessageID
 	data := broadcast.Params.Message.Data
 
-	expectedMessageId := messagedata.Hash(data, signature)
-	if expectedMessageId != messageId {
-		return xerrors.Errorf("message_id is wrong: expected %q found %q", expectedMessageId, messageId)
+	expectedMessageID := messagedata.Hash(data, signature)
+	if expectedMessageID != messageID {
+		return xerrors.Errorf("message_id is wrong: expected %q found %q", expectedMessageID, messageID)
 	}
 
 	h.Lock()

--- a/be1-go/hub/standard_hub/message_handling.go
+++ b/be1-go/hub/standard_hub/message_handling.go
@@ -152,6 +152,7 @@ func (h *Hub) handleRootCatchup(senderSocket socket.Socket, byteMessage []byte) 
 	}
 
 	messages := h.rootInbox.GetSortedMessages()
+	
 	return messages, catchup.ID, nil
 }
 

--- a/be1-go/hub/standard_hub/message_handling.go
+++ b/be1-go/hub/standard_hub/message_handling.go
@@ -44,7 +44,8 @@ func (h *Hub) handleRootChannelPublishMesssage(sock socket.Socket, publish metho
 
 	// must be "lao#create"
 	if object != messagedata.LAOObject || action != messagedata.LAOActionCreate {
-		err := answer.NewErrorf(publish.ID, "only lao#create is allowed on root, but found %s#%s", object, action)
+		err := answer.NewErrorf(publish.ID, "only lao#create is allowed on root, "+
+			"but found %s#%s", object, action)
 		sock.SendError(&publish.ID, err)
 		return err
 	}
@@ -77,7 +78,9 @@ func (h *Hub) handleRootChannelPublishMesssage(sock socket.Socket, publish metho
 }
 
 // handleRootChannelPublishMesssage handles an incominxg publish message on the root channel.
-func (h *Hub) handleRootChannelBroadcastMesssage(sock socket.Socket, broadcast method.Broadcast) error {
+func (h *Hub) handleRootChannelBroadcastMesssage(sock socket.Socket,
+	broadcast method.Broadcast) error {
+
 	id := -1
 
 	jsonData, err := base64.URLEncoding.DecodeString(broadcast.Params.Message.Data)
@@ -105,7 +108,8 @@ func (h *Hub) handleRootChannelBroadcastMesssage(sock socket.Socket, broadcast m
 
 	// must be "lao#create"
 	if object != messagedata.LAOObject || action != messagedata.LAOActionCreate {
-		err := answer.NewErrorf(id, "only lao#create is allowed on root, but found %s#%s", object, action)
+		err := answer.NewErrorf(id, "only lao#create is allowed on root, but found %s#%s",
+			object, action)
 		sock.SendError(&id, err)
 		return err
 	}
@@ -139,7 +143,9 @@ func (h *Hub) handleRootChannelBroadcastMesssage(sock socket.Socket, broadcast m
 }
 
 // handleRootCatchup handles an incoming catchup message on the root channel
-func (h *Hub) handleRootCatchup(senderSocket socket.Socket, byteMessage []byte) ([]message.Message, int, error) {
+func (h *Hub) handleRootCatchup(senderSocket socket.Socket,
+	byteMessage []byte) ([]message.Message, int, error) {
+
 	var catchup method.Catchup
 
 	err := json.Unmarshal(byteMessage, &catchup)
@@ -148,11 +154,12 @@ func (h *Hub) handleRootCatchup(senderSocket socket.Socket, byteMessage []byte) 
 	}
 
 	if catchup.Params.Channel != rootChannel {
-		return nil, catchup.ID, xerrors.Errorf("server catchup message can only be sent on /root channel")
+		return nil, catchup.ID, xerrors.Errorf("server catchup message can only " +
+			"be sent on /root channel")
 	}
 
 	messages := h.rootInbox.GetSortedMessages()
-	
+
 	return messages, catchup.ID, nil
 }
 
@@ -232,7 +239,6 @@ func (h *Hub) handleAnswer(senderSocket socket.Socket, byteMessage []byte) error
 
 // handleDuringCatchup handle a message obtained by the server catching up
 func (h *Hub) handleDuringCatchup(socket socket.Socket, publish method.Publish) error {
-
 	h.Lock()
 	_, stored := h.hubInbox.GetMessage(publish.Params.Message.MessageID)
 	if stored {
@@ -277,7 +283,8 @@ func (h *Hub) handlePublish(socket socket.Socket, byteMessage []byte) (int, erro
 
 	expectedMessageID := messagedata.Hash(data, signature)
 	if expectedMessageID != messageID {
-		return publish.ID, xerrors.Errorf("message_id is wrong: expected %q found %q", expectedMessageID, messageID)
+		return publish.ID, xerrors.Errorf("message_id is wrong: expected %q found %q",
+			expectedMessageID, messageID)
 	}
 
 	alreadyReceived, err := h.broadcastToServers(publish.Params.Message, publish.Params.Channel)
@@ -325,7 +332,8 @@ func (h *Hub) handleBroadcast(socket socket.Socket, byteMessage []byte) error {
 
 	expectedMessageID := messagedata.Hash(data, signature)
 	if expectedMessageID != messageID {
-		return xerrors.Errorf("message_id is wrong: expected %q found %q", expectedMessageID, messageID)
+		return xerrors.Errorf("message_id is wrong: expected %q found %q",
+			expectedMessageID, messageID)
 	}
 
 	h.Lock()
@@ -404,7 +412,9 @@ func (h *Hub) handleUnsubscribe(socket socket.Socket, byteMessage []byte) (int, 
 	return unsubscribe.ID, nil
 }
 
-func (h *Hub) handleCatchup(socket socket.Socket, byteMessage []byte) ([]message.Message, int, error) {
+func (h *Hub) handleCatchup(socket socket.Socket,
+	byteMessage []byte) ([]message.Message, int, error) {
+
 	var catchup method.Catchup
 
 	err := json.Unmarshal(byteMessage, &catchup)

--- a/be1-go/hub/standard_hub/mod.go
+++ b/be1-go/hub/standard_hub/mod.go
@@ -243,6 +243,7 @@ func (h *Hub) Receiver() chan<- socket.IncomingMessage {
 // catchup from the new server
 func (h *Hub) NotifyNewServer(socket socket.Socket) error {
 	h.serverSockets.Upsert(socket)
+
 	err := h.catchupToServer(socket, rootChannel)
 	return err
 }
@@ -286,6 +287,7 @@ func (h *Hub) catchupToServer(socket socket.Socket, channel string) error {
 	}
 
 	socket.Send(buf)
+
 	return nil
 }
 
@@ -376,6 +378,7 @@ func (h *Hub) handleMessageFromClient(incomingMessage *socket.IncomingMessage) e
 	}
 
 	socket.SendResult(id, nil)
+
 	return nil
 }
 
@@ -459,6 +462,7 @@ func (h *Hub) handleMessageFromServer(incomingMessage *socket.IncomingMessage) e
 	}
 
 	socket.SendResult(id, nil)
+
 	return nil
 }
 
@@ -574,6 +578,7 @@ func (h *Hub) Sign(data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("failed to sign the data: %v", err)
 	}
+	
 	return signatureBuf, nil
 }
 

--- a/be1-go/hub/standard_hub/mod.go
+++ b/be1-go/hub/standard_hub/mod.go
@@ -546,7 +546,8 @@ func (h *Hub) createLao(msg message.Message, laoCreate messagedata.LaoCreate,
 	}
 
 	if !h.GetPubKeyOwner().Equal(senderPubKey) {
-		return answer.NewErrorf(-5, "sender's public key does not match the organizer's: %q != %q", senderPubKey, h.GetPubKeyOwner())
+		return answer.NewErrorf(-5, "sender's public key does not match the organizer's: %q != %q",
+			senderPubKey, h.GetPubKeyOwner())
 	}
 
 	laoCh := h.laoFac(laoChannelPath, h, msg, h.log, senderPubKey, socket)
@@ -578,7 +579,7 @@ func (h *Hub) Sign(data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("failed to sign the data: %v", err)
 	}
-	
+
 	return signatureBuf, nil
 }
 

--- a/be1-go/hub/standard_hub/mod_test.go
+++ b/be1-go/hub/standard_hub/mod_test.go
@@ -203,8 +203,8 @@ func Test_Create_LAO_Bad_MessageID(t *testing.T) {
 		Message: publishBuf,
 	})
 
-	expectedMessageId := messagedata.Hash(dataBase64, signatureBase64)
-	require.EqualError(t, sock.err, fmt.Sprintf("failed to handle method: message_id is wrong: expected %q found %q", expectedMessageId, badMessageID))
+	expectedMessageID := messagedata.Hash(dataBase64, signatureBase64)
+	require.EqualError(t, sock.err, fmt.Sprintf("failed to handle method: message_id is wrong: expected %q found %q", expectedMessageID, badMessageID))
 }
 
 func Test_Create_LAO(t *testing.T) {
@@ -849,8 +849,8 @@ func Test_Create_LAO_Broadcast_Wrong_MessageID(t *testing.T) {
 		Message: publishBuf,
 	})
 
-	expectedMessageId := messagedata.Hash(dataBase64, signatureBase64)
-	require.EqualError(t, sock.err, fmt.Sprintf("failed to handle method: message_id is wrong: expected %q found %q", expectedMessageId, fakeMessageID))
+	expectedMessageID := messagedata.Hash(dataBase64, signatureBase64)
+	require.EqualError(t, sock.err, fmt.Sprintf("failed to handle method: message_id is wrong: expected %q found %q", expectedMessageID, fakeMessageID))
 }
 
 // Check that if the organizer receives a subscribe message, it will call the

--- a/be1-go/inbox/mod.go
+++ b/be1-go/inbox/mod.go
@@ -149,6 +149,7 @@ func (i *Inbox) GetMessage(messageID string) (*message.Message, bool) {
 	if !ok {
 		return nil, false
 	}
+	
 	return &msgInfo.message, true
 }
 

--- a/be1-go/inbox/mod.go
+++ b/be1-go/inbox/mod.go
@@ -149,7 +149,7 @@ func (i *Inbox) GetMessage(messageID string) (*message.Message, bool) {
 	if !ok {
 		return nil, false
 	}
-	
+
 	return &msgInfo.message, true
 }
 
@@ -187,7 +187,8 @@ func (i *Inbox) storeMessageInDB(messageInfo *messageInfo) error {
 
 	msg := messageInfo.message
 
-	_, err = stmt.Exec(msg.MessageID, msg.Sender, msg.Signature, msg.Data, messageInfo.storedTime, i.channelID)
+	_, err = stmt.Exec(msg.MessageID, msg.Sender, msg.Signature, msg.Data,
+		messageInfo.storedTime, i.channelID)
 	if err != nil {
 		return xerrors.Errorf("failed to exec query: %v", err)
 	}

--- a/be1-go/message/messagedata/chirp_broadcast.go
+++ b/be1-go/message/messagedata/chirp_broadcast.go
@@ -2,6 +2,7 @@ package messagedata
 
 import (
 	"encoding/base64"
+
 	"golang.org/x/xerrors"
 )
 
@@ -9,7 +10,7 @@ import (
 type ChirpBroadcast struct {
 	Object  string `json:"object"`
 	Action  string `json:"action"`
-	ChirpId string `json:"chirp_id"`
+	ChirpID string `json:"chirp_id"`
 	Channel string `json:"channel"`
 
 	// Timestamp is a Unix timestamp
@@ -24,9 +25,9 @@ func (message ChirpBroadcast) Verify() error {
 	}
 
 	// verify that the chirp id is base64URL encoded
-	_, err := base64.URLEncoding.DecodeString(message.ChirpId)
+	_, err := base64.URLEncoding.DecodeString(message.ChirpID)
 	if err != nil {
-		return xerrors.Errorf("chirp id is %s, should be base64URL encoded", message.ChirpId)
+		return xerrors.Errorf("chirp id is %s, should be base64URL encoded", message.ChirpID)
 	}
 
 	return nil

--- a/be1-go/message/messagedata/chirp_delete.go
+++ b/be1-go/message/messagedata/chirp_delete.go
@@ -2,6 +2,7 @@ package messagedata
 
 import (
 	"encoding/base64"
+
 	"golang.org/x/xerrors"
 )
 
@@ -9,7 +10,7 @@ import (
 type ChirpDelete struct {
 	Object  string `json:"object"`
 	Action  string `json:"action"`
-	ChirpId string `json:"chirp_id"`
+	ChirpID string `json:"chirp_id"`
 
 	// Timestamp is a Unix timestamp
 	Timestamp int64 `json:"timestamp"`
@@ -24,9 +25,9 @@ func (message ChirpDelete) Verify() error {
 	}
 
 	// verify that the chirp id is base64URL encoded
-	_, err := base64.URLEncoding.DecodeString(message.ChirpId)
+	_, err := base64.URLEncoding.DecodeString(message.ChirpID)
 	if err != nil {
-		return xerrors.Errorf("chirp id is %s, should be base64URL encoded", message.ChirpId)
+		return xerrors.Errorf("chirp id is %s, should be base64URL encoded", message.ChirpID)
 	}
 
 	return nil

--- a/be1-go/message/messagedata/chirp_notify_add.go
+++ b/be1-go/message/messagedata/chirp_notify_add.go
@@ -2,6 +2,7 @@ package messagedata
 
 import (
 	"encoding/base64"
+
 	"golang.org/x/xerrors"
 )
 
@@ -9,7 +10,7 @@ import (
 type ChirpNotifyAdd struct {
 	Object  string `json:"object"`
 	Action  string `json:"action"`
-	ChirpId string `json:"chirp_id"`
+	ChirpID string `json:"chirp_id"`
 	Channel string `json:"channel"`
 
 	// Timestamp is a Unix timestamp
@@ -25,9 +26,9 @@ func (message ChirpNotifyAdd) Verify() error {
 	}
 
 	// verify that the chirp id is base64URL encoded
-	_, err := base64.URLEncoding.DecodeString(message.ChirpId)
+	_, err := base64.URLEncoding.DecodeString(message.ChirpID)
 	if err != nil {
-		return xerrors.Errorf("chirp id is %s, should be base64URL encoded", message.ChirpId)
+		return xerrors.Errorf("chirp id is %s, should be base64URL encoded", message.ChirpID)
 	}
 
 	return nil

--- a/be1-go/message/messagedata/chirp_notify_delete.go
+++ b/be1-go/message/messagedata/chirp_notify_delete.go
@@ -2,6 +2,7 @@ package messagedata
 
 import (
 	"encoding/base64"
+
 	"golang.org/x/xerrors"
 )
 
@@ -9,7 +10,7 @@ import (
 type ChirpNotifyDelete struct {
 	Object  string `json:"object"`
 	Action  string `json:"action"`
-	ChirpId string `json:"chirp_id"`
+	ChirpID string `json:"chirp_id"`
 	Channel string `json:"channel"`
 
 	// Timestamp is a Unix timestamp
@@ -25,9 +26,9 @@ func (message ChirpNotifyDelete) Verify() error {
 	}
 
 	// verify that the chirp id is base64URL encoded
-	_, err := base64.URLEncoding.DecodeString(message.ChirpId)
+	_, err := base64.URLEncoding.DecodeString(message.ChirpID)
 	if err != nil {
-		return xerrors.Errorf("chirp id is %s, should be base64URL encoded", message.ChirpId)
+		return xerrors.Errorf("chirp id is %s, should be base64URL encoded", message.ChirpID)
 	}
 
 	return nil

--- a/be1-go/message/messagedata/consensus_accept.go
+++ b/be1-go/message/messagedata/consensus_accept.go
@@ -49,6 +49,7 @@ func (message ConsensusAccept) Verify() error {
 	if message.Value.AcceptedTry < -1 {
 		return xerrors.Errorf("accepted try is %d, should be minimum -1", message.Value.AcceptedTry)
 	}
+	
 	return nil
 }
 

--- a/be1-go/message/messagedata/consensus_accept.go
+++ b/be1-go/message/messagedata/consensus_accept.go
@@ -49,7 +49,7 @@ func (message ConsensusAccept) Verify() error {
 	if message.Value.AcceptedTry < -1 {
 		return xerrors.Errorf("accepted try is %d, should be minimum -1", message.Value.AcceptedTry)
 	}
-	
+
 	return nil
 }
 

--- a/be1-go/message/messagedata/consensus_accept.go
+++ b/be1-go/message/messagedata/consensus_accept.go
@@ -19,6 +19,7 @@ type ConsensusAccept struct {
 	Value ValueAccept `json:"value"`
 }
 
+// ValueAccept defines the accepted value and try of a ConsensusAccept message
 type ValueAccept struct {
 	AcceptedTry   int64 `json:"accepted_try"`
 	AcceptedValue bool  `json:"accepted_value"`

--- a/be1-go/message/messagedata/consensus_elect.go
+++ b/be1-go/message/messagedata/consensus_elect.go
@@ -18,6 +18,13 @@ type ConsensusElect struct {
 	Value string `json:"value"`
 }
 
+// Key defines the object that the consensus refers to
+type Key struct {
+	Type     string `json:"type"`
+	ID       string `json:"id"`
+	Property string `json:"property"`
+}
+
 // Verify implements Verifiable. It verifies that the ConsensusElect message is
 // correct
 func (message ConsensusElect) Verify() error {
@@ -60,10 +67,4 @@ func (ConsensusElect) GetAction() string {
 // NewEmpty implements MessageData
 func (ConsensusElect) NewEmpty() MessageData {
 	return &ConsensusElect{}
-}
-
-type Key struct {
-	Type     string `json:"type"`
-	ID       string `json:"id"`
-	Property string `json:"property"`
 }

--- a/be1-go/message/messagedata/consensus_failure.go
+++ b/be1-go/message/messagedata/consensus_failure.go
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// ConsensusLearn defines a message data
+// ConsensusFailure defines a message data
 type ConsensusFailure struct {
 	Object     string `json:"object"`
 	Action     string `json:"action"`

--- a/be1-go/message/messagedata/consensus_learn.go
+++ b/be1-go/message/messagedata/consensus_learn.go
@@ -21,6 +21,7 @@ type ConsensusLearn struct {
 	AcceptorSignatures []string `json:"acceptor-signatures"`
 }
 
+// ValueLearn defines the final decision of the consensus
 type ValueLearn struct {
 	Decision bool `json:"decision"`
 }

--- a/be1-go/message/messagedata/consensus_learn.go
+++ b/be1-go/message/messagedata/consensus_learn.go
@@ -50,7 +50,8 @@ func (message ConsensusLearn) Verify() error {
 	for acceptor := range message.AcceptorSignatures {
 		_, err := base64.URLEncoding.DecodeString(message.AcceptorSignatures[acceptor])
 		if err != nil {
-			return xerrors.Errorf("acceptor id is %s, should be base64URL encoded", message.AcceptorSignatures[acceptor])
+			return xerrors.Errorf("acceptor id is %s, should be base64URL encoded",
+				message.AcceptorSignatures[acceptor])
 		}
 	}
 

--- a/be1-go/message/messagedata/consensus_prepare.go
+++ b/be1-go/message/messagedata/consensus_prepare.go
@@ -19,6 +19,7 @@ type ConsensusPrepare struct {
 	Value ValuePrepare `json:"value"`
 }
 
+// ValuePrepare defines the id of the proposition
 type ValuePrepare struct {
 	ProposedTry int64 `json:"proposed_try"`
 }

--- a/be1-go/message/messagedata/consensus_propose.go
+++ b/be1-go/message/messagedata/consensus_propose.go
@@ -55,7 +55,8 @@ func (message ConsensusPropose) Verify() error {
 	for acceptor := range message.AcceptorSignatures {
 		_, err = base64.URLEncoding.DecodeString(message.AcceptorSignatures[acceptor])
 		if err != nil {
-			return xerrors.Errorf("acceptor id is %s, should be base64URL encoded", message.AcceptorSignatures[acceptor])
+			return xerrors.Errorf("acceptor id is %s, should be base64URL encoded",
+				message.AcceptorSignatures[acceptor])
 		}
 	}
 

--- a/be1-go/message/messagedata/mod.go
+++ b/be1-go/message/messagedata/mod.go
@@ -127,6 +127,6 @@ func Hash(strs ...string) string {
 		h.Write([]byte(fmt.Sprintf("%d", len(s))))
 		h.Write([]byte(s))
 	}
-	
+
 	return base64.URLEncoding.EncodeToString(h.Sum(nil))
 }

--- a/be1-go/message/messagedata/mod.go
+++ b/be1-go/message/messagedata/mod.go
@@ -127,5 +127,6 @@ func Hash(strs ...string) string {
 		h.Write([]byte(fmt.Sprintf("%d", len(s))))
 		h.Write([]byte(s))
 	}
+	
 	return base64.URLEncoding.EncodeToString(h.Sum(nil))
 }

--- a/be1-go/message/query/method/message/message.go
+++ b/be1-go/message/query/method/message/message.go
@@ -3,6 +3,7 @@ package message
 import (
 	"encoding/base64"
 	"encoding/json"
+
 	"golang.org/x/xerrors"
 )
 

--- a/be1-go/message/test/messagedata/chirp_add_broadcast_test.go
+++ b/be1-go/message/test/messagedata/chirp_add_broadcast_test.go
@@ -2,11 +2,12 @@ package messagedata
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"popstellar/message/messagedata"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_Chirp_Notify_Add(t *testing.T) {
@@ -29,7 +30,7 @@ func Test_Chirp_Notify_Add(t *testing.T) {
 	require.Equal(t, "chirp", msg.Object)
 	require.Equal(t, "notify_add", msg.Action)
 	require.Equal(t, "/root/<lao_id>/social/<sender>", msg.Channel)
-	require.Equal(t, "ONYYu9Q2kGdAVpfbGwdmgBPf4QBznjt-JQO2gGCL3iI=", msg.ChirpId)
+	require.Equal(t, "ONYYu9Q2kGdAVpfbGwdmgBPf4QBznjt-JQO2gGCL3iI=", msg.ChirpID)
 	require.Equal(t, int64(1634760180), msg.Timestamp)
 
 	err = msg.Verify()
@@ -56,7 +57,7 @@ func Test_Chirp_Notify_Add_Negative_Timestamp(t *testing.T) {
 	require.Equal(t, "chirp", msg.Object)
 	require.Equal(t, "notify_add", msg.Action)
 	require.Equal(t, "/root/<lao_id>/social/<sender>", msg.Channel)
-	require.Equal(t, "ONYYu9Q2kGdAVpfbGwdmgBPf4QBznjt-JQO2gGCL3iI=", msg.ChirpId)
+	require.Equal(t, "ONYYu9Q2kGdAVpfbGwdmgBPf4QBznjt-JQO2gGCL3iI=", msg.ChirpID)
 	require.Equal(t, int64(-1), msg.Timestamp)
 
 	err = msg.Verify()
@@ -83,7 +84,7 @@ func Test_Chirp_Notify_Add_Not_Base64_Message(t *testing.T) {
 	require.Equal(t, "chirp", msg.Object)
 	require.Equal(t, "notify_add", msg.Action)
 	require.Equal(t, "/root/<lao_id>/social/<sender>", msg.Channel)
-	require.Equal(t, "@@@", msg.ChirpId)
+	require.Equal(t, "@@@", msg.ChirpID)
 	require.Equal(t, int64(1634760180), msg.Timestamp)
 
 	err = msg.Verify()

--- a/be1-go/message/test/messagedata/chirp_delete_broadcast_test.go
+++ b/be1-go/message/test/messagedata/chirp_delete_broadcast_test.go
@@ -29,7 +29,7 @@ func Test_Chirp_Notify_Delete(t *testing.T) {
 	require.Equal(t, "chirp", msg.Object)
 	require.Equal(t, "notify_delete", msg.Action)
 	require.Equal(t, "/root/<lao_id>/social/<sender>", msg.Channel)
-	require.Equal(t, "ONYYu9Q2kGdAVpfbGwdmgBPf4QBznjt-JQO2gGCL3iI=", msg.ChirpId)
+	require.Equal(t, "ONYYu9Q2kGdAVpfbGwdmgBPf4QBznjt-JQO2gGCL3iI=", msg.ChirpID)
 	require.Equal(t, int64(1634760180), msg.Timestamp)
 
 	err = msg.Verify()
@@ -56,7 +56,7 @@ func Test_Chirp_Notify_Delete_Negative_Timestamp(t *testing.T) {
 	require.Equal(t, "chirp", msg.Object)
 	require.Equal(t, "notify_delete", msg.Action)
 	require.Equal(t, "/root/<lao_id>/social/<sender>", msg.Channel)
-	require.Equal(t, "ONYYu9Q2kGdAVpfbGwdmgBPf4QBznjt-JQO2gGCL3iI=", msg.ChirpId)
+	require.Equal(t, "ONYYu9Q2kGdAVpfbGwdmgBPf4QBznjt-JQO2gGCL3iI=", msg.ChirpID)
 	require.Equal(t, int64(-1), msg.Timestamp)
 
 	err = msg.Verify()
@@ -83,7 +83,7 @@ func Test_Chirp_Notify_Delete_Not_Base64_Message(t *testing.T) {
 	require.Equal(t, "chirp", msg.Object)
 	require.Equal(t, "notify_delete", msg.Action)
 	require.Equal(t, "/root/<lao_id>/social/<sender>", msg.Channel)
-	require.Equal(t, "@@@", msg.ChirpId)
+	require.Equal(t, "@@@", msg.ChirpID)
 	require.Equal(t, int64(1634760180), msg.Timestamp)
 
 	err = msg.Verify()

--- a/be1-go/message/test/messagedata/chirp_delete_publish_test.go
+++ b/be1-go/message/test/messagedata/chirp_delete_publish_test.go
@@ -28,7 +28,7 @@ func Test_Chirp_Delete_Publish(t *testing.T) {
 
 	require.Equal(t, "chirp", msg.Object)
 	require.Equal(t, "delete", msg.Action)
-	require.Equal(t, "ONYYu9Q2kGdAVpfbGwdmgBPf4QBznjt-JQO2gGCL3iI=", msg.ChirpId)
+	require.Equal(t, "ONYYu9Q2kGdAVpfbGwdmgBPf4QBznjt-JQO2gGCL3iI=", msg.ChirpID)
 	require.Equal(t, int64(1634760180), msg.Timestamp)
 
 	err = msg.Verify()
@@ -54,7 +54,7 @@ func Test_Chirp_Delete_Publish_Negative_Timestamp(t *testing.T) {
 
 	require.Equal(t, "chirp", msg.Object)
 	require.Equal(t, "delete", msg.Action)
-	require.Equal(t, "ONYYu9Q2kGdAVpfbGwdmgBPf4QBznjt-JQO2gGCL3iI=", msg.ChirpId)
+	require.Equal(t, "ONYYu9Q2kGdAVpfbGwdmgBPf4QBznjt-JQO2gGCL3iI=", msg.ChirpID)
 	require.Equal(t, int64(-1), msg.Timestamp)
 
 	err = msg.Verify()
@@ -80,7 +80,7 @@ func Test_Chirp_Delete_Publish_Not_Base64_Message(t *testing.T) {
 
 	require.Equal(t, "chirp", msg.Object)
 	require.Equal(t, "delete", msg.Action)
-	require.Equal(t, "@@@", msg.ChirpId)
+	require.Equal(t, "@@@", msg.ChirpID)
 	require.Equal(t, int64(1634760180), msg.Timestamp)
 
 	err = msg.Verify()

--- a/be1-go/network/server.go
+++ b/be1-go/network/server.go
@@ -151,7 +151,7 @@ func (s *Server) Shutdown() error {
 	close(s.done)
 
 	s.wg.Wait()
-	
+
 	return nil
 }
 

--- a/be1-go/network/server.go
+++ b/be1-go/network/server.go
@@ -75,6 +75,7 @@ func NewServer(hub hub.Hub, port int, st socket.SocketType, log zerolog.Logger) 
 	log.Info().Msgf("setting handler at %s for port %d", path, port)
 
 	server.srv = httpServer
+
 	return server
 }
 
@@ -150,6 +151,7 @@ func (s *Server) Shutdown() error {
 	close(s.done)
 
 	s.wg.Wait()
+	
 	return nil
 }
 


### PR DESCRIPTION
Reorganized the channels so that they all have the same layout, which is : 

- types
- NewChannel method
- Publish-subscribe methods in order (sub, unsub, pub, catch, broadcast)
- handleMessage
- registry
- processMessages functions
- verify functions
- broadcastToAll function
- and finally the rest

Also fixed some mistakes in the messageData comments, wraped a few lines that were too big, added missing new lines and removed unecessary ones.