### PR TITLE
lao create self contained tests

### DIFF
--- a/tests/karate/src/test/java/be/LAO/create.feature
+++ b/tests/karate/src/test/java/be/LAO/create.feature
@@ -9,7 +9,6 @@ Feature: Create a pop LAO
     * call read('classpath:be/utils/server.feature')
     * call read('classpath:be/mockFrontEnd.feature')
     * call read('classpath:be/constants.feature')
-    * def id = 1
     * string channel = "/root"
 
   Scenario: Create Lao request with empty lao name should fail with an error response 2
@@ -25,7 +24,7 @@ Feature: Create a pop LAO
           "witnesses": []
         }
       """
-    When frontend.publish(JSON.stringify(badLaoReq), id, channel)
+    When frontend.publish(JSON.stringify(badLaoReq), channel)
     And json answer = frontend.getBackendResponseWithoutBroadcast()
     Then match answer contains INVALID_MESSAGE_FIELD
     And match frontend.receiveNoMoreResponses() == true
@@ -44,7 +43,7 @@ Feature: Create a pop LAO
           "witnesses": []
         }
       """
-    When frontend.publish(JSON.stringify(badLaoReq), id, channel)
+    When frontend.publish(JSON.stringify(badLaoReq), channel)
     And json answer = frontend.getBackendResponseWithoutBroadcast()
     Then match answer contains INVALID_MESSAGE_FIELD
     And match frontend.receiveNoMoreResponses() == true
@@ -61,7 +60,7 @@ Feature: Create a pop LAO
           "witnesses": []
         }
       """
-    When frontend.publish(JSON.stringify(badLaoReq), id, channel)
+    When frontend.publish(JSON.stringify(badLaoReq), channel)
     And json answer = frontend.getBackendResponseWithoutBroadcast()
     Then match answer contains INVALID_MESSAGE_FIELD
     And match frontend.receiveNoMoreResponses() == true
@@ -78,7 +77,7 @@ Feature: Create a pop LAO
           "witnesses": []
         }
       """
-    When frontend.publish(JSON.stringify(laoCreateRequest), id, channel)
+    When frontend.publish(JSON.stringify(laoCreateRequest), channel)
     And json answer = frontend.getBackendResponseWithoutBroadcast()
     Then match answer contains VALID_MESSAGE
     And match frontend.receiveNoMoreResponses() == true

--- a/tests/karate/src/test/java/be/LAO/create.feature
+++ b/tests/karate/src/test/java/be/LAO/create.feature
@@ -7,47 +7,78 @@ Feature: Create a pop LAO
         # Meaning they share def variables, configurations ...
         # Especially JS functions defined in server.feature can be directly used here thanks to Karate shared scopes
     * call read('classpath:be/utils/server.feature')
+    * call read('classpath:be/mockFrontEnd.feature')
+    * call read('classpath:be/constants.feature')
     * def id = 1
     * string channel = "/root"
 
-  Scenario: Create Lao request with empty lao name should fail with an error response
-    Given string laoCreateData = read('classpath:data/lao/data/bad_lao_create_empty_name_data.json')
-    * string laoCreate = converter.publishМessageFromData(laoCreateData, id, channel)
-    And   def socket = karate.webSocket(wsURL,handle)
-    When  eval socket.send(laoCreate)
-    *  karate.log('Sent: '+ karate.pretty(laoCreate))
-    And  json err = socket.listen(timeout)
-    * karate.log('Received: '+ err )
-    Then match err contains deep {jsonrpc: '2.0', id: '#(id)', error: {code: -4, description: '#string'}}
+  Scenario: Create Lao request with empty lao name should fail with an error response 2
+    Given def badLaoReq =
+      """
+        {
+          "object": "lao",
+          "action": "create",
+          "id": '#(getLaoIdEmptyName)',
+          "name": "",
+          "creation": 1633098234,
+          "organizer": '#(getOrganizer)',
+          "witnesses": []
+        }
+      """
+    When frontend.publish(JSON.stringify(badLaoReq), id, channel)
+    And json answer = frontend.getBackendResponseWithoutBroadcast()
+    Then match answer contains INVALID_MESSAGE_FIELD
+    And match frontend.receiveNoMoreResponses() == true
+
 
   Scenario: Create Lao with negative time should fail with an error response
-      Given string badLaoCreateData = read('classpath:data/lao/data/bad_lao_create_negative_data.json')
-      * string badLaoCreate = converter.publishМessageFromData(badLaoCreateData, id, channel)
-      And   def socket = karate.webSocket(wsURL,handle)
-      When  eval socket.send(badLaoCreate)
-      *  karate.log('Sent: '+ karate.pretty(badLaoCreate))
-      And  json err = socket.listen(timeout)
-      *  karate.log('Received: '+ karate.pretty(err) )
-      Then match err contains deep {jsonrpc: '2.0', id: '#(id)', error: {code: -4, description: '#string'}}
-
+    Given def badLaoReq =
+      """
+        {
+          "object": "lao",
+          "action": "create",
+          "id": '#(getLaoIdNegativeTime)',
+          "name": "LAO",
+          "creation": -1633098234,
+          "organizer": '#(getOrganizer)',
+          "witnesses": []
+        }
+      """
+    When frontend.publish(JSON.stringify(badLaoReq), id, channel)
+    And json answer = frontend.getBackendResponseWithoutBroadcast()
+    Then match answer contains INVALID_MESSAGE_FIELD
+    And match frontend.receiveNoMoreResponses() == true
   Scenario: Create Lao with invalid id hash should fail with an error response
-      Given string badLaoCreateData = read('classpath:data/lao/data/bad_lao_create_id_invalid_hash_data.json')
-      * string badLaoCreate = converter.publishМessageFromData(badLaoCreateData, id, channel)
-      And   def socket = karate.webSocket(wsURL,handle)
-      When  eval socket.send(badLaoCreate)
-      *  karate.log('Sent: '+ karate.pretty(badLaoCreate))
-      And  json err = socket.listen(timeout)
-      *  karate.log('Received: '+ karate.pretty(err) )
-      Then match err contains deep {jsonrpc: '2.0', id: '#(id)', error: {code: -4, description: '#string'}}
-
+    Given def badLaoReq =
+      """
+        {
+          "object": "lao",
+          "action": "create",
+          "id": '#(getOrganizer)',
+          "name": "LAO",
+          "creation": 1633098234,
+          "organizer": '#(getOrganizer)',
+          "witnesses": []
+        }
+      """
+    When frontend.publish(JSON.stringify(badLaoReq), id, channel)
+    And json answer = frontend.getBackendResponseWithoutBroadcast()
+    Then match answer contains INVALID_MESSAGE_FIELD
+    And match frontend.receiveNoMoreResponses() == true
   Scenario: Create should succeed with a valid creation request
-    Given string laoCreateData = read('classpath:data/lao/data/valid_lao_create_data.json')
-    And string laoCreate = converter.publishМessageFromData(laoCreateData, id, channel)
-    *   def socket = karate.webSocket(wsURL,handle)
-    * karate.log('Create Request = ' + laoCreate)
-    When  eval socket.send(laoCreate)
-    *  karate.log('Sent: '+ karate.pretty(laoCreate))
-    And   json answer = socket.listen(timeout)
-    * karate.log('Received answer = ' + answer)
-    Then match answer contains deep {jsonrpc: '2.0', id: '#(id)', result: 0}
-
+    Given def laoCreateRequest =
+      """
+        {
+          "object": "lao",
+          "action": "create",
+          "id": '#(getLaoValid)',
+          "name": "LAO",
+          "creation": 1633035721,
+          "organizer": '#(getOrganizer)',
+          "witnesses": []
+        }
+      """
+    When frontend.publish(JSON.stringify(laoCreateRequest), id, channel)
+    And json answer = frontend.getBackendResponseWithoutBroadcast()
+    Then match answer contains VALID_MESSAGE
+    And match frontend.receiveNoMoreResponses() == true

--- a/tests/karate/src/test/java/be/ServerTest.java
+++ b/tests/karate/src/test/java/be/ServerTest.java
@@ -10,35 +10,35 @@ public class ServerTest {
     return Karate.run("classpath:be/LAO");
   }
 
-//  @Karate.Test
-//  Karate testCreateRollCall() {
-//    return Karate.run("classpath:be/rollCall/createRollCall.feature");
-//  }
-//
-//  @Karate.Test
-//  Karate testOpenRollCall() {
-//    return Karate.run("classpath:be/rollCall/openRollCall.feature");
-//  }
-//
-//  @Karate.Test
-//  Karate testCloseRollCall() {
-//    return Karate.run("classpath:be/rollCall/closeRollCall.feature");
-//  }
-//
-//  @Karate.Test
-//  Karate testElectionSetup(){
-//    return Karate.run("classpath:be/election/electionSetup.feature");
-//  }
-//
-//  @Karate.Test
-//  Karate testCastVote(){
-//    return Karate.run("classpath:be/election/castVote.feature");
-//  }
-//
-//  @Karate.Test
-//  Karate testElectionEnd(){
-//    return Karate.run("classpath:be/election/electionEnd.feature");
-//  }
+  @Karate.Test
+  Karate testCreateRollCall() {
+    return Karate.run("classpath:be/rollCall/createRollCall.feature");
+  }
+
+  @Karate.Test
+  Karate testOpenRollCall() {
+    return Karate.run("classpath:be/rollCall/openRollCall.feature");
+  }
+
+  @Karate.Test
+  Karate testCloseRollCall() {
+    return Karate.run("classpath:be/rollCall/closeRollCall.feature");
+  }
+
+  @Karate.Test
+  Karate testElectionSetup(){
+    return Karate.run("classpath:be/election/electionSetup.feature");
+  }
+
+  @Karate.Test
+  Karate testCastVote(){
+    return Karate.run("classpath:be/election/castVote.feature");
+  }
+
+  @Karate.Test
+  Karate testElectionEnd(){
+    return Karate.run("classpath:be/election/electionEnd.feature");
+  }
 }
 
 

--- a/tests/karate/src/test/java/be/ServerTest.java
+++ b/tests/karate/src/test/java/be/ServerTest.java
@@ -10,35 +10,35 @@ public class ServerTest {
     return Karate.run("classpath:be/LAO");
   }
 
-  @Karate.Test
-  Karate testCreateRollCall() {
-    return Karate.run("classpath:be/rollCall/createRollCall.feature");
-  }
-
-  @Karate.Test
-  Karate testOpenRollCall() {
-    return Karate.run("classpath:be/rollCall/openRollCall.feature");
-  }
-
-  @Karate.Test
-  Karate testCloseRollCall() {
-    return Karate.run("classpath:be/rollCall/closeRollCall.feature");
-  }
-
-  @Karate.Test
-  Karate testElectionSetup(){
-    return Karate.run("classpath:be/election/electionSetup.feature");
-  }
-
-  @Karate.Test
-  Karate testCastVote(){
-    return Karate.run("classpath:be/election/castVote.feature");
-  }
-
-  @Karate.Test
-  Karate testElectionEnd(){
-    return Karate.run("classpath:be/election/electionEnd.feature");
-  }
+//  @Karate.Test
+//  Karate testCreateRollCall() {
+//    return Karate.run("classpath:be/rollCall/createRollCall.feature");
+//  }
+//
+//  @Karate.Test
+//  Karate testOpenRollCall() {
+//    return Karate.run("classpath:be/rollCall/openRollCall.feature");
+//  }
+//
+//  @Karate.Test
+//  Karate testCloseRollCall() {
+//    return Karate.run("classpath:be/rollCall/closeRollCall.feature");
+//  }
+//
+//  @Karate.Test
+//  Karate testElectionSetup(){
+//    return Karate.run("classpath:be/election/electionSetup.feature");
+//  }
+//
+//  @Karate.Test
+//  Karate testCastVote(){
+//    return Karate.run("classpath:be/election/castVote.feature");
+//  }
+//
+//  @Karate.Test
+//  Karate testElectionEnd(){
+//    return Karate.run("classpath:be/election/electionEnd.feature");
+//  }
 }
 
 

--- a/tests/karate/src/test/java/be/constants.feature
+++ b/tests/karate/src/test/java/be/constants.feature
@@ -1,0 +1,36 @@
+@ignore @report=false
+Feature: Constants
+  Scenario: Creates constants that will be used by other features
+    # TODO: make the function depend on all the attributes the lao id depends on
+    * def createLaoIdEmptyName =
+      """
+        function(){
+          return "p8TW08AWlBScs9FGXK3KbLQX7Fbgz8_gLwX-B5VEWS0="
+        }
+      """
+    * def createLaoIdNegativeTime =
+      """
+        function(){
+          return "p8TW08AWlBScs9FGXK3KbLQX7Fbgz8_gLwX-B5VEWS0="
+        }
+      """
+    * def createLaoValid =
+      """
+        function(){
+          return "p_EYbHyMv6sopI5QhEXBf40MO_eNoq7V_LygBd4c9RA="
+        }
+      """
+
+    * def organizerPk =
+      """
+        function(){
+          return "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM="
+        }
+      """
+    * def getLaoIdEmptyName = call createLaoIdEmptyName
+    * def getLaoIdNegativeTime = call createLaoIdNegativeTime
+    * def getLaoValid = call createLaoValid
+    * def getOrganizer = call organizerPk
+    * def INTERNAL_SERVER_ERROR = {error: {code: -6, description: '#string'}}
+    * def INVALID_MESSAGE_FIELD = {error: {code: -4, description: '#string'}}
+    * def VALID_MESSAGE = {result: 0}

--- a/tests/karate/src/test/java/common/net/MultiMsgWebSocketClient.java
+++ b/tests/karate/src/test/java/common/net/MultiMsgWebSocketClient.java
@@ -1,8 +1,12 @@
 package common.net;
 
+import be.utils.JsonConverter;
+import com.intuit.karate.Json;
 import com.intuit.karate.Logger;
 import com.intuit.karate.http.WebSocketClient;
 import com.intuit.karate.http.WebSocketOptions;
+import com.intuit.karate.graal.JsMap;
+import net.minidev.asm.ConvertDate;
 
 /** A WebSocketClient that can handle multiple received messages */
 public class MultiMsgWebSocketClient extends WebSocketClient {
@@ -36,5 +40,28 @@ public class MultiMsgWebSocketClient extends WebSocketClient {
 
   public MessageBuffer getBuffer() {
     return queue;
+  }
+
+  public void publish(String data, int id, String channel){
+    JsonConverter jsonConverter = new JsonConverter();
+    Json request =  jsonConverter.publishМessageFromData(data, id, channel);
+    this.send(request.toString());
+  }
+
+  public String getBackendResponseWithBroadcast(String a){
+    String broadcast = getBuffer().takeTimeout(5000);
+    String result = getBuffer().takeTimeout(5000);
+    return result;
+  }
+
+  public String getBackendResponseWithoutBroadcast(){
+    String result = getBuffer().takeTimeout(5000);
+    return result;
+  }
+
+  public boolean receiveNoMoreResponses(){
+    String result_dummy = getBuffer().takeTimeout(5000);
+    String result = getBuffer().takeTimeout(5000);
+    return result == null;
   }
 }

--- a/tests/karate/src/test/java/common/net/MultiMsgWebSocketClient.java
+++ b/tests/karate/src/test/java/common/net/MultiMsgWebSocketClient.java
@@ -8,6 +8,8 @@ import com.intuit.karate.http.WebSocketOptions;
 import com.intuit.karate.graal.JsMap;
 import net.minidev.asm.ConvertDate;
 
+import java.util.Random;
+
 /** A WebSocketClient that can handle multiple received messages */
 public class MultiMsgWebSocketClient extends WebSocketClient {
 
@@ -42,15 +44,18 @@ public class MultiMsgWebSocketClient extends WebSocketClient {
     return queue;
   }
 
-  public void publish(String data, int id, String channel){
+  public void publish(String data, String channel){
     JsonConverter jsonConverter = new JsonConverter();
+    Random random = new Random();
+    int id = random.nextInt();
     Json request =  jsonConverter.publishМessageFromData(data, id, channel);
     this.send(request.toString());
   }
 
-  public String getBackendResponseWithBroadcast(String a){
-    String broadcast = getBuffer().takeTimeout(5000);
-    String result = getBuffer().takeTimeout(5000);
+  public String getBackendResponseWithBroadcast(){
+    String answer1 = getBuffer().takeTimeout(5000);
+    String answer2 = getBuffer().takeTimeout(5000);
+    String result = answer1.contains("result") ? answer1 : answer2;
     return result;
   }
 
@@ -60,7 +65,6 @@ public class MultiMsgWebSocketClient extends WebSocketClient {
   }
 
   public boolean receiveNoMoreResponses(){
-    String result_dummy = getBuffer().takeTimeout(5000);
     String result = getBuffer().takeTimeout(5000);
     return result == null;
   }


### PR DESCRIPTION
Karate is not a straightforward framework and gets some time to get used to, in order for developers that do not want to understand the functionality of the karate tests we decide to create tests that are somewhat similar to human readable language, so that anyone who has the basic understanding of the PoP protocol can read and even write a karate test more easily. This wasy it is more developer and reader friendly. 

This PR addresses the first step towards this easy reading tests and addresses the basic building blocks for these kind of tests and transforms the already existent LAO create karate tests into tests that respect this paradigm we want to achieve. 