### PR TITLE
Fix bug in witnessing feature

### DIFF
--- a/fe1-web/src/features/index.ts
+++ b/fe1-web/src/features/index.ts
@@ -50,6 +50,7 @@ export function configureFeatures() {
     enabled: false,
     messageRegistry,
     getCurrentLao: laoConfiguration.functions.getCurrentLao,
+    getCurrentLaoId: laoConfiguration.functions.getCurrentLaoId,
     isLaoWitness: laoConfiguration.functions.isLaoWitness,
     useCurrentLao: laoConfiguration.hooks.useCurrentLao,
   });

--- a/fe1-web/src/features/witness/interface/Configuration.ts
+++ b/fe1-web/src/features/witness/interface/Configuration.ts
@@ -24,7 +24,7 @@ export interface WitnessConfiguration {
 
   /**
    * Returns the currently active lao id. Should be used outside react components
-   * @returns The current lao  or undefined if there is none.
+   * @returns The current lao or undefined if there is none.
    */
   getCurrentLaoId: () => Hash | undefined;
 

--- a/fe1-web/src/features/witness/interface/Configuration.ts
+++ b/fe1-web/src/features/witness/interface/Configuration.ts
@@ -1,4 +1,5 @@
 import { MessageRegistry } from 'core/network/jsonrpc/messages';
+import { Hash } from 'core/objects';
 import FeatureInterface from 'core/objects/FeatureInterface';
 
 import { WitnessFeature } from './Feature';
@@ -20,6 +21,12 @@ export interface WitnessConfiguration {
    * @returns The current lao
    */
   getCurrentLao: () => WitnessFeature.Lao;
+
+  /**
+   * Returns the currently active lao id. Should be used outside react components
+   * @returns The current lao  or undefined if there is none.
+   */
+  getCurrentLaoId: () => Hash | undefined;
 
   /**
    * Returns whether the user is witness of the current lao

--- a/fe1-web/src/features/witness/network/WitnessStoreWatcher.ts
+++ b/fe1-web/src/features/witness/network/WitnessStoreWatcher.ts
@@ -3,7 +3,7 @@ import { Store } from 'redux';
 import { getMessagesState } from 'core/network/ingestion';
 import { ExtendedMessage } from 'core/network/ingestion/ExtendedMessage';
 
-import { WitnessConfiguration, WitnessFeature } from '../interface';
+import { WitnessConfiguration } from '../interface';
 import { getWitnessRegistryEntryType, WitnessingType } from './messages/WitnessRegistry';
 import { requestWitnessMessage } from './WitnessMessageApi';
 

--- a/fe1-web/src/features/witness/network/WitnessStoreWatcher.ts
+++ b/fe1-web/src/features/witness/network/WitnessStoreWatcher.ts
@@ -3,7 +3,7 @@ import { Store } from 'redux';
 import { getMessagesState } from 'core/network/ingestion';
 import { ExtendedMessage } from 'core/network/ingestion/ExtendedMessage';
 
-import { WitnessConfiguration } from '../interface';
+import { WitnessConfiguration, WitnessFeature } from '../interface';
 import { getWitnessRegistryEntryType, WitnessingType } from './messages/WitnessRegistry';
 import { requestWitnessMessage } from './WitnessMessageApi';
 
@@ -53,6 +53,7 @@ export const afterMessageProcessingHandler =
  */
 export const makeWitnessStoreWatcher = (
   store: Store,
+  getCurrentLaoId: () => Hash | undefined,
   afterProcessingHandler: (msg: ExtendedMessage) => void,
 ) => {
   let previousAllIds: string[] = [];
@@ -61,7 +62,16 @@ export const makeWitnessStoreWatcher = (
   let currentAllIds: string[] = [];
   let currentUnprocessedIds: string[] = [];
   return () => {
+    // we have to be careful with ExtendedMessage.fromState
+    // since some message constructors assume that we are connected to a lao
+    // thus we delay this watcher until we are connected to a lao
+    // (sending witness messages would also be difficult under these circumstances)
+    if (!getCurrentLaoId()) {
+      return;
+    }
+
     const state = store.getState();
+
     const msgState = getMessagesState(state);
     const allIds = msgState?.allIds || [];
     previousAllIds = currentAllIds;
@@ -95,7 +105,6 @@ export const makeWitnessStoreWatcher = (
 
       // i.e. all messages that have been processed
       // since the last call of this function
-
       afterProcessingHandler(ExtendedMessage.fromState(msgState.byId[msgId]));
     }
   };

--- a/fe1-web/src/features/witness/network/WitnessStoreWatcher.ts
+++ b/fe1-web/src/features/witness/network/WitnessStoreWatcher.ts
@@ -2,6 +2,7 @@ import { Store } from 'redux';
 
 import { getMessagesState } from 'core/network/ingestion';
 import { ExtendedMessage } from 'core/network/ingestion/ExtendedMessage';
+import { Hash } from 'core/objects';
 
 import { WitnessConfiguration } from '../interface';
 import { getWitnessRegistryEntryType, WitnessingType } from './messages/WitnessRegistry';

--- a/fe1-web/src/features/witness/network/__tests__/WitnessStoreWatcher.test.ts
+++ b/fe1-web/src/features/witness/network/__tests__/WitnessStoreWatcher.test.ts
@@ -1,6 +1,12 @@
 import { combineReducers, createStore } from 'redux';
 
-import { configureTestFeatures, mockAddress, mockChannel, mockKeyPair } from '__tests__/utils';
+import {
+  configureTestFeatures,
+  mockAddress,
+  mockChannel,
+  mockKeyPair,
+  mockLaoIdHash,
+} from '__tests__/utils';
 import {
   addMessages,
   clearAllMessages,
@@ -30,11 +36,17 @@ beforeEach(() => {
 
 describe('makeWitnessStoreWatcher', () => {
   it('returns a listener function', () => {
-    expect(makeWitnessStoreWatcher(mockStore, mockAfterProcessingHandler)).toBeFunction();
+    expect(
+      makeWitnessStoreWatcher(mockStore, () => mockLaoIdHash, mockAfterProcessingHandler),
+    ).toBeFunction();
   });
 
   it('afterProcessingHandler is not called when a new message is added', () => {
-    const watcher = makeWitnessStoreWatcher(mockStore, mockAfterProcessingHandler);
+    const watcher = makeWitnessStoreWatcher(
+      mockStore,
+      () => mockLaoIdHash,
+      mockAfterProcessingHandler,
+    );
 
     const msg = ExtendedMessage.fromMessage(
       ExtendedMessage.fromData(
@@ -52,7 +64,11 @@ describe('makeWitnessStoreWatcher', () => {
   });
 
   it('afterProcessingHandler is called when a message has been processed', () => {
-    const watcher = makeWitnessStoreWatcher(mockStore, mockAfterProcessingHandler);
+    const watcher = makeWitnessStoreWatcher(
+      mockStore,
+      () => mockLaoIdHash,
+      mockAfterProcessingHandler,
+    );
 
     const msg = ExtendedMessage.fromMessage(
       ExtendedMessage.fromData(

--- a/fe1-web/src/features/witness/network/index.ts
+++ b/fe1-web/src/features/witness/network/index.ts
@@ -21,5 +21,11 @@ export const configureNetwork = (config: WitnessConfiguration) => {
 
   // listen for new processable messages
   const store = getStore();
-  store.subscribe(makeWitnessStoreWatcher(store, afterMessageProcessingHandler(config.enabled)));
+  store.subscribe(
+    makeWitnessStoreWatcher(
+      store,
+      config.getCurrentLaoId,
+      afterMessageProcessingHandler(config.enabled),
+    ),
+  );
 };


### PR DESCRIPTION
Previously the witnessing feature tried to call `ExtendedMessage.fromState` without being connected to a LAO when fe-1 was refreshed (since the watcher thinks all stored messages are new messages). Since certain message constructors such as CreateRollCall throw an error if the application is not connected to a LAO, this causes the application to error and fail.

This PR fixes this issue by delaying all actions triggered by the watcher until the application is connected to a LAO.