### PR TITLE
Added vote id verification on be1

### DIFF
--- a/be1-go/channel/election/mod.go
+++ b/be1-go/channel/election/mod.go
@@ -67,8 +67,8 @@ type Channel struct {
 
 // question represents a question in an election.
 type question struct {
-	// ID represents the id of the question.
-	id []byte
+	// ID represents the ID of the question.
+	ID []byte
 
 	// ballotOptions represents different ballot options.
 	ballotOptions []string
@@ -655,7 +655,7 @@ func getAllQuestionsForElectionChannel(questions []messagedata.ElectionSetupQues
 		copy(ballotOpts, q.BallotOptions)
 
 		qs[q.ID] = &question{
-			id:            []byte(q.ID),
+			ID:            []byte(q.ID),
 			ballotOptions: ballotOpts,
 			validVotesMu:  sync.RWMutex{},
 			validVotes:    make(map[string]validVote),

--- a/be1-go/channel/election/verification.go
+++ b/be1-go/channel/election/verification.go
@@ -132,10 +132,10 @@ func (c *Channel) verifyMessageCastVote(castVote messagedata.VoteCastVote) error
 		sort.Ints(vote.Vote)
 		sortedIndex := arrayToString(vote.Vote, ",")
 
-		hash := messagedata.Hash("Vote", electionID, string(qs.id), sortedIndex)
+		hash := messagedata.Hash("Vote", electionID, string(qs.ID), sortedIndex)
 
 		if vote.ID != hash {
-			return xerrors.Errorf("vote ID of vote %d is %s should be %s", i, vote.ID, hash)
+			return xerrors.Errorf("vote ID of vote %d is incorrect", i)
 		}
 	}
 

--- a/be1-go/channel/election/verification_test.go
+++ b/be1-go/channel/election/verification_test.go
@@ -287,3 +287,10 @@ func TestVerify_ElectionEnd_already_closed(t *testing.T) {
 	err = electChannel.verifyMessageElectionEnd(electionEnd)
 	require.Error(t, err)
 }
+
+func Test_Array_To_String(t *testing.T) {
+	a := []int{0, 1, 3, 5, 7, 9, 0}
+
+	require.Equal(t, "0,1,3,5,7,9,0", arrayToString(a, ","))
+	require.Equal(t, "0.1.3.5.7.9.0", arrayToString(a, "."))
+}


### PR DESCRIPTION
This PR is a fix for #942 and #929 where vote IDs and question IDs were not checked in the verification of the message.