### PR TITLE
Fix bug in RollCallOpened

### DIFF
--- a/fe1-web/src/features/rollCall/screens/RollCallOpened.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallOpened.tsx
@@ -1,5 +1,5 @@
 import { useNavigation, useRoute } from '@react-navigation/core';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, View, ViewStyle } from 'react-native';
 import { Badge } from 'react-native-elements';
 import { useToast } from 'react-native-toast-notifications';
@@ -32,6 +32,9 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     margin: Spacing.xs,
   } as ViewStyle,
+  qrScanner: {
+    width: '30%',
+  },
 });
 
 const tokenMatcher = new RegExp('^[A-Za-z0-9_-]{43}=$');
@@ -41,7 +44,7 @@ const RollCallOpened = () => {
   const navigation = useNavigation<any>();
   const route = useRoute<any>();
   const { rollCallID } = route.params;
-  const [attendees, updateAttendees] = useState(new Set<string>());
+  const [attendeePopTokens, updateAttendeePopTokens] = useState(new Set<string>());
   const [inputModalIsVisible, setInputModalIsVisible] = useState(false);
   const toast = useToast();
   const lao = useSelector(selectCurrentLao);
@@ -56,54 +59,35 @@ const RollCallOpened = () => {
     throw new Error('Impossible to open a Roll Call that does not exist');
   }
 
-  // This will run only when the state changes
-  useEffect(() => {
-    if (!lao || !lao.id || !toast) {
-      return;
-    }
+  const handleError = useCallback(
+    (err: any) => {
+      console.error(err.toString());
+      toast.show(err.toString(), {
+        type: 'danger',
+        placement: 'top',
+        duration: FOUR_SECONDS,
+      });
+    },
+    [toast],
+  );
 
-    const addOwnToken = async () => {
-      try {
-        const tok = await Wallet.generateToken(lao.id, rollCall.id);
-        updateAttendees((prev) => new Set<string>([...prev, tok.publicKey.valueOf()]));
-      } catch (err) {
-        toast.show(`Could not generate organizer's PoP token, error: ${err}`, {
-          type: 'danger',
+  const addAttendeePopToken = useCallback(
+    (popToken: string) =>
+      updateAttendeePopTokens(new Set<string>([...attendeePopTokens, popToken])),
+    [updateAttendeePopTokens, attendeePopTokens],
+  );
+
+  const addAttendeePopTokenAndShowToast = (popToken: string, toastMessage: string) => {
+    if (tokenMatcher.test(popToken)) {
+      // only show a toast if an actual *new* token is added
+      if (!attendeePopTokens.has(popToken)) {
+        addAttendeePopToken(popToken);
+        toast.show(toastMessage, {
+          type: 'success',
           placement: 'top',
           duration: FOUR_SECONDS,
         });
       }
-    };
-
-    // Add the token of the organizer as soon as we open the roll call
-    if (!rollCall.attendees) {
-      addOwnToken().catch((e) => console.error(e));
-    }
-  }, [lao, rollCall, toast]);
-
-  const handleError = (err: any) => {
-    console.error(err.toString());
-    toast.show(err.toString(), {
-      type: 'danger',
-      placement: 'top',
-      duration: FOUR_SECONDS,
-    });
-  };
-
-  const addAttendeeAndShowToast = (attendee: string, toastMessage: string) => {
-    if (!attendees.has(attendee)) {
-      updateAttendees((prev) => new Set<string>(prev.add(attendee)));
-      toast.show(toastMessage, {
-        type: 'success',
-        placement: 'top',
-        duration: FOUR_SECONDS,
-      });
-    }
-  };
-
-  const handleEnterManually = (input: string) => {
-    if (tokenMatcher.test(input)) {
-      addAttendeeAndShowToast(input, STRINGS.roll_call_participant_added);
     } else {
       toast.show(STRINGS.roll_call_invalid_token, {
         type: 'danger',
@@ -113,26 +97,43 @@ const RollCallOpened = () => {
     }
   };
 
-  const onCloseRollCall = () => {
-    const screenAttendeesList = Array.from(attendees).map((key: string) => new PublicKey(key));
+  const onCloseRollCall = async () => {
+    const screenAttendeesList = Array.from(attendeePopTokens).map(
+      (key: string) => new PublicKey(key),
+    );
     const attendeesList = rollCall.attendees
       ? rollCall.attendees.concat(screenAttendeesList)
       : screenAttendeesList;
+
     if (!rollCall.idAlias) {
       throw new Error('Trying to close a roll call that has no idAlias defined');
     }
-    return requestCloseRollCall(rollCall.idAlias, attendeesList)
-      .then(() => {
-        navigation.navigate(STRINGS.organizer_navigation_tab_home);
-      })
-      .catch((err) => {
-        toast.show(`Could not close roll call, error: ${err}`, {
-          type: 'danger',
-          placement: 'top',
-          duration: FOUR_SECONDS,
-        });
+
+    try {
+      await requestCloseRollCall(rollCall.idAlias, attendeesList);
+      navigation.navigate(STRINGS.organizer_navigation_tab_home);
+    } catch (err) {
+      toast.show(`Could not close roll call, error: ${err}`, {
+        type: 'danger',
+        placement: 'top',
+        duration: FOUR_SECONDS,
       });
+    }
   };
+
+  // This will run only when the state changes
+  useEffect(() => {
+    if (!lao?.id) {
+      return;
+    }
+
+    // Add the token of the organizer as soon as we open the roll call
+    if (!rollCall.attendees) {
+      Wallet.generateToken(lao.id, rollCall.id)
+        .then((popToken) => addAttendeePopToken(popToken.publicKey.valueOf()))
+        .catch(handleError);
+    }
+  }, [lao, rollCall, addAttendeePopToken, handleError]);
 
   return (
     <View style={containerStyles.flex}>
@@ -142,13 +143,13 @@ const RollCallOpened = () => {
           delay={300}
           onScan={(data) => {
             if (data) {
-              addAttendeeAndShowToast(data, STRINGS.roll_call_scan_participant);
+              addAttendeePopTokenAndShowToast(data, STRINGS.roll_call_scan_participant);
             }
           }}
           onError={handleError}
-          style={{ width: '30%' }}
+          style={[styles.qrScanner]}
         />
-        <Badge value={attendees.size} status="success" />
+        <Badge value={attendeePopTokens.size} status="success" />
         <WideButtonView title={STRINGS.roll_call_scan_close} onPress={() => onCloseRollCall()} />
         <WideButtonView
           title={STRINGS.roll_call_add_attendee_manually}
@@ -160,7 +161,7 @@ const RollCallOpened = () => {
         setVisibility={setInputModalIsVisible}
         title={STRINGS.roll_call_modal_add_attendee}
         description={STRINGS.roll_call_modal_enter_token}
-        onConfirmPress={handleEnterManually}
+        onConfirmPress={addAttendeePopTokenAndShowToast}
         buttonConfirmText={STRINGS.general_add}
         hasTextInput
         textInputPlaceholder={STRINGS.roll_call_attendee_token_placeholder}

--- a/fe1-web/src/features/rollCall/screens/__tests__/RollCallOpened.test.tsx
+++ b/fe1-web/src/features/rollCall/screens/__tests__/RollCallOpened.test.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 // @ts-ignore
 import { fireScan as fakeQrReaderScan } from 'react-qr-reader';
 import * as reactRedux from 'react-redux';
-import keyPair from 'test_data/keypair.json';
 
 import { mockLao, mockLaoId, mockLaoName, mockPopToken } from '__tests__/utils/TestUtils';
 import { Hash, PublicKey, Timestamp } from 'core/objects';
@@ -14,7 +13,8 @@ import STRINGS from 'resources/strings';
 import { requestCloseRollCall as mockRequestCloseRollCall } from '../../network/RollCallMessageApi';
 import RollCallOpened from '../RollCallOpened';
 
-const mockPublicKey2 = new PublicKey(keyPair.publicKey2);
+const mockPublicKey2 = new PublicKey('mockPublicKey2_fFcHDaVHcCcY8IBfHE7auXJ7h4ms=');
+const mockPublicKey3 = new PublicKey('mockPublicKey3_fFcHDaVHcCcY8IBfHE7auXJ7h4ms=');
 
 const TIMESTAMP = 1609455600;
 const time = new Timestamp(TIMESTAMP).toString(); // 1st january 2021
@@ -71,6 +71,10 @@ describe('RollCallOpened', () => {
   it('renders correctly when scanning attendees', async () => {
     const { toJSON } = render(<RollCallOpened />);
     await waitFor(async () => {
+      // scan valid pop tokens
+      fakeQrReaderScan(mockPublicKey2.valueOf());
+      fakeQrReaderScan(mockPublicKey3.valueOf());
+      // scan invalid pop tokens
       fakeQrReaderScan('123');
       fakeQrReaderScan('456');
       expect(generateTokenMock).toHaveBeenCalled();
@@ -81,8 +85,8 @@ describe('RollCallOpened', () => {
   it('shows toast when scanning attendees', async () => {
     render(<RollCallOpened />);
     await waitFor(async () => {
-      fakeQrReaderScan('123');
-      fakeQrReaderScan('456');
+      fakeQrReaderScan(mockPublicKey2.valueOf());
+      fakeQrReaderScan(mockPublicKey3.valueOf());
       expect(generateTokenMock).toHaveBeenCalled();
     });
     expect(mockToastShow).toHaveBeenCalledTimes(2);
@@ -93,7 +97,7 @@ describe('RollCallOpened', () => {
     const addAttendeeButton = getByText(STRINGS.roll_call_add_attendee_manually);
     fireEvent.press(addAttendeeButton);
     const textInput = getByPlaceholderText(STRINGS.roll_call_attendee_token_placeholder);
-    fireEvent.changeText(textInput, mockPublicKey2.valueOf());
+    fireEvent.changeText(textInput, mockPopToken.publicKey.valueOf());
     const confirmButton = getByText(STRINGS.general_add);
     fireEvent.press(confirmButton);
     await waitFor(() => {
@@ -126,14 +130,14 @@ describe('RollCallOpened', () => {
   it('closes correctly with two attendees', async () => {
     const button = render(<RollCallOpened />).getByText(STRINGS.roll_call_scan_close);
     await waitFor(() => {
-      fakeQrReaderScan('123');
-      fakeQrReaderScan('456');
+      fakeQrReaderScan(mockPublicKey2.valueOf());
+      fakeQrReaderScan(mockPublicKey3.valueOf());
       expect(generateTokenMock).toHaveBeenCalled();
     });
     fireEvent.press(button);
     expect(mockRequestCloseRollCall).toHaveBeenCalledWith(expect.anything(), [
-      new PublicKey('123'),
-      new PublicKey('456'),
+      mockPublicKey2,
+      mockPublicKey3,
       mockPopToken.publicKey,
     ]);
   });


### PR DESCRIPTION
This PR fixes smaller issues in RollCallOpened:
- Check all scanned tokens whether they are valid (base64 strings of a given length). (Prevents the lao connection qr code from being added as a pop token)
- Add token of the organizer if it failed the first time, setup his wallet afterwards and then re-opens the rollcall
- Deduplicate pop tokens when merging the newly scanned ones (after re-opening) with the old ones
- Remove inline style