### PR TITLE
[BE2] validate sum of transaction outputs

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Transaction.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Transaction.scala
@@ -52,6 +52,9 @@ final case class Transaction(
       Signature(txin.script.sig).verify(txin.script.pubkey, signaturePayload)
     }
 
+  def sumOutputs(): Either[Error, Uint53] =
+    Uint53.safeSum(outputs.map(_.value))
+
   def sign(keypairs: Seq[KeyPair]): Transaction = {
     val privateKeyIndex = Map.from(keypairs.map(p => p.publicKey -> p.privateKey))
     copy(inputs=inputs.map { txin =>

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Transaction.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Transaction.scala
@@ -73,7 +73,7 @@ object Transaction extends Parsable {
   )
 
   final case class Output(
-    value: Long,
+    value: Uint53,
     script: LockScript,
   )
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Uint53.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Uint53.scala
@@ -1,0 +1,42 @@
+package ch.epfl.pop.model.objects
+
+
+class ArithmeticOverflowError(msg: String) extends Error(msg)
+
+
+/**
+ * Operations on 53-bits non-negative integers.
+ *
+ * These values can be handled without loss of precision in IEEE754 64-bit
+ * floating numbers, and thus in JSON.
+ */
+object Uint53 {
+  /** Internal representation in this implementation */
+  type Repr = Long
+
+  /** Smallest allowed value */
+  final val MinValue: Uint53 = 0
+
+  /** Largest allowed value */
+  final val MaxValue: Uint53 = 0x1FFFFFFFFFFFFFL
+
+  /** Whether the value is in-range */
+  def inRange(v: Uint53) = v >= MinValue && v <= MaxValue
+
+  /** Compute the sum of many Uint53 values, or indicate an overflow if
+   *  the sum is too large.
+   *
+   *  Per the Either documentation, "Convention dictates that Left is used for
+   *  failure and Right is used for success."
+   */
+  def safeSum(seq: IterableOnce[Uint53]): Either[ArithmeticOverflowError, Uint53] = {
+    var acc = 0L
+    for (v <- seq.iterator) {
+      require(inRange(v), s"value $v out of range for uint53")
+      acc += v
+      if (acc > MaxValue)
+        return Left(new ArithmeticOverflowError("uint53 addition overflow"))
+    }
+    Right(acc)
+  }
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/objects/package.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/objects/package.scala
@@ -4,4 +4,5 @@ package ch.epfl.pop.model
  * This package defines simple primitive types
  */
 package object objects {
+  type Uint53 = Uint53.Repr
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/CoinValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/CoinValidator.scala
@@ -24,7 +24,10 @@ case object CoinValidator extends MessageDataContentValidator {
         } else if (!data.transaction.checkSignatures()) {
           Right(validationError("bad signature"))
         } else {
-          Left(rpcMessage)
+          data.transaction.sumOutputs() match {
+            case Left(err) => Right(validationError(err.getMessage()))
+            case Right(_) => Left(rpcMessage)
+          }
         }
 
       case _ => Right(validationErrorNoMessage(rpcMessage.id))

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/Uint53Suite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/Uint53Suite.scala
@@ -1,0 +1,42 @@
+package ch.epfl.pop.model.objects
+
+import org.scalatest.{FunSuite, Matchers}
+
+class Uint53Suite extends FunSuite with Matchers {
+  import Uint53._
+
+  test("MinValue is zero") {
+    MinValue should equal(0)
+  }
+
+  test("MaxValue computed another way matches") {
+    MaxValue should equal((1L<<53) - 1)
+  }
+
+  test("inRange examples") {
+    inRange(-1) shouldBe false
+    inRange(0) shouldBe true
+    inRange(MaxValue) shouldBe true
+    inRange(MaxValue+1) shouldBe false
+  }
+
+  test("safeSum examples case") {
+    safeSum(Seq()) shouldBe Right(0)
+    safeSum(Seq(MaxValue)) shouldBe Right(MaxValue)
+    safeSum(Seq(MaxValue, 1)) shouldBe a[Left[_,_]]
+    safeSum(Seq(MaxValue/2, MaxValue/2)) shouldBe Right(MaxValue - 1)
+    safeSum(Seq(MaxValue/2, MaxValue/2, 1)) shouldBe Right(MaxValue)
+  }
+
+  test("safeSum tricky case 1") {
+    val seq = Iterable.fill(2048)(1L<<52)
+    assume(seq.sum == Long.MinValue)
+    safeSum(seq) shouldBe a[Left[_,_]]
+  }
+
+  test("safeSum tricky case 2") {
+    val seq = Iterable.fill(4096)(1L<<52)
+    assume(seq.sum == 0)
+    safeSum(seq) shouldBe a[Left[_,_]]
+  }
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/CoinValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/CoinValidatorSuite.scala
@@ -70,4 +70,10 @@ class CoinValidatorSuite extends TestKit(ActorSystem("coinValidatorTestActorSyst
     val message: GraphMessage = CoinValidator.validatePostTransaction(postTransaction)
     message should matchPattern { case Right(_) => }
   }
+
+  test("Posting a transaction with an arithmetic overflow does not work") {
+    val postTransaction = postTransactionOverflowSum
+    val message: GraphMessage = CoinValidator.validatePostTransaction(postTransaction)
+    message shouldEqual Right(PipelineError(-4,"PostTransaction content validation failed: uint53 addition overflow",Some(1)))
+  }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/CoinValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/CoinValidatorSuite.scala
@@ -62,13 +62,13 @@ class CoinValidatorSuite extends TestKit(ActorSystem("coinValidatorTestActorSyst
   test("Posting a transaction with an incorrect ID does not work") {
     val postTransaction = postTransactionWrongTransactionId
     val message: GraphMessage = CoinValidator.validatePostTransaction(postTransaction)
-    message should matchPattern { case Right(_) => }
+    message shouldEqual Right(PipelineError(-4,"PostTransaction content validation failed: incorrect transaction id",Some(1)))
   }
 
   test("Posting a transaction with an incorrect signature does not work") {
     val postTransaction = postTransactionBadSignature
     val message: GraphMessage = CoinValidator.validatePostTransaction(postTransaction)
-    message should matchPattern { case Right(_) => }
+    message shouldEqual Right(PipelineError(-4,"PostTransaction content validation failed: bad signature",Some(1)))
   }
 
   test("Posting a transaction with an arithmetic overflow does not work") {

--- a/be2-scala/src/test/scala/util/examples/data/CoinMessages.scala
+++ b/be2-scala/src/test/scala/util/examples/data/CoinMessages.scala
@@ -21,6 +21,7 @@ object PostTransactionMessages extends CoinMessagesTrait {
   final val postTransactionBadSignature: JsonRpcRequest = getJsonRPCRequestFromFile("coin/post_transaction_bad_signature.json")()
   final val postTransactionMaxAmount: JsonRpcRequest = getJsonRPCRequestFromFile("coin/post_transaction_max_amount.json")()
   final val postTransactionOverflowAmount: JsonRpcRequest = getJsonRPCRequestFromFile("coin/post_transaction_overflow_amount.json")()
+  final val postTransactionOverflowSum: JsonRpcRequest = getJsonRPCRequestFromFile("coin/post_transaction_overflow_sum.json")()
   final val postTransactionZeroAmount: JsonRpcRequest = getJsonRPCRequestFromFile("coin/post_transaction_zero_amount.json")()
   final val postTransactionNegativeAmount: JsonRpcRequest = getJsonRPCRequestFromFile("coin/post_transaction_negative_amount.json")()
   final val postTransactionWrongTransactionId: JsonRpcRequest = getJsonRPCRequestFromFile("coin/post_transaction_wrong_transaction_id.json")()

--- a/protocol/examples/messageData/coin/post_transaction_overflow_sum.json
+++ b/protocol/examples/messageData/coin/post_transaction_overflow_sum.json
@@ -1,0 +1,32 @@
+{
+    "object": "coin",
+    "action": "post_transaction",
+    "transaction_id": "Mfb8JwEb0rn6lZe9m6TJBRtleGMxnaF5HUfy6QJt7ac=",
+    "transaction": {
+	    "version": 1,
+	    "inputs": [{
+		    "tx_out_hash": "47DEQpj8HBSa--TImW-5JCeuQeRkm5NMpJWZG3hSuFU=",
+		    "tx_out_index": 0,
+		    "script": {
+			    "type": "P2PKH",
+			    "pubkey": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
+			    "sig": "4SbbszRmoI4-Rlhs1q7-2Dge1o1pSNW5SPMcnZPPRNUfGZ3Dy60sHIfTcw3SC2T2v-Gp4oGiIeZvrvEFEKbjDA=="
+		    }
+	    }],
+	    "outputs": [{
+		    "value": 9007199254740991,
+		    "script": {
+			    "type": "P2PKH",
+			    "pubkey_hash": "2jmj7l5rSw0yVb-vlWAYkK-YBwk="
+		    }
+	    },
+	    {
+		    "value": 1,
+		    "script": {
+			    "type": "P2PKH",
+			    "pubkey_hash": "2jmj7l5rSw0yVb-vlWAYkK-YBwk="
+		    }
+	    }],
+	    "lock_time": 0
+    }
+}


### PR DESCRIPTION
There's a transparent type alias for Uint53 along with a summation operation.

We check sum of outputs because it's possible in a stateless way. Conveniently, it's the one you should check to avoid ex-nihilo money bugs.

I also found out that some of the negative test cases fail for the wrong reasons so I fixed that.