### PR TITLE
Checking if election open is not before election setup create time

### DIFF
--- a/be1-go/channel/election/mod.go
+++ b/be1-go/channel/election/mod.go
@@ -37,6 +37,9 @@ type Channel struct {
 
 	// *baseChannel
 
+	// Creation time of the election
+	createdAt int64
+
 	// Starting time of the election
 	start int64
 
@@ -120,6 +123,7 @@ func NewChannel(channelPath string, msgData messagedata.ElectionSetup,
 		inbox:     inbox.NewInbox(channelPath),
 		channelID: channelPath,
 
+		createdAt:  msgData.CreatedAt,
 		start:      msgData.StartTime,
 		end:        msgData.EndTime,
 		started:    false,

--- a/be1-go/channel/election/verification.go
+++ b/be1-go/channel/election/verification.go
@@ -67,6 +67,10 @@ func (c *Channel) verifyMessageElectionOpen(electionOpen messagedata.ElectionOpe
 		return xerrors.Errorf("election was already started or terminated")
 	}
 
+	if electionOpen.OpenedAt < c.createdAt {
+		return xerrors.Errorf("election open cannot have a creation time prior to election setup")
+	}
+
 	return nil
 }
 

--- a/be1-go/channel/election/verification_test.go
+++ b/be1-go/channel/election/verification_test.go
@@ -103,7 +103,8 @@ func TestVerify_ElectionOpen_already_closed(t *testing.T) {
 }
 
 func TestVerify_ElectionOpen_created_time_less_than_create_time_setup(t *testing.T) {
-	// create the opened election channel with election open time less than election creation time
+	// create the opened election channel with election open time less than
+	// election creation time
 	electChannel, _ := newFakeChannel(t)
 
 	buf, err := os.ReadFile(filepath.Join(relativeMsgDataExamplePath, "election_open",

--- a/be1-go/channel/election/verification_test.go
+++ b/be1-go/channel/election/verification_test.go
@@ -102,6 +102,26 @@ func TestVerify_ElectionOpen_already_closed(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestVerify_ElectionOpen_created_time_less_than_create_time_setup(t *testing.T) {
+	// create the opened election channel with election open time less than election creation time
+	electChannel, _ := newFakeChannel(t)
+
+	buf, err := os.ReadFile(filepath.Join(relativeMsgDataExamplePath, "election_open",
+		"election_open.json"))
+	require.NoError(t, err)
+
+	var electionOpen messagedata.ElectionOpen
+
+	err = json.Unmarshal(buf, &electionOpen)
+	require.NoError(t, err)
+
+	electChannel.createdAt = electionOpen.OpenedAt + 100
+
+	// send the election open message to the channel
+	err = electChannel.verifyMessageElectionOpen(electionOpen)
+	require.Error(t, err)
+}
+
 func TestVerify_CastVote(t *testing.T) {
 	// create the election channel
 	electChannel, _ := newFakeChannel(t)

--- a/be1-go/channel/lao/mod.go
+++ b/be1-go/channel/lao/mod.go
@@ -625,7 +625,7 @@ func (c *Channel) createElection(msg message.Message,
 	// Check if the Lao ID of the message corresponds to the channel ID
 	channelID := c.channelID[6:]
 	if channelID != setupMsg.Lao {
-		return answer.NewErrorf(-4, "Lao ID of the message is %s, should be "+
+		return answer.NewInvalidMessageFieldError( "Lao ID of the message is %s, should be "+
 			"equal to the channel ID %s", setupMsg.Lao, channelID)
 	}
 

--- a/be1-go/channel/lao/mod.go
+++ b/be1-go/channel/lao/mod.go
@@ -551,7 +551,7 @@ func (c *Channel) verifyMessage(msg message.Message) error {
 
 	// Check if the message already exists
 	if _, ok := c.inbox.GetMessage(msg.MessageID); ok {
-		return answer.NewError(-3, "message already exists")
+		return answer.NewDuplicateResourceError("message already exists")
 	}
 
 	return nil
@@ -625,7 +625,7 @@ func (c *Channel) createElection(msg message.Message,
 	// Check if the Lao ID of the message corresponds to the channel ID
 	channelID := c.channelID[6:]
 	if channelID != setupMsg.Lao {
-		return answer.NewInvalidMessageFieldError( "Lao ID of the message is %s, should be "+
+		return answer.NewInvalidMessageFieldError("Lao ID of the message is %s, should be "+
 			"equal to the channel ID %s", setupMsg.Lao, channelID)
 	}
 
@@ -647,12 +647,12 @@ func (c *Channel) createElection(msg message.Message,
 
 func compareLaoUpdateAndState(update messagedata.LaoUpdate, state messagedata.LaoState) error {
 	if update.LastModified != state.LastModified {
-		return answer.NewErrorf(-4, "mismatch between last modified: expected %d got %d",
+		return answer.NewInvalidMessageFieldError("mismatch between last modified: expected %d got %d",
 			update.LastModified, state.LastModified)
 	}
 
 	if update.Name != state.Name {
-		return answer.NewErrorf(-4, "mismatch between name: expected %s got %s",
+		return answer.NewInvalidMessageFieldError("mismatch between name: expected %s got %s",
 			update.Name, state.Name)
 	}
 
@@ -660,7 +660,7 @@ func compareLaoUpdateAndState(update messagedata.LaoUpdate, state messagedata.La
 	N := len(state.Witnesses)
 
 	if M != N {
-		return answer.NewErrorf(-4, "mismatch between witness count: expected %d got %d", M, N)
+		return answer.NewInvalidMessageFieldError("mismatch between witness count: expected %d got %d", M, N)
 	}
 
 	match := 0
@@ -675,7 +675,7 @@ func compareLaoUpdateAndState(update messagedata.LaoUpdate, state messagedata.La
 	}
 
 	if match != M {
-		return answer.NewErrorf(-4, "mismatch between witness keys: expected %d keys to "+
+		return answer.NewInvalidMessageFieldError("mismatch between witness keys: expected %d keys to "+
 			"match but %d matched", M, match)
 	}
 

--- a/be1-go/channel/lao/mod.go
+++ b/be1-go/channel/lao/mod.go
@@ -647,12 +647,12 @@ func (c *Channel) createElection(msg message.Message,
 
 func compareLaoUpdateAndState(update messagedata.LaoUpdate, state messagedata.LaoState) error {
 	if update.LastModified != state.LastModified {
-		return answer.NewInvalidMessageFieldError("mismatch between last modified: expected %d got %d",
+		return answer.NewErrorf(-4, "mismatch between last modified: expected %d got %d",
 			update.LastModified, state.LastModified)
 	}
 
 	if update.Name != state.Name {
-		return answer.NewInvalidMessageFieldError("mismatch between name: expected %s got %s",
+		return answer.NewErrorf(-4, "mismatch between name: expected %s got %s",
 			update.Name, state.Name)
 	}
 
@@ -660,7 +660,7 @@ func compareLaoUpdateAndState(update messagedata.LaoUpdate, state messagedata.La
 	N := len(state.Witnesses)
 
 	if M != N {
-		return answer.NewInvalidMessageFieldError("mismatch between witness count: expected %d got %d", M, N)
+		return answer.NewErrorf(-4, "mismatch between witness count: expected %d got %d", M, N)
 	}
 
 	match := 0
@@ -675,7 +675,7 @@ func compareLaoUpdateAndState(update messagedata.LaoUpdate, state messagedata.La
 	}
 
 	if match != M {
-		return answer.NewInvalidMessageFieldError("mismatch between witness keys: expected %d keys to "+
+		return answer.NewErrorf(-4, "mismatch between witness keys: expected %d keys to "+
 			"match but %d matched", M, match)
 	}
 

--- a/tests/karate/src/test/java/be/ServerTest.java
+++ b/tests/karate/src/test/java/be/ServerTest.java
@@ -34,15 +34,15 @@ public class ServerTest {
   Karate testElectionOpen(){
     return Karate.run("classpath:be/election/electionOpen.feature");
   }
-  @Karate.Test
-  Karate testCastVote(){
-    return Karate.run("classpath:be/election/castVote.feature");
-  }
-
-  @Karate.Test
-  Karate testElectionEnd(){
-    return Karate.run("classpath:be/election/electionEnd.feature");
-  }
+//  @Karate.Test
+//  Karate testCastVote(){
+//    return Karate.run("classpath:be/election/castVote.feature");
+//  }
+//
+//  @Karate.Test
+//  Karate testElectionEnd(){
+//    return Karate.run("classpath:be/election/electionEnd.feature");
+//  }
 }
 
 

--- a/tests/karate/src/test/java/be/ServerTest.java
+++ b/tests/karate/src/test/java/be/ServerTest.java
@@ -34,15 +34,15 @@ public class ServerTest {
   Karate testElectionOpen(){
     return Karate.run("classpath:be/election/electionOpen.feature");
   }
-//  @Karate.Test
-//  Karate testCastVote(){
-//    return Karate.run("classpath:be/election/castVote.feature");
-//  }
-//
-//  @Karate.Test
-//  Karate testElectionEnd(){
-//    return Karate.run("classpath:be/election/electionEnd.feature");
-//  }
+  @Karate.Test
+  Karate testCastVote(){
+    return Karate.run("classpath:be/election/castVote.feature");
+  }
+
+  @Karate.Test
+  Karate testElectionEnd(){
+    return Karate.run("classpath:be/election/electionEnd.feature");
+  }
 }
 
 


### PR DESCRIPTION
In the current state of the system we could have an election open time that is prior to election creation time, which does not make sense timewise and thus this PR inserts a check that will prevent a misuse of this flaw.