### PR TITLE
Fix a bug occuring sometimes when ending an election

### DIFF
--- a/fe1-web/src/features/evoting/network/messages/EndElection.ts
+++ b/fe1-web/src/features/evoting/network/messages/EndElection.ts
@@ -65,15 +65,14 @@ export class EndElection implements MessageData {
   }
 
   public static computeRegisteredVotesHash(election: Election) {
-    // sort array in-place
-    election.registeredVotes
+    // sort mutates the array in-place, but this can be the object retrieved from the store
+    // thus we should create a copy
+    const sortedVoteIds = [...election.registeredVotes]
       // First sort by timestamp, than by message ID as tiebreaker
       .sort((a, b) => {
         const tiebreaker = a.messageId.valueOf() < b.messageId.valueOf() ? -1 : 1;
         return a !== b ? a.createdAt - b.createdAt : tiebreaker;
-      });
-
-    const sortedVoteIds = election.registeredVotes
+      })
       // Now expand each registered vote to the contained vote ids
       // flatMap = map + flatten array
       .flatMap((registeredVote) => registeredVote.votes.map((vote) => vote.id));


### PR DESCRIPTION
`.sort()` mutates arrays in place and since data retrieved from the redux store (sometimes?) is immutable, this will throw an error.

To circumvent this issue, we can just create a copy of the votes before sorting them. Another option would be to always sort them when updating an election object but this makes it less clear that the order for `computeRegisteredVotesHash` is important.