### PR TITLE
Fix roll call issue

### DIFF
--- a/fe1-web/src/features/rollCall/components/EventRollCall.tsx
+++ b/fe1-web/src/features/rollCall/components/EventRollCall.tsx
@@ -89,7 +89,7 @@ const EventRollCall = (props: IPropTypes) => {
   const onScanAttendees = () => {
     if (eventHasBeenOpened) {
       navigation.navigate(STRINGS.roll_call_open, {
-        rollCallID: rollCall.idAlias.toString(),
+        rollCallID: rollCall.id.toString(),
       });
     } else {
       makeToastErr('Unable to scan attendees, the event does not have an idAlias');


### PR DESCRIPTION
This reverts a changed that was most likely introduced by accident.

Compare to an earlier version

https://github.com/dedis/popstellar/blob/6736b0b65a3908a03c0d56e2582a67d459ab5b95/fe1-web/src/features/rollCall/components/EventRollCall.tsx#L57-L79

Without this fix, the pop tokens are not valid since they are not generated using the rollcalls id after creation but rather the new one after opening it.