### PR TITLE
Add support for witness messages in scala back end

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandler.scala
@@ -1,27 +1,44 @@
 package ch.epfl.pop.pubsub.graph.handlers
 
 import ch.epfl.pop.model.network.JsonRpcRequest
-import ch.epfl.pop.model.network.method.message.Message
 import ch.epfl.pop.model.network.method.message.data.witness.WitnessMessage
-import ch.epfl.pop.model.objects.{Hash, WitnessSignaturePair}
-import ch.epfl.pop.pubsub.graph.GraphMessage
+import ch.epfl.pop.model.objects.{Channel, DbActorNAckException, Hash, Signature, WitnessSignaturePair}
+import ch.epfl.pop.pubsub.graph.{ErrorCodes, GraphMessage, PipelineError}
+import ch.epfl.pop.storage.DbActor
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.Await
+import scala.util.{Failure, Success}
 
 case object WitnessHandler extends MessageHandler {
 
   def handleWitnessMessage(rpcMessage: JsonRpcRequest): GraphMessage = {
     val decodedData: WitnessMessage = rpcMessage.getDecodedData.get.asInstanceOf[WitnessMessage]
     val messageId: Hash = decodedData.message_id
+    val signature: Signature = decodedData.signature
+    val channel: Channel = rpcMessage.getParamsChannel
 
-    // get message (Message) with messageId message_id from db
-    var message: Message = ???
-
-    // add new witness signature to existing ones
-    message = message.addWitnessSignature(WitnessSignaturePair(message.sender, message.signature))
-
-    // overwrite message in db
-    val ask: Future[GraphMessage] = ??? // dbAskWritePropagate(rpcMessage, message)
-    Await.result(ask, duration)
+    rpcMessage.getParamsMessage match {
+      case Some(witnessMessage) =>
+        // get message (Message) with messageId message_id from db
+        val askRead = dbActor ? DbActor.Read(channel, messageId)
+        Await.ready(askRead, duration).value match {
+          case Some(Success(DbActor.DbActorReadAck(Some(message)))) =>
+            // add new witness signature to existing ones
+            message.addWitnessSignature(WitnessSignaturePair(witnessMessage.sender, signature))
+            val askWritePropagate = dbActor ? DbActor.WriteAndPropagate(channel, message)
+            Await.result(askWritePropagate, duration) match {
+              case Success(_) => Left(rpcMessage)
+              case Failure(ex: DbActorNAckException) => Right(PipelineError(ex.code, s"handleWitnessMessage failed : ${ex.message}", rpcMessage.getId))
+              case reply => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleWitnessMessage failed : unexpected DbActor reply '$reply'", rpcMessage.getId))
+            }
+          case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleWitnessMessage failed : ${ex.message}", rpcMessage.getId))
+          case reply => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleWitnessMessage failed : unexpected DbActor reply '$reply'", rpcMessage.getId))
+        }
+      case _ => Right(PipelineError(
+        ErrorCodes.SERVER_ERROR.id,
+        s"Unable to handle witness message $rpcMessage. Not a AddWitness message",
+        rpcMessage.id
+      ))
+    }
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandler.scala
@@ -6,9 +6,11 @@ import ch.epfl.pop.model.network.method.message.data.witness.WitnessMessage
 import ch.epfl.pop.model.objects.{Channel, DbActorNAckException, Hash, Signature}
 import ch.epfl.pop.pubsub.graph.{ErrorCodes, GraphMessage, PipelineError}
 import ch.epfl.pop.storage.DbActor
+import ch.epfl.pop.storage.DbActor.DbActorAddWitnessMessage
 
 import scala.concurrent.Await
 import scala.util.{Failure, Success}
+import scala.concurrent.ExecutionContext.Implicits.global
 
 /**
  * WitnessHandler object uses the db instance from the MessageHandler
@@ -35,20 +37,18 @@ class WitnessHandler(dbRef: => AskableActorRef) extends MessageHandler {
 
     rpcMessage.getParamsMessage match {
       case Some(_) =>
+        val combined = for {
           // add new witness signature to existing ones
-          val askAddWitness =  dbActor ? DbActor.AddWitnessSignature(channel, messageId, signature)
-          Await.ready(askAddWitness, duration).value match {
-            case Some(Success(DbActor.DbActorAddWitnessMessage(witnessMessage))) =>
-              //overwrites the message containing now the witness signature in the db
-              val askWritePropagate = dbActor ? DbActor.WriteAndPropagate(channel, witnessMessage)
-              Await.ready(askWritePropagate, duration).value.get match {
-                case Success(_) => Left(rpcMessage)
-                case Failure(ex: DbActorNAckException) => Right(PipelineError(ex.code, s"handleWitnessMessage failed : ${ex.message}", rpcMessage.getId))
-                case reply => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleWitnessMessage failed : unknown DbActor reply $reply", rpcMessage.getId))
-              }
-            case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleWitnessMessage failed : ${ex.message}", rpcMessage.getId))
-            case reply => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleWitnessMessage failed : unknown DbActor reply $reply", rpcMessage.getId))
-          }
+          DbActorAddWitnessMessage(witnessMessage) <- dbActor ? DbActor.AddWitnessSignature(channel, messageId, signature)
+          //overwrites the message containing now the witness signature in the db
+          _ <- dbActor ? DbActor.WriteAndPropagate(channel, witnessMessage)
+        } yield ()
+
+        Await.ready(combined, duration).value.get match {
+          case Success(_) => Left(rpcMessage)
+          case Failure(ex: DbActorNAckException) => Right(PipelineError(ex.code, s"handleWitnessMessage failed : ${ex.message}", rpcMessage.getId))
+          case reply => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleWitnessMessage failed : unknown DbActor reply $reply", rpcMessage.getId))
+        }
 
       case _ => Right(PipelineError(
         ErrorCodes.SERVER_ERROR.id,

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandler.scala
@@ -2,7 +2,7 @@ package ch.epfl.pop.pubsub.graph.handlers
 
 import ch.epfl.pop.model.network.JsonRpcRequest
 import ch.epfl.pop.model.network.method.message.data.witness.WitnessMessage
-import ch.epfl.pop.model.objects.{Channel, DbActorNAckException, Hash, Signature, WitnessSignaturePair}
+import ch.epfl.pop.model.objects.{Channel, DbActorNAckException, Hash, Signature}
 import ch.epfl.pop.pubsub.graph.{ErrorCodes, GraphMessage, PipelineError}
 import ch.epfl.pop.storage.DbActor
 import ch.epfl.pop.storage.DbActor.DbActorAddWitnessMessage
@@ -36,7 +36,7 @@ case object WitnessHandler extends MessageHandler {
 
       case _ => Right(PipelineError(
         ErrorCodes.SERVER_ERROR.id,
-        s"Unable to handle witness message $rpcMessage. Not a AddWitnessSignature message",
+        s"Unable to handle witness message $rpcMessage. Not an AddWitnessSignature message",
         rpcMessage.id
       ))
     }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/ElectionValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/ElectionValidator.scala
@@ -85,7 +85,7 @@ sealed class ElectionValidator(dbActorRef: => AskableActorRef) extends MessageDa
 
         if (!validateTimestampStaleness(data.opened_at)) {
           Right(validationError(s"stale 'opened_at' timestamp (${data.opened_at})"))
-        } else if (electionId !=  data.election) {
+        } else if (electionId != data.election) {
           Right(validationError("Unexpected election id"))
         } else if (laoId != data.lao) {
           Right(validationError("Unexpected lao id"))

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidator.scala
@@ -1,6 +1,11 @@
 package ch.epfl.pop.pubsub.graph.validators
 
 import ch.epfl.pop.model.network.JsonRpcRequest
+import ch.epfl.pop.model.network.method.message.Message
+import ch.epfl.pop.model.network.method.message.data.ObjectType
+import ch.epfl.pop.model.network.method.message.data.witness.WitnessMessage
+import ch.epfl.pop.model.objects.{Channel, Hash, PublicKey, Signature}
+import ch.epfl.pop.pubsub.graph.validators.MessageValidator.{validateChannelType, validateOwner}
 import ch.epfl.pop.pubsub.graph.{GraphMessage, PipelineError}
 
 
@@ -9,7 +14,24 @@ case object WitnessValidator extends MessageDataContentValidator {
     def validationError(reason: String): PipelineError = super.validationError(reason, "WitnessMessage", rpcMessage.id)
 
     rpcMessage.getParamsMessage match {
-      case Some(_) => Left(rpcMessage)
+      case Some(message: Message) =>
+        val data: WitnessMessage = message.decodedData.get.asInstanceOf[WitnessMessage]
+        val signature: Signature = data.signature
+        val messageId: Hash = data.message_id
+        val sender: PublicKey = message.sender
+
+        val channel: Channel = rpcMessage.getParamsChannel
+
+        //check if the signature in the message received is valid
+        if (!signature.verify(sender, messageId.base64Data)) {
+          Right(validationError("verification of the signature over the message id failed"))
+        } else if (!validateOwner(sender, channel)) {
+          Right(validationError(s"invalid sender $sender"))
+        } else if (!validateChannelType(ObjectType.LAO, channel)) {
+          Right(validationError(s"trying to send a WitnessMessage message on a wrong type of channel $channel"))
+        } else {
+          Left(rpcMessage)
+        }
       case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidator.scala
@@ -23,7 +23,7 @@ case object WitnessValidator extends MessageDataContentValidator {
         val channel: Channel = rpcMessage.getParamsChannel
 
         //check if the signature in the message received is valid
-        //not sure thought .. 
+        //not sure thought ..
         if (!signature.verify(sender, messageId.base64Data)) {
           Right(validationError("verification of the signature over the message id failed"))
         } else if (!validateOwner(sender, channel)) {

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidator.scala
@@ -23,6 +23,7 @@ case object WitnessValidator extends MessageDataContentValidator {
         val channel: Channel = rpcMessage.getParamsChannel
 
         //check if the signature in the message received is valid
+        //not sure thought .. 
         if (!signature.verify(sender, messageId.base64Data)) {
           Right(validationError("verification of the signature over the message id failed"))
         } else if (!validateOwner(sender, channel)) {

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandlerTest.scala
@@ -1,0 +1,125 @@
+package ch.epfl.pop.pubsub.graph.handlers
+
+import akka.actor.{Actor, ActorSystem, Props, Status}
+import akka.pattern.AskableActorRef
+import akka.testkit.{ImplicitSender, TestKit}
+import akka.util.Timeout
+import ch.epfl.pop.model.network.method.message.Message
+import ch.epfl.pop.model.objects.{Base64Data, DbActorNAckException, Hash, Signature, WitnessSignaturePair}
+import ch.epfl.pop.pubsub.graph.PipelineError
+import ch.epfl.pop.storage.DbActor
+import ch.epfl.pop.storage.DbActor.DbActorAddWitnessMessage
+import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import util.examples.data.WitnessMessages
+import util.examples.lao.CreateLaoExamples.{SENDER, createLao}
+
+import scala.concurrent.duration.FiniteDuration
+
+
+class WitnessHandlerTest extends TestKit(ActorSystem("Witness-DB-System")) with FunSuiteLike with ImplicitSender with Matchers with BeforeAndAfterAll {
+  // Implicits for system actors
+  implicit val duration: FiniteDuration = FiniteDuration(5, "seconds")
+  implicit val timeout: Timeout = Timeout(duration)
+
+  //arrange
+  final val message: Message = Message(
+    data = Base64Data("eyJvYmplY3QiOiJsYW8iLCJhY3Rpb24iOiJjcmVhdGUiLCJuYW1lIjoiTEFPIiwiY3JlYXRpb24iOjE2MzMwMzU3MjEsIm9yZ2FuaXplciI6Iko5ZkJ6SlY3MEprNWMtaTMyNzdVcTRDbWVMNHQ1M1dEZlVnaGFLMEhwZU09Iiwid2l0bmVzc2VzIjpbXSwiaWQiOiJwX0VZYkh5TXY2c29wSTVRaEVYQmY0ME1PX2VOb3E3Vl9MeWdCZDRjOVJBPSJ9"),
+    sender = SENDER,
+    signature = Signature(Base64Data("ONylxgHA9cbsB_lwdfbn3iyzRd4aTpJhBMnvEKhmJF_niE_pUHdmjxDXjEwFyvo5WiH1NZXWyXG27SYEpkasCA==")),
+    message_id = Hash(Base64Data("kAG_m4nEQXkguuO_LVphXFE_c_dPoQrHNsb0MvwhXTA=")),
+    witness_signatures = List.empty
+  )
+
+  val witnessSignature: Signature = Signature(Base64Data.encode("witnessSignature"))
+  val witnessMessage: Message = message.addWitnessSignature(WitnessSignaturePair(message.sender, witnessSignature))
+
+  override def afterAll(): Unit = {
+    // Stops the testKit
+    TestKit.shutdownActorSystem(system)
+  }
+
+  def mockDbWithNack: AskableActorRef = {
+    val dbActorMock = Props(new Actor() {
+      override def receive: Receive = {
+        case DbActor.WriteAndPropagate =>
+          system.log.info("Received a message")
+          system.log.info("Responding with a Nack")
+          sender() ! Status.Failure(DbActorNAckException(1, "error"))
+
+        case DbActor.AddWitnessSignature =>
+          system.log.info("Received a message")
+          system.log.info("Responding with a Nack")
+          sender() ! Status.Failure(DbActorNAckException(1, "error"))
+        case x =>
+          system.log.info(s"Received - error $x")
+      }
+    })
+    system.actorOf(dbActorMock, "MockedDB-NACK")
+  }
+
+  def mockDbWithAck: AskableActorRef = {
+    val dbActorMock = Props(new Actor() {
+      override def receive: Receive = {
+        case DbActor.WriteAndPropagate =>
+          system.log.info("Received a message")
+          system.log.info("Responding with a Ack")
+          sender() ! DbActor.DbActorAck()
+        case DbActor.AddWitnessSignature =>
+          system.log.info("Received a message")
+          system.log.info("Responding with a Ack")
+          sender() ! DbActorAddWitnessMessage(witnessMessage)
+        case x =>
+          system.log.info(s"Received - error $x")
+      }
+    })
+    system.actorOf(dbActorMock, "MockedDB-ACK")
+  }
+
+  def mockDbWithNackAddWitnessSignature: AskableActorRef = {
+    val dbActorMock = Props(new Actor() {
+      override def receive: Receive = {
+        case DbActor.WriteAndPropagate =>
+          system.log.info("Received a message")
+          system.log.info("Responding with a Ack")
+          sender() ! DbActor.DbActorAck()
+        case DbActor.AddWitnessSignature =>
+          system.log.info("Received a message")
+          system.log.info("Responding with a Nack")
+          sender() ! Status.Failure(DbActorNAckException(1, "error"))
+        case x =>
+          system.log.info(s"Received - error $x")
+      }
+    })
+    system.actorOf(dbActorMock, "MockedDBAddWitnessSignature-ACK")
+  }
+
+  test("WitnessMessage fails if the database fails storing the message") {
+    val mockedDB = mockDbWithNack
+    val rc = new WitnessHandler(mockedDB)
+    val request = WitnessMessages.witnessMessage
+
+    rc.handleWitnessMessage(request) shouldBe an[Right[PipelineError, _]]
+
+    system.stop(mockedDB.actorRef)
+  }
+
+  test("WitnessMessage succeeds if the database succeeds storing the message") {
+    val mockedDB = mockDbWithAck
+    val rc = new WitnessHandler(mockedDB)
+    val request = WitnessMessages.witnessMessage
+
+    rc.handleWitnessMessage(request) should equal(Left(request))
+
+    system.stop(mockedDB.actorRef)
+  }
+
+  test("WitnessMessage fails if the database fails adding a witness signature") {
+    val mockedDB = mockDbWithNackAddWitnessSignature
+    val rc = new WitnessHandler(mockedDB)
+    val request = WitnessMessages.witnessMessage
+
+    rc.handleWitnessMessage(request) shouldBe an[Right[PipelineError, _]]
+
+    system.stop(mockedDB.actorRef)
+  }
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/Lao/WitnessValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/Lao/WitnessValidatorSuite.scala
@@ -1,0 +1,123 @@
+package ch.epfl.pop.pubsub.graph.validators.Lao
+
+import akka.actor.{Actor, ActorRef, ActorSystem, Props}
+import akka.pattern.AskableActorRef
+import akka.testkit.{ImplicitSender, TestKit}
+import akka.util.Timeout
+import ch.epfl.pop.model.network.method.message.data.ObjectType
+import ch.epfl.pop.model.objects._
+import ch.epfl.pop.pubsub.graph.validators.WitnessValidator
+import ch.epfl.pop.pubsub.graph.{GraphMessage, PipelineError}
+import ch.epfl.pop.pubsub.{AskPatternConstants, MessageRegistry, PubSubMediator}
+import ch.epfl.pop.storage.{DbActor, InMemoryStorage}
+import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import util.examples.JsonRpcRequestExample._
+import util.examples.Witness.WitnessMessageExamples
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+import scala.reflect.io.Directory
+
+class WitnessValidatorSuite extends TestKit(ActorSystem("witnessValidatorTestActorSystem"))
+  with FunSuiteLike
+  with ImplicitSender
+  with Matchers with BeforeAndAfterAll with AskPatternConstants {
+
+  final val DB_TEST_FOLDER: String = "databaseWitnessTest"
+
+  val pubSubMediatorRef: ActorRef = system.actorOf(PubSubMediator.props, "PubSubMediator")
+  val dbActorRef: AskableActorRef = system.actorOf(Props(DbActor(pubSubMediatorRef, MessageRegistry(), InMemoryStorage())), "DbActor")
+
+  // Implicit for system actors
+  implicit val timeout: Timeout = Timeout(1, TimeUnit.SECONDS)
+
+  override def afterAll(): Unit = {
+    // Stops the testKit
+    TestKit.shutdownActorSystem(system)
+
+    // Deletes the test database
+    val directory = new Directory(new File(DB_TEST_FOLDER))
+    directory.deleteRecursively()
+  }
+
+  private final val PUBLIC_KEY: PublicKey = WitnessMessageExamples.SENDER
+  private final val PRIVATE_KEY: PrivateKey = WitnessMessageExamples.privateKey
+  private final val PK_WRONG_OWNER: PublicKey = PublicKey(Base64Data.encode("wrongOwner"))
+  private final val laoDataRight: LaoData = LaoData(PUBLIC_KEY, List(PUBLIC_KEY), PRIVATE_KEY, PUBLIC_KEY, List.empty)
+  private final val laoDataWrong: LaoData = LaoData(PK_WRONG_OWNER, List(PK_WRONG_OWNER), PRIVATE_KEY, PUBLIC_KEY, List.empty)
+  private final val channelData: ChannelData = ChannelData(ObjectType.LAO, List.empty)
+  private final val channelDataWrong: ChannelData = ChannelData(ObjectType.INVALID, List.empty)
+
+  private def mockDbWorking: AskableActorRef = {
+    val dbActorMock = Props(new Actor() {
+      override def receive: Receive = {
+        case DbActor.ReadLaoData(_) =>
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+        case DbActor.ReadChannelData(_) =>
+          sender() ! DbActor.DbActorReadChannelDataAck(channelData)
+      }
+    })
+    system.actorOf(dbActorMock)
+  }
+
+  private def mockDbWrongToken: AskableActorRef = {
+    val dbActorMock = Props(new Actor() {
+      override def receive: Receive = {
+        case DbActor.ReadLaoData(_) =>
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataWrong)
+        case DbActor.ReadChannelData(_) =>
+          sender() ! DbActor.DbActorReadChannelDataAck(channelData)
+      }
+    })
+    system.actorOf(dbActorMock)
+  }
+
+  private def mockDbWrongChannel: AskableActorRef = {
+    val dbActorMock = Props(new Actor() {
+      override def receive: Receive = {
+        case DbActor.ReadLaoData(_) =>
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+        case DbActor.ReadChannelData(_) =>
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataWrong)
+      }
+    })
+    system.actorOf(dbActorMock)
+  }
+
+  //WitnessMessage
+  test("Witnessing a message works as intended") {
+    val dbActorRef = mockDbWorking
+    val message: GraphMessage = new WitnessValidator(dbActorRef).validateWitnessMessage(WITNESS_MESSAGE_RPC)
+    message should equal(Left(ADD_CHIRP_RPC))
+    system.stop(dbActorRef.actorRef)
+  }
+
+  test("Witnessing a message without valid PoP token fails") {
+    val dbActorRef = mockDbWrongToken
+    val message: GraphMessage = new WitnessValidator(dbActorRef).validateWitnessMessage(WITNESS_MESSAGE_RPC)
+    message shouldBe a[Right[_, PipelineError]]
+    system.stop(dbActorRef.actorRef)
+  }
+
+  test("Witnessing a message on wrong type of channel fails") {
+    val dbActorRef = mockDbWrongChannel
+    val message: GraphMessage = new WitnessValidator(dbActorRef).validateWitnessMessage(WITNESS_MESSAGE_RPC)
+    message shouldBe a[Right[_, PipelineError]]
+    system.stop(dbActorRef.actorRef)
+  }
+
+  //not quite sure how to verify the signature
+  /*test("Witnessing a message with wrong signature fails") {
+    val dbActorRef = mockDbWorking
+    val message: GraphMessage = new WitnessValidator(dbActorRef).validateWitnessMessage(WITNESS_MESSAGE_WRONG_SIGNATURE_RPC)
+    message shouldBe a[Right[_, PipelineError]]
+    system.stop(dbActorRef.actorRef)
+  }*/
+
+  test("Validating a RpcMessage without Params does not work in validateAddChirp") {
+    val dbActorRef = mockDbWorking
+    val message: GraphMessage = new WitnessValidator(dbActorRef).validateWitnessMessage(RPC_NO_PARAMS)
+    message shouldBe a[Right[_, PipelineError]]
+    system.stop(dbActorRef.actorRef)
+  }
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/storage/DbActorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/storage/DbActorSuite.scala
@@ -410,6 +410,32 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     list should contain(message2)
   }
 
+  test("addWitnessSignature should not fail if the messageId is valid") {
+    //arrange
+    val storage: InMemoryStorage = InMemoryStorage()
+    val message: Message = MESSAGE
+    val messageId: Hash = message.message_id
+    val signature: Signature = Signature(Base64Data.encode("witnessSign")) //not valid signature, just to test storage
+
+    val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), storage)))
+
+    storage.size should equal (0)
+
+    //act
+    dbActor ! DbActor.CreateChannel(Channel(CHANNEL_NAME), ObjectType.LAO); sleep()
+    // writing to the previously created channel
+    dbActor ! DbActor.Write(Channel(CHANNEL_NAME), MESSAGE); sleep()
+    dbActor ! DbActor.AddWitnessSignature(Channel(CHANNEL_NAME), messageId, signature)
+
+    message.addWitnessSignature(WitnessSignaturePair(message.sender, signature))
+
+    //assert
+    expectMsg(DbActor.DbActorAck())
+    storage.size should equal (2)
+    storage.elements(CHANNEL_NAME) should equal (ChannelData(ObjectType.LAO, MESSAGE.message_id :: Nil).toJsonString)
+    storage.elements(s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}") should equal (message.toJsonString)
+  }
+
   test("catchup should not fail on a channel with ChannelData containing missing message_ids (and only return valid messages)"){
     // arrange
     val channelName1: Channel = Channel(CHANNEL_NAME)

--- a/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
+++ b/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
@@ -8,6 +8,7 @@ import util.examples.Election.OpenElectionExamples._
 import util.examples.Election.SetupElectionExamples._
 import util.examples.Election.EndElectionExamples._
 import util.examples.MessageExample._
+import util.examples.Witness.WitnessMessageExamples._
 import util.examples.socialMedia.AddChirpExamples._
 import util.examples.socialMedia.AddReactionExamples._
 import util.examples.socialMedia.DeleteChirpExamples._
@@ -130,6 +131,15 @@ object JsonRpcRequestExample {
   final val END_ELECTION_WRONG_ID_RPC: JsonRpcRequest = JsonRpcRequest(rpc, methodType, paramsWithEndElectionWrongId, id)
   final val END_ELECTION_WRONG_LAO_ID_RPC: JsonRpcRequest = JsonRpcRequest(rpc, methodType, paramsWithEndElectionWrongLaoId, id)
   final val END_ELECTION_WRONG_OWNER_RPC: JsonRpcRequest = JsonRpcRequest(rpc, methodType, paramsWithEndElectionWrongOwner, id)
+
+  //for WitnessMessage testing
+  private final val laoChannel: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + Base64Data.encode("laoId"))
+  private final val paramsWithWitnessMessage: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_WITNESS_MESSAGE_WORKING)
+  private final val paramsWithWitnessMessageWrongSignature: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_WITNESS_MESSAGE_WRONG_SIGNATURE)
+  private final val paramsWithWitnessMessageWrongOwner: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_WITNESS_MESSAGE_WRONG_OWNER)
+  final val WITNESS_MESSAGE_RPC: JsonRpcRequest = JsonRpcRequest(rpc, methodType, paramsWithWitnessMessage, id)
+  final val WITNESS_MESSAGE_WRONG_SIGNATURE_RPC: JsonRpcRequest = JsonRpcRequest(rpc, methodType, paramsWithWitnessMessageWrongSignature, id)
+  final val WITNESS_MESSAGE_WRONG_SENDER_RPC: JsonRpcRequest = JsonRpcRequest(rpc, methodType, paramsWithWitnessMessageWrongOwner, id)
 
   // broadcast JsonRpcRequest
   final val broadcastRpcRequest: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.BROADCAST, paramsWithMessage, None)

--- a/be2-scala/src/test/scala/util/examples/Witness/WitnessMessageExamples.scala
+++ b/be2-scala/src/test/scala/util/examples/Witness/WitnessMessageExamples.scala
@@ -1,0 +1,52 @@
+package util.examples.Witness
+
+import ch.epfl.pop.json.MessageDataProtocol._
+import ch.epfl.pop.model.network.method.message.Message
+import ch.epfl.pop.model.network.method.message.data.witness.WitnessMessage
+import ch.epfl.pop.model.objects._
+import com.google.crypto.tink.subtle.Ed25519Sign
+import spray.json._
+
+
+object WitnessMessageExamples {
+
+  val keyPair: Ed25519Sign.KeyPair = Ed25519Sign.KeyPair.newKeyPair
+  val privateKey: PrivateKey = PrivateKey(Base64Data.encode(keyPair.getPrivateKey))
+  val SENDER: PublicKey = PublicKey(Base64Data.encode(keyPair.getPublicKey))
+
+  final val SIGNATURE: Signature = Signature(Base64Data("ONylxgHA9cbsB_lwdfbn3iyzRd4aTpJhBMnvEKhmJF_niE_pUHdmjxDXjEwFyvo5WiH1NZXWyXG27SYEpkasCA=="))
+  final val MESSAGE_ID: Hash = Hash(Base64Data.encode("messageId"))
+  final val WITNESS_SIGNATURE: Signature = privateKey.signData(MESSAGE_ID.base64Data)
+
+  val invalidSender: PublicKey = PublicKey(Base64Data.encode("wrong"))
+  val invalidSignature: Signature = Signature(Base64Data.encode("wrongSignature"))
+
+  val workingWitnessMessage: WitnessMessage = WitnessMessage(MESSAGE_ID, SIGNATURE)
+  final val MESSAGE_WITNESS_MESSAGE_WORKING: Message = Message(
+    Base64Data.encode(workingWitnessMessage.toJson.toString),
+    SENDER,
+    SIGNATURE,
+    Hash(Base64Data("")),
+    List.empty,
+    Some(workingWitnessMessage)
+  )
+
+  val wrongSignatureWitnessMessage: WitnessMessage = WitnessMessage(MESSAGE_ID, invalidSignature)
+  final val MESSAGE_WITNESS_MESSAGE_WRONG_SIGNATURE: Message = new Message(
+    Base64Data.encode(wrongSignatureWitnessMessage.toJson.toString),
+    SENDER,
+    SIGNATURE,
+    Hash(Base64Data("")),
+    List.empty,
+    Some(wrongSignatureWitnessMessage)
+  )
+
+  final val MESSAGE_WITNESS_MESSAGE_WRONG_OWNER: Message = new Message(
+    Base64Data.encode(workingWitnessMessage.toJson.toString),
+    invalidSender,
+    SIGNATURE,
+    Hash(Base64Data("")),
+    List.empty,
+    Some(workingWitnessMessage)
+  )
+}

--- a/be2-scala/src/test/scala/util/examples/data/WitnessMessages.scala
+++ b/be2-scala/src/test/scala/util/examples/data/WitnessMessages.scala
@@ -1,0 +1,21 @@
+package util.examples.data
+
+import ch.epfl.pop.model.network.JsonRpcRequest
+import ch.epfl.pop.model.network.method.message.data.ActionType
+import ch.epfl.pop.model.network.method.message.data.ActionType.ActionType
+import ch.epfl.pop.model.objects.{Base64Data, Channel}
+import util.examples.data.traits.WitnessMessagesTrait
+
+/**
+ * Generates high level Witness Messages from protocol folder
+ * For content validation: all the params are required
+ */
+object WitnessMessages extends WitnessMessagesTrait {
+
+  override val action: ActionType = ActionType.WITNESS
+  override val CHANNEL: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + Base64Data.encode("witness_message_channel"))
+
+  final val witnessMessage: JsonRpcRequest = getJsonRPCRequestFromFile("message_witness.json")()
+
+}
+

--- a/be2-scala/src/test/scala/util/examples/data/WitnessMessages.scala
+++ b/be2-scala/src/test/scala/util/examples/data/WitnessMessages.scala
@@ -7,7 +7,7 @@ import ch.epfl.pop.model.objects.{Base64Data, Channel}
 import util.examples.data.traits.WitnessMessagesTrait
 
 /**
- * Generates high level Witness Messages from protocol folder
+ * Generates high level Election Messages from protocol folder
  * For content validation: all the params are required
  */
 object WitnessMessages extends WitnessMessagesTrait {
@@ -18,4 +18,3 @@ object WitnessMessages extends WitnessMessagesTrait {
   final val witnessMessage: JsonRpcRequest = getJsonRPCRequestFromFile("message_witness.json")()
 
 }
-

--- a/be2-scala/src/test/scala/util/examples/data/builders/HighLevelMessageGenerator.scala
+++ b/be2-scala/src/test/scala/util/examples/data/builders/HighLevelMessageGenerator.scala
@@ -6,6 +6,7 @@ import ch.epfl.pop.model.network.method.message.data.election.{OpenElection, Set
 import ch.epfl.pop.model.network.method.message.data.rollCall.{CloseRollCall, CreateRollCall, OpenRollCall}
 import ch.epfl.pop.model.network.method.message.data.socialMedia._
 import ch.epfl.pop.model.network.method.message.data.coin._
+import ch.epfl.pop.model.network.method.message.data.witness.WitnessMessage
 import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType}
 import ch.epfl.pop.model.network.{JsonRpcRequest, MethodType}
 import ch.epfl.pop.model.objects._
@@ -152,6 +153,12 @@ object HighLevelMessageGenerator {
 
         case (ObjectType.ELECTION, ActionType.OPEN) =>
           messageData = OpenElection.buildFromJson(payload)
+          params = new ParamsWithMessage(paramsChannel, message.withDecodedData(messageData).toMessage)
+          JsonRpcRequest(RpcValidator.JSON_RPC_VERSION, methodType, params, id)
+
+        //Witness
+        case (ObjectType.MESSAGE, ActionType.WITNESS) =>
+          messageData = WitnessMessage.buildFromJson(payload)
           params = new ParamsWithMessage(paramsChannel, message.withDecodedData(messageData).toMessage)
           JsonRpcRequest(RpcValidator.JSON_RPC_VERSION, methodType, params, id)
 

--- a/be2-scala/src/test/scala/util/examples/data/traits/WitnessMessagesTrait.scala
+++ b/be2-scala/src/test/scala/util/examples/data/traits/WitnessMessagesTrait.scala
@@ -1,0 +1,14 @@
+package util.examples.data.traits
+
+import ch.epfl.pop.model.network.MethodType
+import ch.epfl.pop.model.network.method.message.data.ObjectType
+import ch.epfl.pop.model.network.method.message.data.ObjectType.ObjectType
+
+/**
+ * Trait to be implemented by WitnessMessage examples
+ */
+trait WitnessMessagesTrait extends ExampleMessagesTrait {
+  override val obj: ObjectType = ObjectType.MESSAGE
+  override val METHOD_TYPE: MethodType.MethodType = MethodType.PUBLISH
+
+}

--- a/fe1-web/src/features/index.ts
+++ b/fe1-web/src/features/index.ts
@@ -57,7 +57,7 @@ export function configureFeatures() {
   const rollCallConfiguration = rollCall.configure(messageRegistry);
   const socialConfiguration = social.configure(messageRegistry);
   const witnessConfiguration = witness.configure({
-    enabled: false,
+    enabled: true,
     messageRegistry,
     useCurrentLaoId: laoConfiguration.hooks.useCurrentLaoId,
     getCurrentLao: laoConfiguration.functions.getCurrentLao,

--- a/fe1-web/src/features/witness/network/messages/WitnessRegistry.ts
+++ b/fe1-web/src/features/witness/network/messages/WitnessRegistry.ts
@@ -33,7 +33,7 @@ const k = (...args: string[]) => args.join(',');
 
 const WITNESSING_TYPE_MAP = new Map<string, WitnessEntry>([
   // Lao
-  [k(LAO, CREATE), { type: WitnessingType.PASSIVE }],
+  [k(LAO, CREATE), { type: WitnessingType.ACTIVE }],
   [k(LAO, STATE), { type: WitnessingType.NO_WITNESSING }],
   [k(LAO, UPDATE_PROPERTIES), { type: WitnessingType.NO_WITNESSING }],
 
@@ -43,8 +43,8 @@ const WITNESSING_TYPE_MAP = new Map<string, WitnessEntry>([
 
   // Roll call
   // FIXME: This is only set to ACTIVE for testing purposes of the witnessing feature
-  [k(ROLL_CALL, CREATE), { type: WitnessingType.PASSIVE }],
-  [k(ROLL_CALL, OPEN), { type: WitnessingType.NO_WITNESSING }],
+  [k(ROLL_CALL, CREATE), { type: WitnessingType.ACTIVE }],
+  [k(ROLL_CALL, OPEN), { type: WitnessingType.ACTIVE }],
   [k(ROLL_CALL, CLOSE), { type: WitnessingType.NO_WITNESSING }],
   [k(ROLL_CALL, REOPEN), { type: WitnessingType.NO_WITNESSING }],
 

--- a/fe1-web/src/features/witness/network/messages/WitnessRegistry.ts
+++ b/fe1-web/src/features/witness/network/messages/WitnessRegistry.ts
@@ -33,7 +33,7 @@ const k = (...args: string[]) => args.join(',');
 
 const WITNESSING_TYPE_MAP = new Map<string, WitnessEntry>([
   // Lao
-  [k(LAO, CREATE), { type: WitnessingType.NO_WITNESSING }],
+  [k(LAO, CREATE), { type: WitnessingType.PASSIVE }],
   [k(LAO, STATE), { type: WitnessingType.NO_WITNESSING }],
   [k(LAO, UPDATE_PROPERTIES), { type: WitnessingType.NO_WITNESSING }],
 
@@ -43,7 +43,7 @@ const WITNESSING_TYPE_MAP = new Map<string, WitnessEntry>([
 
   // Roll call
   // FIXME: This is only set to ACTIVE for testing purposes of the witnessing feature
-  [k(ROLL_CALL, CREATE), { type: WitnessingType.ACTIVE }],
+  [k(ROLL_CALL, CREATE), { type: WitnessingType.PASSIVE }],
   [k(ROLL_CALL, OPEN), { type: WitnessingType.NO_WITNESSING }],
   [k(ROLL_CALL, CLOSE), { type: WitnessingType.NO_WITNESSING }],
   [k(ROLL_CALL, REOPEN), { type: WitnessingType.NO_WITNESSING }],


### PR DESCRIPTION
- Implementation of the AddWitnessSignature in DbActor
- Implementation of handler and validator of WitnessMessage
- Tests for handler and validator of WitnessMessage 
**Question**: how to check the validity of the signature in the message WitnessMessage ?
_It needs to be tested more in depth with the frontend: tested with rollcall#create messages, and it seems to work_ 