### PR TITLE
Fix issue 964: removed castvote time checks for start and end time

### DIFF
--- a/be1-go/channel/election/verification.go
+++ b/be1-go/channel/election/verification.go
@@ -122,22 +122,6 @@ func (c *Channel) verifyMessageCastVote(castVote messagedata.VoteCastVote) error
 		return xerrors.Errorf("cast vote created at is %d, should be minimum 0", castVote.CreatedAt)
 	}
 
-	// verify created at is after start of election
-	if castVote.CreatedAt < c.start {
-		return xerrors.Errorf("cast vote created at is %d, should be greater or "+
-			"equal to defined start time %d",
-			castVote.CreatedAt, c.start)
-	}
-
-	// verify created at is before end of election
-	if castVote.CreatedAt > c.end {
-		// note that CreatedAt is provided by the client and can't be fully trusted.
-		// We leave this check as is until we have a better solution.
-		return xerrors.Errorf("cast vote created at is %d, should be smaller or "+
-			"equal to defined end time %d",
-			castVote.CreatedAt, c.end)
-	}
-
 	return nil
 }
 

--- a/be1-go/channel/election/verification_test.go
+++ b/be1-go/channel/election/verification_test.go
@@ -156,8 +156,6 @@ func TestVerify_CastVote(t *testing.T) {
 	t.Run("lao id invalid hash", getTestBadExample("bad_vote_cast_vote_lao_invalid_hash.json"))
 	t.Run("election id invalid hash", getTestBadExample("bad_vote_cast_vote_election_invalid_hash.json"))
 	t.Run("created at negative", getTestBadExample("bad_vote_cast_vote_created_at_negative.json"))
-	t.Run("created at before start", getTestBadExample("bad_vote_cast_vote_created_at_before_start.json"))
-	t.Run("created at after end", getTestBadExample("bad_vote_cast_vote_created_at_after_end.json"))
 }
 
 func TestVerify_CastVote_not_open(t *testing.T) {


### PR DESCRIPTION
Small fix for issue [964](https://github.com/dedis/popstellar/issues/964).

Removed start time and end time checks in the verification of cast_vote messages.
Removed tests that relied on these verifications.