### PR TITLE
Update election#cast_vote implementation

### DIFF
--- a/fe1-web/src/features/events/objects/__tests__/LaoEventBuilder.test.ts
+++ b/fe1-web/src/features/events/objects/__tests__/LaoEventBuilder.test.ts
@@ -56,7 +56,7 @@ describe('LaoEventBuilder', () => {
     const registeredVotes: RegisteredVote = {
       createdAt: 1520255700,
       sender: 'Sender1',
-      votes: [{ id: 'v1', question: 'q1', vote: [0] }],
+      votes: [{ id: 'v1', question: 'q1', vote: 0 }],
       messageId: 'messageId1',
     };
     const election: ElectionState = {

--- a/fe1-web/src/features/evoting/__tests__/utils.ts
+++ b/fe1-web/src/features/evoting/__tests__/utils.ts
@@ -68,8 +68,8 @@ export const mockRegisteredVotes: RegisteredVote[] = [
     messageId: '0',
     sender: 'sender 1',
     votes: [
-      { id: 'id1', question: 'q1', vote: [0] },
-      { id: 'id2', question: 'q2', vote: [0] },
+      { id: 'id1', question: 'q1', vote: 0 },
+      { id: 'id2', question: 'q2', vote: 0 },
     ],
   },
   {
@@ -77,8 +77,8 @@ export const mockRegisteredVotes: RegisteredVote[] = [
     messageId: '1',
     sender: 'sender 2',
     votes: [
-      { id: 'id3', question: 'q3', vote: [0] },
-      { id: 'id4', question: 'q4', vote: [0] },
+      { id: 'id3', question: 'q3', vote: 0 },
+      { id: 'id4', question: 'q4', vote: 0 },
     ],
   },
 ];
@@ -135,22 +135,22 @@ export const mockElectionTerminated = new Election({
 
 export const mockRegistedVotesHash = EndElection.computeRegisteredVotesHash(mockElectionOpened);
 
-export const mockVoteVotes1 = new Set([0]);
-export const mockVoteVotes2 = new Set([1, 0]);
+export const mockVoteOption1 = 0;
+export const mockVoteOption2 = 1;
 
-export const mockVoteId1 = CastVote.computeVoteId(mockElectionNotStarted, 0, mockVoteVotes1);
-export const mockVoteId2 = CastVote.computeVoteId(mockElectionNotStarted, 1, mockVoteVotes2);
+export const mockVoteId1 = CastVote.computeVoteId(mockElectionNotStarted, 0, mockVoteOption1);
+export const mockVoteId2 = CastVote.computeVoteId(mockElectionNotStarted, 1, mockVoteOption2);
 
 export const mockVote1: Vote = {
   id: mockVoteId1.toString(),
   question: mockQuestionId1.valueOf(),
-  vote: [0],
+  vote: 0,
 };
 
 export const mockVote2: Vote = {
   id: mockVoteId2.toString(),
   question: mockQuestionId2.valueOf(),
-  vote: [1],
+  vote: 1,
 };
 
 export const mockVotes = [mockVote1];

--- a/fe1-web/src/features/evoting/components/ElectionOpened.tsx
+++ b/fe1-web/src/features/evoting/components/ElectionOpened.tsx
@@ -67,9 +67,14 @@ const ElectionOpened = ({ election, questions, isOrganizer }: IPropTypes) => {
                 key={q.title + idx.toString()}
                 title={q.title}
                 values={q.data}
-                onChange={(values: number[]) =>
-                  setSelectedBallots({ ...selectedBallots, [idx]: new Set(values) })
-                }
+                clickableOptions={1}
+                onChange={(values: number[]) => {
+                  if (values.length > 1) {
+                    throw new Error('Only single vote elections are supported');
+                  }
+
+                  setSelectedBallots({ ...selectedBallots, [idx]: values[0] });
+                }}
               />
             ))}
             <WideButtonView title={STRINGS.cast_vote} onPress={onCastVote} />

--- a/fe1-web/src/features/evoting/components/__tests__/EventElection.test.tsx
+++ b/fe1-web/src/features/evoting/components/__tests__/EventElection.test.tsx
@@ -59,7 +59,7 @@ const registeredVote: RegisteredVote = {
   createdAt: 0,
   messageId: '',
   sender: '',
-  votes: [{ id: '', question: '', vote: [0] }],
+  votes: [{ id: '', question: '', vote: 0 }],
 };
 
 const questionResult: QuestionResult = {

--- a/fe1-web/src/features/evoting/network/__tests__/ElectionMessageApi.test.ts
+++ b/fe1-web/src/features/evoting/network/__tests__/ElectionMessageApi.test.ts
@@ -115,7 +115,7 @@ describe('openElection', () => {
 
 describe('castVote', () => {
   it('works as expected using a valid set of parameters (open ballot)', () => {
-    const selectedBallots: SelectedBallots = { 0: new Set([0]), 1: new Set([1]) };
+    const selectedBallots: SelectedBallots = { 0: 0, 1: 1 };
 
     castVote(mockElectionNotStarted, undefined, selectedBallots);
 
@@ -144,7 +144,7 @@ describe('castVote', () => {
   });
 
   it('works as expected using a valid set of parameters (secret ballot)', () => {
-    const selectedBallots: SelectedBallots = { 0: new Set([3]), 1: new Set([7]) };
+    const selectedBallots: SelectedBallots = { 0: 3, 1: 7 };
     const keyPair = ElectionKeyPair.generate();
 
     castVote(mockSecretBallotElectionNotStarted, keyPair.publicKey, selectedBallots);
@@ -168,17 +168,14 @@ describe('castVote', () => {
     );
 
     expect(castVoteMessage.votes.length).toEqual(2);
-    expect(castVoteMessage.votes[0].vote.length).toEqual(1);
-    expect(castVoteMessage.votes[1].vote.length).toEqual(1);
-
-    expect(castVoteMessage.votes[0].vote[0]).toBeString();
-    expect(castVoteMessage.votes[1].vote[0]).toBeString();
+    expect(castVoteMessage.votes[0].vote).toBeString();
+    expect(castVoteMessage.votes[1].vote).toBeString();
 
     expect(
-      keyPair.privateKey.decrypt(castVoteMessage.votes[0].vote[0] as string).readIntBE(0, 2),
+      keyPair.privateKey.decrypt(castVoteMessage.votes[0].vote as string).readIntBE(0, 2),
     ).toEqual(3);
     expect(
-      keyPair.privateKey.decrypt(castVoteMessage.votes[1].vote[0] as string).readIntBE(0, 2),
+      keyPair.privateKey.decrypt(castVoteMessage.votes[1].vote as string).readIntBE(0, 2),
     ).toEqual(7);
 
     expect(publish).toHaveBeenCalledTimes(1);

--- a/fe1-web/src/features/evoting/network/messages/CastVote.ts
+++ b/fe1-web/src/features/evoting/network/messages/CastVote.ts
@@ -64,7 +64,7 @@ export class CastVote implements MessageData {
       if (!vote.question) {
         throw new ProtocolError("Undefined 'question id' parameter encountered during 'CastVote'");
       }
-      if (!vote.vote) {
+      if (vote.vote === undefined) {
         throw new ProtocolError("Undefined 'vote' parameters encountered during 'CastVote'");
       }
     });
@@ -103,9 +103,9 @@ export class CastVote implements MessageData {
       throw new Error('selectedBallotsToVotes() should only be called on open ballot elections');
     }
     // Convert object to array
-    const ballotArray = Object.entries(selectedBallots).map(([idx, selectionOptions]) => ({
+    const ballotArray = Object.entries(selectedBallots).map(([idx, selectedOptionIndex]) => ({
       index: parseInt(idx, 10),
-      selectionOptions,
+      selectedOptionIndex,
     }));
 
     // sort the answers by index
@@ -114,13 +114,13 @@ export class CastVote implements MessageData {
     return (
       ballotArray
         // and add an id to all votes as well as the matching question id
-        .map<Vote>(({ index, selectionOptions }) => ({
+        .map<Vote>(({ index, selectedOptionIndex }) => ({
           // generate the vote id
-          id: CastVote.computeVoteId(election, index, selectionOptions).valueOf(),
+          id: CastVote.computeVoteId(election, index, selectedOptionIndex).valueOf(),
           // find matching question id from the election
           question: election.questions[index].id,
           // convert the set to an array and sort votes in ascending order
-          vote: [...selectionOptions].sort((a, b) => a - b),
+          vote: selectedOptionIndex,
         }))
     );
   }
@@ -144,9 +144,9 @@ export class CastVote implements MessageData {
     }
 
     // Convert object to array
-    const ballotArray = Object.entries(selectedBallots).map(([idx, selectionOptions]) => ({
+    const ballotArray = Object.entries(selectedBallots).map(([idx, selectedOptionIndex]) => ({
       index: parseInt(idx, 10),
-      selectionOptions,
+      selectedOptionIndex,
     }));
 
     // sort the answers by index
@@ -155,33 +155,27 @@ export class CastVote implements MessageData {
     return (
       ballotArray
         // and add an id to all votes as well as the matching question id
-        .map<EncryptedVote>(({ index, selectionOptions }) => {
-          // convert the set to an array, sort votes in ascending order and encrypt the indices
-          const encryptedOptionIndices = [...selectionOptions]
-            .sort((a, b) => a - b)
-            // map each number to 2 bytes using big endian
-            .map((option) => {
-              if (option >= MAX_OPTION_INDEX) {
-                throw new Error(
-                  `The selected option index ${option} is greater than ${MAX_OPTION_INDEX}. This is not supported`,
-                );
-              }
+        .map<EncryptedVote>(({ index, selectedOptionIndex }) => {
+          if (selectedOptionIndex >= MAX_OPTION_INDEX) {
+            throw new Error(
+              `The selected option index ${selectedOptionIndex} is greater than ${MAX_OPTION_INDEX}. This is not supported`,
+            );
+          }
 
-              // allocUnsafe is fine, we will overwrite all bytes
-              const buffer = Buffer.allocUnsafe(2);
-              // write 2 bytes using big endian
-              buffer.writeIntBE(option, 0, 2);
+          // allocUnsafe is fine, we will overwrite all bytes
+          const buffer = Buffer.allocUnsafe(2);
+          // write 2 bytes using big endian
+          buffer.writeIntBE(selectedOptionIndex, 0, 2);
 
-              return electionKey.encrypt(buffer);
-            });
+          const encryptedOptionIndex = electionKey.encrypt(buffer);
 
           return {
             // generate the vote id based on the **encrypted** option indices
-            id: CastVote.computeSecretVoteId(election, index, encryptedOptionIndices).valueOf(),
+            id: CastVote.computeSecretVoteId(election, index, encryptedOptionIndex).valueOf(),
             // find matching question id from the election
             question: election.questions[index].id,
             // use the encrypted votes
-            vote: encryptedOptionIndices,
+            vote: encryptedOptionIndex,
           };
         })
     );
@@ -190,64 +184,40 @@ export class CastVote implements MessageData {
   /**
    * Generates a vote id as described in
    * https://github.com/dedis/popstellar/blob/master/protocol/query/method/message/data/dataCastVote.json
-   * HashLen('Vote', election_id, question_id, (vote_index(es)|write_in)), concatenate vote indexes - must use delimiter
    * @param election The election for which this vote id is generated
    * @param questionIndex The index of the question in the given election, this vote is cast for
-   * @param selectionOptions The selected option indices
+   * @param selectionOptionIndex The selected option index
    */
   public static computeVoteId(
     election: Election,
     questionIndex: number,
-    selectionOptions: Set<number>,
+    selectionOptionIndex: number,
   ): Hash {
     return Hash.fromStringArray(
       EventTags.VOTE,
       election.id.toString(),
       election.questions[questionIndex].id,
-      // Important: A standardized order is required, otherwise the hash cannot be verified
-      // Even more important: A standardized delimiter has to be used to disambiguate [1,0] from [10]
-      // See https://github.com/dedis/popstellar/issues/843 for details
-      [...selectionOptions]
-        // sort in ascending order
-        .sort((a, b) => a - b)
-        // convert to strings
-        .map((idx) => idx.toString())
-        // concatenate and add delimiter in between strings
-        .join(','),
+      selectionOptionIndex.toString(),
     );
   }
 
   /**
    * Generates a vote id for a secret ballot election as described in
    * https://github.com/dedis/popstellar/blob/master/protocol/query/method/message/data/dataCastVote.json
-   * HashLen('Vote', election_id, question_id, (enc(vote_index(es))|enc(write_in))), concatenate encrypted vote indices - must use delimiter ','
    * @param election The election for which this vote id is generated
    * @param questionIndex The index of the question in the given election, this vote is cast for
-   * @param encryptedOptionIndices The encrypted selected option indices
+   * @param encryptedOptionIndex The encrypted selected option indices
    */
   public static computeSecretVoteId(
     election: Election,
     questionIndex: number,
-    encryptedOptionIndices: Set<string> | string[],
+    encryptedOptionIndex: string,
   ): Hash {
     return Hash.fromStringArray(
       EventTags.VOTE,
       election.id.toString(),
       election.questions[questionIndex].id,
-      // Important: A standardized order is required, otherwise the hash cannot be verified
-      // Even more important: A standardized delimiter has to be used to disambiguate [1,0] from [10]
-      [...encryptedOptionIndices]
-        // sort in alphabetical order
-        .sort((a, b) => {
-          if (a === b) {
-            return 0;
-          }
-          return a < b ? -1 : 1;
-        })
-        // convert to strings
-        .map((idx) => idx.toString())
-        // concatenate and add delimiter in between strings
-        .join(','),
+      encryptedOptionIndex,
     );
   }
 }

--- a/fe1-web/src/features/evoting/network/messages/__tests__/CastVote.test.ts
+++ b/fe1-web/src/features/evoting/network/messages/__tests__/CastVote.test.ts
@@ -160,49 +160,49 @@ describe('CastVote', () => {
     it('returns true if all fields are defined', () => {
       expect(() => CastVote.validateVotes([])).not.toThrow();
       expect(() =>
-        CastVote.validateVotes([{ id: 'someId', question: 'q', vote: [0] }]),
+        CastVote.validateVotes([{ id: 'someId', question: 'q', vote: 0 }]),
       ).not.toThrow();
     });
 
     it('returns false if some fields are undefined', () => {
       expect(() =>
         CastVote.validateVotes([
-          { id: 'someId', question: 'q', vote: undefined as unknown as string[] },
+          { id: 'someId', question: 'q', vote: undefined as unknown as string },
         ]),
       ).toThrow(ProtocolError);
 
       expect(() =>
         CastVote.validateVotes([
-          { id: 'someId', question: undefined as unknown as string, vote: [0] },
+          { id: 'someId', question: undefined as unknown as string, vote: 0 },
         ]),
       ).toThrow(ProtocolError);
 
       expect(() =>
-        CastVote.validateVotes([{ id: undefined as unknown as string, question: 'q', vote: [0] }]),
+        CastVote.validateVotes([{ id: undefined as unknown as string, question: 'q', vote: 0 }]),
       ).toThrow(ProtocolError);
     });
   });
 
   describe('selectedBallotsToVotes', () => {
     it('should convert the selected ballot options to votes', () => {
-      const q1SelectedOptions = new Set([0]);
-      const q2SelectedOptions = new Set([1]);
+      const q1SelectedOption = 0;
+      const q2SelectedOption = 1;
 
       expect(
         CastVote.selectedBallotsToVotes(mockElectionOpened, {
-          0: q1SelectedOptions,
-          1: q2SelectedOptions,
+          0: q1SelectedOption,
+          1: q2SelectedOption,
         }),
       ).toEqual([
         {
-          id: CastVote.computeVoteId(mockElectionOpened, 0, q1SelectedOptions).valueOf(),
+          id: CastVote.computeVoteId(mockElectionOpened, 0, q1SelectedOption).valueOf(),
           question: mockElectionOpened.questions[0].id,
-          vote: [...q1SelectedOptions],
+          vote: q1SelectedOption,
         },
         {
-          id: CastVote.computeVoteId(mockElectionOpened, 1, q2SelectedOptions).valueOf(),
+          id: CastVote.computeVoteId(mockElectionOpened, 1, q2SelectedOption).valueOf(),
           question: mockElectionOpened.questions[1].id,
-          vote: [...q2SelectedOptions],
+          vote: q2SelectedOption,
         },
       ] as Vote[]);
     });
@@ -210,8 +210,8 @@ describe('CastVote', () => {
 
   describe('selectedBallotsToEncryptedVotes', () => {
     it('should throw an error if an option index is too big', () => {
-      const q1SelectedOptions = new Set([2 ** (2 * 8)]);
-      const q2SelectedOptions = new Set([1]);
+      const q1SelectedOption = 2 ** (2 * 8);
+      const q2SelectedOption = 1;
 
       const keyPair = ElectionKeyPair.generate();
 
@@ -220,16 +220,16 @@ describe('CastVote', () => {
           mockSecretBallotElectionNotStarted,
           keyPair.publicKey,
           {
-            0: q1SelectedOptions,
-            1: q2SelectedOptions,
+            0: q1SelectedOption,
+            1: q2SelectedOption,
           },
         ),
       ).toThrow('not supported');
     });
 
     it('should converted the selected ballots to encrypted votes', () => {
-      const q1SelectedOptions = new Set([0]);
-      const q2SelectedOptions = new Set([1]);
+      const q1SelectedOption = 0;
+      const q2SelectedOption = 1;
 
       const keyPair = ElectionKeyPair.generate();
 
@@ -237,8 +237,8 @@ describe('CastVote', () => {
         mockSecretBallotElectionNotStarted,
         keyPair.publicKey,
         {
-          0: q1SelectedOptions,
-          1: q2SelectedOptions,
+          0: q1SelectedOption,
+          1: q2SelectedOption,
         },
       );
 
@@ -248,7 +248,7 @@ describe('CastVote', () => {
       // by computing the hashes for all combinations and then comapring them
       expect(encryptedVotes[0]).not.toHaveProperty(
         'id',
-        CastVote.computeVoteId(mockSecretBallotElectionNotStarted, 0, q1SelectedOptions).valueOf(),
+        CastVote.computeVoteId(mockSecretBallotElectionNotStarted, 0, q1SelectedOption).valueOf(),
       );
       // but rather the encrypted one!
       expect(encryptedVotes[0]).toHaveProperty(
@@ -264,13 +264,13 @@ describe('CastVote', () => {
         'question',
         mockSecretBallotElectionNotStarted.questions[0].id,
       );
-      expect(encryptedVotes[0].vote.length).toBe(1);
-      expect(keyPair.privateKey.decrypt(encryptedVotes[0].vote[0]).readIntBE(0, 2)).toEqual(0);
+
+      expect(keyPair.privateKey.decrypt(encryptedVotes[0].vote).readIntBE(0, 2)).toEqual(0);
 
       // we should **not** hash the unencrypted vote id, this allows recovering the option index
       expect(encryptedVotes[1]).not.toHaveProperty(
         'id',
-        CastVote.computeVoteId(mockSecretBallotElectionNotStarted, 1, q2SelectedOptions).valueOf(),
+        CastVote.computeVoteId(mockSecretBallotElectionNotStarted, 1, q2SelectedOption).valueOf(),
       );
       // but rather the encrypted one!
       expect(encryptedVotes[1]).toHaveProperty(
@@ -286,41 +286,28 @@ describe('CastVote', () => {
         'question',
         mockSecretBallotElectionNotStarted.questions[1].id,
       );
-      expect(encryptedVotes[1].vote.length).toBe(1);
-      expect(keyPair.privateKey.decrypt(encryptedVotes[1].vote[0]).readIntBE(0, 2)).toEqual(1);
+
+      expect(keyPair.privateKey.decrypt(encryptedVotes[1].vote).readIntBE(0, 2)).toEqual(1);
     });
   });
 
   describe('computeVoteId', () => {
     it('should compute the id correctly', () => {
-      expect(
-        CastVote.computeVoteId(mockSecretBallotElectionNotStarted, 0, new Set([0])).valueOf(),
-      ).toEqual('_SVW5OOqfjZIFn8gwrwhm81-RRgW4WBbsLpHeRe-9I4=');
+      expect(CastVote.computeVoteId(mockSecretBallotElectionNotStarted, 0, 1).valueOf()).toEqual(
+        'Vkhz3iMQNos2qhgvAFj9hXtG92UagFzoiEsLu68r7_8=',
+      );
 
-      expect(
-        CastVote.computeVoteId(mockSecretBallotElectionNotStarted, 0, new Set([1, 0])).valueOf(),
-      ).toEqual('Tgnuii1h06f3M-48F2KYpkE0bIswn77_uS0UrDB5UjA=');
-
-      expect(
-        CastVote.computeVoteId(mockSecretBallotElectionNotStarted, 1, new Set([0])).valueOf(),
-      ).toEqual('pt7i7mgdcAP92dnaxu70R359bbVvGk98PKwpZ-xNBgg=');
-
-      expect(
-        CastVote.computeVoteId(mockSecretBallotElectionNotStarted, 1, new Set([1, 0])).valueOf(),
-      ).toEqual('1fvmPteows90i_bj2B8FLsN3I8Jexk7WxiYHxFaSYOU=');
+      expect(CastVote.computeVoteId(mockSecretBallotElectionNotStarted, 1, 0).valueOf()).toEqual(
+        'pt7i7mgdcAP92dnaxu70R359bbVvGk98PKwpZ-xNBgg=',
+      );
     });
   });
 
   describe('computeSecretVoteId', () => {
     it('should compute the id correctly', () => {
       const mockEncryptedVotes1: EncryptedVote[] = [
-        { id: 'id0', question: 'q0', vote: ['x'] },
-        { id: 'id1', question: 'q1', vote: ['a'] },
-      ];
-
-      const mockEncryptedVotes2: EncryptedVote[] = [
-        { id: 'id0', question: 'q0', vote: ['x', 'y'] },
-        { id: 'id1', question: 'q1', vote: ['a', 'b'] },
+        { id: 'id0', question: 'q0', vote: 'x' },
+        { id: 'id1', question: 'q1', vote: 'a' },
       ];
 
       expect(
@@ -334,26 +321,10 @@ describe('CastVote', () => {
       expect(
         CastVote.computeSecretVoteId(
           mockSecretBallotElectionNotStarted,
-          0,
-          mockEncryptedVotes2[0].vote,
-        ).valueOf(),
-      ).toEqual('m66Xw10lvl7p1-vmFTAIyPdHbYq1ckiLkBiXsUxFCrA=');
-
-      expect(
-        CastVote.computeSecretVoteId(
-          mockSecretBallotElectionNotStarted,
           1,
           mockEncryptedVotes1[1].vote,
         ).valueOf(),
       ).toEqual('P_2lbeTRmrm1BdMX2LuNyENtJLnknnVovp9m5V8QSf0=');
-
-      expect(
-        CastVote.computeSecretVoteId(
-          mockSecretBallotElectionNotStarted,
-          1,
-          mockEncryptedVotes2[1].vote,
-        ).valueOf(),
-      ).toEqual('ayB8VMZHcAhNSbGWZ4k6wNcTZ_oA_4BGHpnU4fDm4YA=');
     });
   });
 });

--- a/fe1-web/src/features/evoting/objects/Election.ts
+++ b/fe1-web/src/features/evoting/objects/Election.ts
@@ -45,17 +45,17 @@ export interface Question {
 export interface Vote {
   id: string;
   question: string;
-  vote: number[];
+  vote: number;
 }
 
 export interface EncryptedVote {
   id: string;
   question: string;
-  vote: string[];
+  vote: string;
 }
 
 // This type ensures that for each question there is a unique set of option indices
-export type SelectedBallots = { [questionIndex: number]: Set<number> };
+export type SelectedBallots = { [questionIndex: number]: number };
 
 export interface RegisteredVote {
   createdAt: number;

--- a/fe1-web/src/features/evoting/objects/__tests__/Election.test.ts
+++ b/fe1-web/src/features/evoting/objects/__tests__/Election.test.ts
@@ -44,7 +44,7 @@ const initializeData = () => {
   vote1 = {
     id: 'v1',
     question: 'q1',
-    vote: [0],
+    vote: 0,
   };
 
   registeredVotes = {


### PR DESCRIPTION
This PR updates the implementation to reflect the specification changes discussed on slack

> Hello,
> Given the current specification of the secret-ballot cast_vote the indexes are encrypted and then sent in an array (it is now an array of encrypted strings). I found that it could be a vulnerability when we allow multiple choice questions because if only one attendee sends two choices, we can then link the votes to the sender even with shuffling.
> There are multiple solution to this problem (that I could find),
> We can disallow multiple choice in secret ballot, update the specs and continue to run like this. (The problem with this is that for future/current pop students that will want to add new voting methods, they will have to redo the implementation that we are doing now)
> We can still have an array of plain text indices but then encrypt the whole vote and encode it in base64. (The problem with this is that the encryption that we use has an upper limit to the size of the data to be encrypted and with multiple choice the data could grow without limit and if you started implementing the other way you would have to change your implementation)
> What do you think is the right way to go ?

Where we decided for option 1.