### PR TITLE
Update of the check of the registered votes in EndElection in scala

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/model/objects/ElectionChannel.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/objects/ElectionChannel.scala
@@ -46,12 +46,12 @@ object ElectionChannel {
      * @param dbActor the AskableActorRef we use (by default the main DbActor, obtained through getInstance)
      * @return the final vote for each attendee that has voted
      */
-    def getLastVotes(dbActor: AskableActorRef = DbActor.getInstance): Future[List[(Message, CastVoteElection)]] = {
+    def getLastVotes(dbActor: AskableActorRef = DbActor.getInstance): Future[List[CastVoteElection]] = {
       extractMessages[CastVoteElection](dbActor).map{votes =>
-        val attendeeIdToLastVote = mutable.Map[PublicKey, (Message, CastVoteElection)]()
+        val attendeeIdToLastVote = mutable.Map[PublicKey, CastVoteElection]()
         for ((message, castvote) <- votes) {
-          if (!attendeeIdToLastVote.contains(message.sender) || attendeeIdToLastVote(message.sender)._2.created_at < castvote.created_at) {
-            attendeeIdToLastVote.update(message.sender, (message, castvote))
+          if (!attendeeIdToLastVote.contains(message.sender) || attendeeIdToLastVote(message.sender).created_at < castvote.created_at) {
+            attendeeIdToLastVote.update(message.sender, castvote)
           }
         }
         attendeeIdToLastVote.values.toList

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandler.scala
@@ -128,8 +128,7 @@ class ElectionHandler(dbRef: => AskableActorRef) extends MessageHandler {
 
   private def createElectionQuestionResults(electionChannel: Channel): Future[List[ElectionQuestionResult]] = {
     for {
-      votesList <- electionChannel.getLastVotes(dbActor)
-      castsVotesElections = votesList.map(_._2)
+      castsVotesElections <- electionChannel.getLastVotes(dbActor)
       setupMessage <- electionChannel.getSetupMessage(dbActor)
       questionToBallots = setupMessage.questions.map(question => question.id -> question.ballot_options).toMap
       DbActorReadElectionDataAck(electionData) <- dbActor ? DbActor.ReadElectionData(setupMessage.id)

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/ElectionValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/ElectionValidator.scala
@@ -243,10 +243,10 @@ sealed class ElectionValidator(dbActorRef: => AskableActorRef) extends MessageDa
    * @param checkHash The hash of the concatenated votes (i.e. registered_votes)
    * @return True if the hashes are the same, false otherwise
    */
-  private def compareResults(castVotes: List[(Message, CastVoteElection)], checkHash: Hash): Boolean = {
-    val sortedCastVotes: List[CastVoteElection] = castVotes.sortBy(_._1.message_id.toString.toLowerCase).map(_._2)
-    val voteElections: List[VoteElection] = sortedCastVotes.flatMap(_.votes)
-    val computedHash = Hash.fromStrings(voteElections.map(_.id.toString): _*)
+  private def compareResults(castVotes: List[CastVoteElection], checkHash: Hash): Boolean = {
+    val votes: List[VoteElection] = castVotes.flatMap(_.votes)
+    val sortedVotes: List[VoteElection] = votes.sortBy(_.id.toString.toLowerCase)
+    val computedHash = Hash.fromStrings(sortedVotes.map(_.id.toString): _*)
     computedHash == checkHash
   }
 }


### PR DESCRIPTION
To match the implementation of the front ends, we decided to change the protocol of the computation of the registered votes of EndElection: 

- Sorted by voteId uniquely 
- Updated the function getLastVote so that it returns only a List of CastVotes: the Message is not needed anymore