### PR TITLE
Fix Crash on LAO launch with BE1

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
@@ -1181,7 +1181,7 @@ public class LaoDetailViewModel extends AndroidViewModel
                 lao -> {
                   Log.d(TAG, "got an update for lao: " + lao.getName());
                   mCurrentLao.postValue(lao);
-                  boolean isOrganizer = lao.getOrganizer().equals(keyManager.getMainPublicKey());
+                  boolean isOrganizer = keyManager.getMainPublicKey().equals(lao.getOrganizer());
                   mIsOrganizer.setValue(isOrganizer);
                 }));
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
@@ -1181,7 +1181,7 @@ public class LaoDetailViewModel extends AndroidViewModel
                 lao -> {
                   Log.d(TAG, "got an update for lao: " + lao.getName());
                   mCurrentLao.postValue(lao);
-                  boolean isOrganizer = keyManager.getMainPublicKey().equals(lao.getOrganizer());
+                  boolean isOrganizer = lao.getOrganizer().equals(keyManager.getMainPublicKey());
                   mIsOrganizer.setValue(isOrganizer);
                 }));
   }


### PR DESCRIPTION
Solves a bug I introduced with #955. The current implementation starts the LAO with some of the the attributes being null. This fixes it by only launching when the catch up is received. 