### PR TITLE
Fix update vote

### DIFF
--- a/be1-go/channel/election/mod.go
+++ b/be1-go/channel/election/mod.go
@@ -803,7 +803,7 @@ func updateVote(msgID string, sender string, castVote messagedata.VoteCastVote,
 			return xerrors.Errorf("failed to validate voting method props: %w", err)
 		}
 
-		if !ok || earlierVote.voteTime > castVote.CreatedAt {
+		if !ok || earlierVote.voteTime < castVote.CreatedAt {
 			qs.validVotes[sender] = validVote{
 				msgID,
 				vote.ID,

--- a/be1-go/go.mod
+++ b/be1-go/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	go.dedis.ch/kyber/v3 v3.0.13
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
-	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1

--- a/be1-go/go.sum
+++ b/be1-go/go.sum
@@ -55,7 +55,6 @@ golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=


### PR DESCRIPTION
When tested during pop meeting of the 7th of June, we realised that the go backend only counted the first votes of each sender instead of the last one.

- Changed the direction of the time check in update_vote
- Added a test for update_vote