### PR TITLE
data: add pubkey hashes

### DIFF
--- a/tests/data/keypair.json
+++ b/tests/data/keypair.json
@@ -1,6 +1,8 @@
 {
     "publicKey": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
     "privateKey": "0leCDBokllJXKXT72psnqF5UYFVRxnc1BNDShY05KHQn18HMlXvQmTlz6LfbvtSrgKZ4vi3ndYN9SCForQel4w==",
+    "publicKeyHash": "-_qR4IHwsiq50raa8jURNArds54=",
     "publicKey2": "oKHk3AivbpNXk_SfFcHDaVHcCcY8IBfHE7auXJ7h4ms=",
-    "privateKey2": "DPUR0v5MIL67a9UcGnzpc9It4z1xLd9faaktmeh5NjugoeTcCK9uk1eT9J8VwcNpUdwJxjwgF8cTtq5cnuHiaw=="
+    "privateKey2": "DPUR0v5MIL67a9UcGnzpc9It4z1xLd9faaktmeh5NjugoeTcCK9uk1eT9J8VwcNpUdwJxjwgF8cTtq5cnuHiaw==",
+    "publicKeyHash2": "SGnNfF533PBEUMYPMqBSQY83z5U="
 }


### PR DESCRIPTION
This augments the test public keys with their respective public key hashes. The hashes were computed by [this notebook](https://gist.github.com/lourkeur/886e1a7ac93957a10f9543d52c4290fd), verified with BE2, and meet the digital cash specification.