### PR TITLE
Fix roll call closing bug

### DIFF
--- a/fe1-web/src/features/rollCall/components/EventRollCall.tsx
+++ b/fe1-web/src/features/rollCall/components/EventRollCall.tsx
@@ -90,6 +90,7 @@ const EventRollCall = (props: IPropTypes) => {
     if (eventHasBeenOpened) {
       navigation.navigate(STRINGS.roll_call_open, {
         rollCallID: rollCall.id.toString(),
+        rollCallIDAlias: rollCall.idAlias.toString(),
       });
     } else {
       makeToastErr('Unable to scan attendees, the event does not have an idAlias');

--- a/fe1-web/src/features/rollCall/screens/RollCallOpened.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallOpened.tsx
@@ -38,7 +38,7 @@ const RollCallOpened = () => {
   // FIXME: navigation and route should user proper type
   const navigation = useNavigation<any>();
   const route = useRoute<any>();
-  const { rollCallID } = route.params;
+  const { rollCallID, rollCallIDAlias } = route.params;
   const [attendees, updateAttendees] = useState(new Set<string>());
   const [inputModalIsVisible, setInputModalIsVisible] = useState(false);
   const toast = useToast();
@@ -105,7 +105,7 @@ const RollCallOpened = () => {
 
   const onCloseRollCall = () => {
     const attendeesList = Array.from(attendees).map((key: string) => new PublicKey(key));
-    return requestCloseRollCall(rollCallID, attendeesList)
+    return requestCloseRollCall(rollCallIDAlias, attendeesList)
       .then(() => {
         navigation.navigate(STRINGS.organizer_navigation_tab_home);
       })

--- a/fe1-web/src/features/rollCall/screens/__tests__/RollCallOpened.test.tsx
+++ b/fe1-web/src/features/rollCall/screens/__tests__/RollCallOpened.test.tsx
@@ -45,7 +45,7 @@ beforeEach(() => {
 
   (useRoute as jest.Mock).mockReturnValue({
     name: STRINGS.roll_call_open,
-    params: { rollCallID: rollCallId, updateID: rollCallId },
+    params: { rollCallID: rollCallId, rollCallIDAlias: rollCallId },
   });
 
   (useNavigation as jest.Mock).mockReturnValue({


### PR DESCRIPTION
The correct roll call ID was used to generate the organizer's token, but the one used for closing the roll call was not the updated idAlias anymore.
Fixed it by passing the two IDs in the scanning screen.
