### PR TITLE
fix make check in be1 windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,8 +137,14 @@ jobs:
         run: make check-fmt ; if [ "$(gofmt -s -l ./ | wc -l)" -gt 0 ]; then exit 1; fi
 
       - name: Run check target
+        if: ${{ matrix.platform == 'ubuntu-latest' }}
         run: |
           make check
+
+      - name: Run test target
+        if: ${{ matrix.platform == 'windows-latest' }}
+        run: |
+          make test
 
       - name: Run go vet
         run: |


### PR DESCRIPTION
Coverage computation almost always fail, in be1 windows even though all tests pass and coverage is computed in be1 ubuntu