### PR TITLE
Remove copy button for seed

### DIFF
--- a/fe1-web/src/core/components/ConfirmModal.tsx
+++ b/fe1-web/src/core/components/ConfirmModal.tsx
@@ -51,7 +51,6 @@ const ConfirmModal = (props: IPropTypes) => {
             value={textInput}
             onChange={setTextInput}
             placeholder={textInputPlaceholder}
-            border
           />
         ) : null}
         <PoPTextButton onPress={() => onConfirmPress(textInput)} testID="confirm-modal-confirm">

--- a/fe1-web/src/core/components/Input.tsx
+++ b/fe1-web/src/core/components/Input.tsx
@@ -9,11 +9,14 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Color.contrast,
     borderRadius: Border.inputRadius,
+    borderWidth: Border.width,
+    borderColor: Color.contrast,
     padding: Spacing.x05,
   },
-  border: {
-    borderWidth: 1,
-    borderColor: Color.primary,
+  negative: {
+    ...Typography.negative,
+    ...Border.negativeColor,
+    backgroundColor: Color.accent,
   },
   disabled: {
     color: Color.gray,
@@ -21,16 +24,18 @@ const styles = StyleSheet.create({
 });
 
 const Input = (props: IPropTypes) => {
-  const { value, placeholder, onChange, enabled, border, testID } = props;
+  const { value, placeholder, onChange, enabled, negative, testID } = props;
 
   const inputStyles = [Typography.paragraph, styles.input];
+
   if (!enabled) {
     inputStyles.push(styles.disabled);
   }
 
-  if (border) {
-    inputStyles.push(styles.border);
+  if (negative) {
+    inputStyles.push(styles.negative);
   }
+
   return (
     <TextInput
       style={inputStyles}
@@ -44,19 +49,19 @@ const Input = (props: IPropTypes) => {
 };
 
 const propTypes = {
-  enabled: PropTypes.bool,
-  border: PropTypes.bool,
   placeholder: PropTypes.string,
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func,
+  enabled: PropTypes.bool,
+  negative: PropTypes.bool,
   testID: PropTypes.string,
 };
 Input.propTypes = propTypes;
 Input.defaultProps = {
   placeholder: '',
-  enabled: true,
-  border: false,
   onChange: undefined,
+  enabled: true,
+  negative: false,
   testID: undefined,
 };
 

--- a/fe1-web/src/core/components/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
+++ b/fe1-web/src/core/components/__tests__/__snapshots__/ConfirmModal.test.tsx.snap
@@ -525,13 +525,11 @@ exports[`ConfirmModal renders correctly with text input 1`] = `
             },
             Object {
               "backgroundColor": "#fff",
+              "borderColor": "#fff",
               "borderRadius": 8,
+              "borderWidth": 1,
               "flex": 1,
               "padding": 8,
-            },
-            Object {
-              "borderColor": "#000",
-              "borderWidth": 1,
             },
           ]
         }

--- a/fe1-web/src/core/styles/typography.ts
+++ b/fe1-web/src/core/styles/typography.ts
@@ -1,4 +1,4 @@
-import { TextStyle } from 'react-native';
+import { Platform, TextStyle } from 'react-native';
 
 import {
   contrast,
@@ -62,6 +62,18 @@ export const centered: TextStyle = {
 
 export const important: TextStyle = {
   fontWeight: 'bold',
+};
+
+// https://www.skcript.com/svr/react-native-fonts/
+export const code: TextStyle = {
+  ...Platform.select({
+    ios: {
+      fontFamily: 'Courier New',
+    },
+    default: {
+      fontFamily: 'monospace',
+    },
+  }),
 };
 
 export const baseCentered: TextStyle = {

--- a/fe1-web/src/features/evoting/screens/__tests__/__snapshots__/CreateElection.test.tsx.snap
+++ b/fe1-web/src/features/evoting/screens/__tests__/__snapshots__/CreateElection.test.tsx.snap
@@ -358,7 +358,9 @@ exports[`CreateElection renders correctly 1`] = `
                                 },
                                 Object {
                                   "backgroundColor": "#fff",
+                                  "borderColor": "#fff",
                                   "borderRadius": 8,
+                                  "borderWidth": 1,
                                   "flex": 1,
                                   "padding": 8,
                                 },
@@ -464,7 +466,9 @@ exports[`CreateElection renders correctly 1`] = `
                                   },
                                   Object {
                                     "backgroundColor": "#fff",
+                                    "borderColor": "#fff",
                                     "borderRadius": 8,
+                                    "borderWidth": 1,
                                     "flex": 1,
                                     "padding": 8,
                                   },
@@ -515,7 +519,9 @@ exports[`CreateElection renders correctly 1`] = `
                                       },
                                       Object {
                                         "backgroundColor": "#fff",
+                                        "borderColor": "#fff",
                                         "borderRadius": 8,
+                                        "borderWidth": 1,
                                         "flex": 1,
                                         "padding": 8,
                                       },

--- a/fe1-web/src/features/home/screens/__tests__/__snapshots__/ConnectConfirm.test.tsx.snap
+++ b/fe1-web/src/features/home/screens/__tests__/__snapshots__/ConnectConfirm.test.tsx.snap
@@ -366,7 +366,9 @@ exports[`ConnectNavigation renders correctly 1`] = `
                                   },
                                   Object {
                                     "backgroundColor": "#fff",
+                                    "borderColor": "#fff",
                                     "borderRadius": 8,
+                                    "borderWidth": 1,
                                     "flex": 1,
                                     "padding": 8,
                                   },
@@ -407,7 +409,9 @@ exports[`ConnectNavigation renders correctly 1`] = `
                                   },
                                   Object {
                                     "backgroundColor": "#fff",
+                                    "borderColor": "#fff",
                                     "borderRadius": 8,
+                                    "borderWidth": 1,
                                     "flex": 1,
                                     "padding": 8,
                                   },

--- a/fe1-web/src/features/home/screens/__tests__/__snapshots__/Launch.test.tsx.snap
+++ b/fe1-web/src/features/home/screens/__tests__/__snapshots__/Launch.test.tsx.snap
@@ -387,7 +387,9 @@ exports[`Launch renders correctly 1`] = `
                                     },
                                     Object {
                                       "backgroundColor": "#fff",
+                                      "borderColor": "#fff",
                                       "borderRadius": 8,
+                                      "borderWidth": 1,
                                       "flex": 1,
                                       "padding": 8,
                                     },
@@ -428,7 +430,9 @@ exports[`Launch renders correctly 1`] = `
                                     },
                                     Object {
                                       "backgroundColor": "#fff",
+                                      "borderColor": "#fff",
                                       "borderRadius": 8,
+                                      "borderWidth": 1,
                                       "flex": 1,
                                       "padding": 8,
                                     },

--- a/fe1-web/src/features/lao/components/__tests__/__snapshots__/Identity.test.tsx.snap
+++ b/fe1-web/src/features/lao/components/__tests__/__snapshots__/Identity.test.tsx.snap
@@ -429,7 +429,9 @@ exports[`Identity renders correctly 1`] = `
                             },
                             Object {
                               "backgroundColor": "#fff",
+                              "borderColor": "#fff",
                               "borderRadius": 8,
+                              "borderWidth": 1,
                               "flex": 1,
                               "padding": 8,
                             },
@@ -472,7 +474,9 @@ exports[`Identity renders correctly 1`] = `
                             },
                             Object {
                               "backgroundColor": "#fff",
+                              "borderColor": "#fff",
                               "borderRadius": 8,
+                              "borderWidth": 1,
                               "flex": 1,
                               "padding": 8,
                             },
@@ -515,7 +519,9 @@ exports[`Identity renders correctly 1`] = `
                             },
                             Object {
                               "backgroundColor": "#fff",
+                              "borderColor": "#fff",
                               "borderRadius": 8,
+                              "borderWidth": 1,
                               "flex": 1,
                               "padding": 8,
                             },
@@ -558,7 +564,9 @@ exports[`Identity renders correctly 1`] = `
                             },
                             Object {
                               "backgroundColor": "#fff",
+                              "borderColor": "#fff",
                               "borderRadius": 8,
+                              "borderWidth": 1,
                               "flex": 1,
                               "padding": 8,
                             },
@@ -601,7 +609,9 @@ exports[`Identity renders correctly 1`] = `
                             },
                             Object {
                               "backgroundColor": "#fff",
+                              "borderColor": "#fff",
                               "borderRadius": 8,
+                              "borderWidth": 1,
                               "flex": 1,
                               "padding": 8,
                             },

--- a/fe1-web/src/features/lao/navigation/__tests__/__snapshots__/LaoNavigation.test.tsx.snap
+++ b/fe1-web/src/features/lao/navigation/__tests__/__snapshots__/LaoNavigation.test.tsx.snap
@@ -501,7 +501,9 @@ exports[`LaoNavigation renders correctly 1`] = `
                                           },
                                           Object {
                                             "backgroundColor": "#fff",
+                                            "borderColor": "#fff",
                                             "borderRadius": 8,
+                                            "borderWidth": 1,
                                             "flex": 1,
                                             "padding": 8,
                                           },
@@ -544,7 +546,9 @@ exports[`LaoNavigation renders correctly 1`] = `
                                           },
                                           Object {
                                             "backgroundColor": "#fff",
+                                            "borderColor": "#fff",
                                             "borderRadius": 8,
+                                            "borderWidth": 1,
                                             "flex": 1,
                                             "padding": 8,
                                           },
@@ -587,7 +591,9 @@ exports[`LaoNavigation renders correctly 1`] = `
                                           },
                                           Object {
                                             "backgroundColor": "#fff",
+                                            "borderColor": "#fff",
                                             "borderRadius": 8,
+                                            "borderWidth": 1,
                                             "flex": 1,
                                             "padding": 8,
                                           },
@@ -630,7 +636,9 @@ exports[`LaoNavigation renders correctly 1`] = `
                                           },
                                           Object {
                                             "backgroundColor": "#fff",
+                                            "borderColor": "#fff",
                                             "borderRadius": 8,
+                                            "borderWidth": 1,
                                             "flex": 1,
                                             "padding": 8,
                                           },
@@ -673,7 +681,9 @@ exports[`LaoNavigation renders correctly 1`] = `
                                           },
                                           Object {
                                             "backgroundColor": "#fff",
+                                            "borderColor": "#fff",
                                             "borderRadius": 8,
+                                            "borderWidth": 1,
                                             "flex": 1,
                                             "padding": 8,
                                           },

--- a/fe1-web/src/features/lao/screens/__tests__/__snapshots__/LaoHomeScreen.test.tsx.snap
+++ b/fe1-web/src/features/lao/screens/__tests__/__snapshots__/LaoHomeScreen.test.tsx.snap
@@ -440,7 +440,9 @@ exports[`LaoHomeScreen renders correctly 1`] = `
                                 },
                                 Object {
                                   "backgroundColor": "#fff",
+                                  "borderColor": "#fff",
                                   "borderRadius": 8,
+                                  "borderWidth": 1,
                                   "flex": 1,
                                   "padding": 8,
                                 },
@@ -483,7 +485,9 @@ exports[`LaoHomeScreen renders correctly 1`] = `
                                 },
                                 Object {
                                   "backgroundColor": "#fff",
+                                  "borderColor": "#fff",
                                   "borderRadius": 8,
+                                  "borderWidth": 1,
                                   "flex": 1,
                                   "padding": 8,
                                 },
@@ -526,7 +530,9 @@ exports[`LaoHomeScreen renders correctly 1`] = `
                                 },
                                 Object {
                                   "backgroundColor": "#fff",
+                                  "borderColor": "#fff",
                                   "borderRadius": 8,
+                                  "borderWidth": 1,
                                   "flex": 1,
                                   "padding": 8,
                                 },
@@ -569,7 +575,9 @@ exports[`LaoHomeScreen renders correctly 1`] = `
                                 },
                                 Object {
                                   "backgroundColor": "#fff",
+                                  "borderColor": "#fff",
                                   "borderRadius": 8,
+                                  "borderWidth": 1,
                                   "flex": 1,
                                   "padding": 8,
                                 },
@@ -612,7 +620,9 @@ exports[`LaoHomeScreen renders correctly 1`] = `
                                 },
                                 Object {
                                   "backgroundColor": "#fff",
+                                  "borderColor": "#fff",
                                   "borderRadius": 8,
+                                  "borderWidth": 1,
                                   "flex": 1,
                                   "padding": 8,
                                 },

--- a/fe1-web/src/features/meeting/screens/__tests__/__snapshots__/CreateMeeting.test.tsx.snap
+++ b/fe1-web/src/features/meeting/screens/__tests__/__snapshots__/CreateMeeting.test.tsx.snap
@@ -358,7 +358,9 @@ exports[`CreateMeeting renders correctly 1`] = `
                                 },
                                 Object {
                                   "backgroundColor": "#fff",
+                                  "borderColor": "#fff",
                                   "borderRadius": 8,
+                                  "borderWidth": 1,
                                   "flex": 1,
                                   "padding": 8,
                                 },
@@ -399,7 +401,9 @@ exports[`CreateMeeting renders correctly 1`] = `
                                 },
                                 Object {
                                   "backgroundColor": "#fff",
+                                  "borderColor": "#fff",
                                   "borderRadius": 8,
+                                  "borderWidth": 1,
                                   "flex": 1,
                                   "padding": 8,
                                 },

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/CreateRollCall.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/CreateRollCall.test.tsx.snap
@@ -358,7 +358,9 @@ exports[`CreateRollCall renders correctly 1`] = `
                                 },
                                 Object {
                                   "backgroundColor": "#fff",
+                                  "borderColor": "#fff",
                                   "borderRadius": 8,
+                                  "borderWidth": 1,
                                   "flex": 1,
                                   "padding": 8,
                                 },
@@ -399,7 +401,9 @@ exports[`CreateRollCall renders correctly 1`] = `
                                 },
                                 Object {
                                   "backgroundColor": "#fff",
+                                  "borderColor": "#fff",
                                   "borderRadius": 8,
+                                  "borderWidth": 1,
                                   "flex": 1,
                                   "padding": 8,
                                 },
@@ -440,7 +444,9 @@ exports[`CreateRollCall renders correctly 1`] = `
                                 },
                                 Object {
                                   "backgroundColor": "#fff",
+                                  "borderColor": "#fff",
                                   "borderRadius": 8,
+                                  "borderWidth": 1,
                                   "flex": 1,
                                   "padding": 8,
                                 },

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallOpened.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallOpened.test.tsx.snap
@@ -611,13 +611,11 @@ exports[`RollCallOpened renders correctly when no scan 1`] = `
                                   },
                                   Object {
                                     "backgroundColor": "#fff",
+                                    "borderColor": "#fff",
                                     "borderRadius": 8,
+                                    "borderWidth": 1,
                                     "flex": 1,
                                     "padding": 8,
-                                  },
-                                  Object {
-                                    "borderColor": "#000",
-                                    "borderWidth": 1,
                                   },
                                 ]
                               }
@@ -1367,13 +1365,11 @@ exports[`RollCallOpened renders correctly when scanning attendees 1`] = `
                                   },
                                   Object {
                                     "backgroundColor": "#fff",
+                                    "borderColor": "#fff",
                                     "borderRadius": 8,
+                                    "borderWidth": 1,
                                     "flex": 1,
                                     "padding": 8,
-                                  },
-                                  Object {
-                                    "borderColor": "#000",
-                                    "borderWidth": 1,
                                   },
                                 ]
                               }

--- a/fe1-web/src/features/wallet/screens/WalletCreateSeed.tsx
+++ b/fe1-web/src/features/wallet/screens/WalletCreateSeed.tsx
@@ -1,14 +1,14 @@
 import { useNavigation } from '@react-navigation/native';
 import { StackScreenProps } from '@react-navigation/stack';
 import React, { useEffect, useState } from 'react';
-import { StyleSheet, Text, View, ViewStyle } from 'react-native';
+import { StyleSheet, Text, TextStyle, View, ViewStyle } from 'react-native';
 import { useToast } from 'react-native-toast-notifications';
 
-import { CopiableTextInput, PoPTextButton } from 'core/components';
+import { Input, PoPTextButton } from 'core/components';
 import ScreenWrapper from 'core/components/ScreenWrapper';
 import { AppScreen } from 'core/navigation/AppNavigation';
 import { AppParamList } from 'core/navigation/typing/AppParamList';
-import { Color, Typography } from 'core/styles';
+import { Border, Color, Spacing, Typography } from 'core/styles';
 import containerStyles from 'core/styles/stylesheets/containerStyles';
 import { FOUR_SECONDS } from 'resources/const';
 import STRINGS from 'resources/strings';
@@ -21,6 +21,24 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Color.accent,
   } as ViewStyle,
+  words: {
+    flex: 1,
+    flexWrap: 'wrap',
+    flexDirection: 'row',
+    borderColor: Color.contrast,
+    borderWidth: Border.width,
+    borderRadius: Border.radius,
+    backgroundColor: Color.secondaryAccent,
+    marginBottom: Spacing.x1,
+    paddingVertical: Spacing.x05,
+  } as ViewStyle,
+  word: {
+    ...Typography.base,
+    ...Typography.code,
+    color: Color.contrast,
+    paddingHorizontal: Spacing.x05,
+    paddingVertical: Spacing.x025,
+  } as TextStyle,
 });
 
 type NavigationProps = StackScreenProps<
@@ -108,7 +126,13 @@ const WalletCreateSeed = () => {
               {STRINGS.wallet_welcome_text_wallet_explanation_4}
             </Text>
           </Text>
-          <CopiableTextInput text={seed} negative />
+          <View style={styles.words}>
+            {seed.split(' ').map((word, idx) => (
+              <Text key={idx.toString()} style={styles.word} selectable>
+                {word}
+              </Text>
+            ))}
+          </View>
           <Text style={Typography.paragraph}>
             <Text style={Typography.negative}>
               {STRINGS.wallet_welcome_text_wallet_explanation_5}

--- a/fe1-web/src/features/wallet/screens/WalletCreateSeed.tsx
+++ b/fe1-web/src/features/wallet/screens/WalletCreateSeed.tsx
@@ -128,7 +128,7 @@ const WalletCreateSeed = () => {
           </Text>
           <View style={styles.words}>
             {seed.split(' ').map((word, idx) => (
-              <Text key={idx.toString()} style={styles.word} selectable>
+              <Text key={idx.toString()} style={styles.word}>
                 {word}
               </Text>
             ))}

--- a/fe1-web/src/features/wallet/screens/WalletCreateSeed.tsx
+++ b/fe1-web/src/features/wallet/screens/WalletCreateSeed.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { StyleSheet, Text, TextStyle, View, ViewStyle } from 'react-native';
 import { useToast } from 'react-native-toast-notifications';
 
-import { Input, PoPTextButton } from 'core/components';
+import { PoPTextButton } from 'core/components';
 import ScreenWrapper from 'core/components/ScreenWrapper';
 import { AppScreen } from 'core/navigation/AppNavigation';
 import { AppParamList } from 'core/navigation/typing/AppParamList';

--- a/fe1-web/src/features/wallet/screens/__tests__/__snapshots__/WalletCreateSeed.test.tsx.snap
+++ b/fe1-web/src/features/wallet/screens/__tests__/__snapshots__/WalletCreateSeed.test.tsx.snap
@@ -490,7 +490,6 @@ exports[`Wallet create seed screen renders correctly 1`] = `
                                 }
                               >
                                 <Text
-                                  selectable={true}
                                   style={
                                     Object {
                                       "color": "#fff",
@@ -506,7 +505,6 @@ exports[`Wallet create seed screen renders correctly 1`] = `
                                   one
                                 </Text>
                                 <Text
-                                  selectable={true}
                                   style={
                                     Object {
                                       "color": "#fff",
@@ -522,7 +520,6 @@ exports[`Wallet create seed screen renders correctly 1`] = `
                                   two
                                 </Text>
                                 <Text
-                                  selectable={true}
                                   style={
                                     Object {
                                       "color": "#fff",

--- a/fe1-web/src/features/wallet/screens/__tests__/__snapshots__/WalletCreateSeed.test.tsx.snap
+++ b/fe1-web/src/features/wallet/screens/__tests__/__snapshots__/WalletCreateSeed.test.tsx.snap
@@ -477,58 +477,66 @@ exports[`Wallet create seed screen renders correctly 1`] = `
                               <View
                                 style={
                                   Object {
-                                    "alignItems": "center",
+                                    "backgroundColor": "#ff4757",
+                                    "borderColor": "#fff",
+                                    "borderRadius": 16,
+                                    "borderWidth": 1,
                                     "flex": 1,
                                     "flexDirection": "row",
-                                    "marginVertical": 16,
+                                    "flexWrap": "wrap",
+                                    "marginBottom": 16,
+                                    "paddingVertical": 8,
                                   }
                                 }
                               >
-                                <TextInput
-                                  editable={false}
-                                  selectTextOnFocus={true}
+                                <Text
+                                  selectable={true}
                                   style={
-                                    Array [
-                                      Object {
-                                        "borderRadius": 16,
-                                        "borderWidth": 1,
-                                        "color": "#000",
-                                        "flexGrow": 1,
-                                        "fontSize": 20,
-                                        "lineHeight": 26,
-                                        "marginRight": 16,
-                                        "padding": 8,
-                                        "textAlign": "center",
-                                        "width": 50,
-                                      },
-                                      Object {
-                                        "color": "#fff",
-                                      },
-                                      Object {
-                                        "borderColor": "#fff",
-                                      },
-                                    ]
+                                    Object {
+                                      "color": "#fff",
+                                      "fontFamily": "Courier New",
+                                      "fontSize": 20,
+                                      "lineHeight": 26,
+                                      "paddingHorizontal": 8,
+                                      "paddingVertical": 4,
+                                      "textAlign": "left",
+                                    }
                                   }
-                                  value="one two three"
-                                />
-                                <View
-                                  accessible={true}
-                                  collapsable={false}
-                                  focusable={true}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onResponderGrant={[Function]}
-                                  onResponderMove={[Function]}
-                                  onResponderRelease={[Function]}
-                                  onResponderTerminate={[Function]}
-                                  onResponderTerminationRequest={[Function]}
-                                  onStartShouldSetResponder={[Function]}
                                 >
-                                  <View>
-                                    <Text />
-                                  </View>
-                                </View>
+                                  one
+                                </Text>
+                                <Text
+                                  selectable={true}
+                                  style={
+                                    Object {
+                                      "color": "#fff",
+                                      "fontFamily": "Courier New",
+                                      "fontSize": 20,
+                                      "lineHeight": 26,
+                                      "paddingHorizontal": 8,
+                                      "paddingVertical": 4,
+                                      "textAlign": "left",
+                                    }
+                                  }
+                                >
+                                  two
+                                </Text>
+                                <Text
+                                  selectable={true}
+                                  style={
+                                    Object {
+                                      "color": "#fff",
+                                      "fontFamily": "Courier New",
+                                      "fontSize": 20,
+                                      "lineHeight": 26,
+                                      "paddingHorizontal": 8,
+                                      "paddingVertical": 4,
+                                      "textAlign": "left",
+                                    }
+                                  }
+                                >
+                                  three
+                                </Text>
                               </View>
                               <Text
                                 style={


### PR DESCRIPTION
<img width="562" alt="Screenshot 2022-06-13 at 11 57 04" src="https://user-images.githubusercontent.com/2634739/173329351-af83d5c2-e438-4dd0-956c-c05ac7ed6e18.png">

Remove the ability to trivially copy the wallet initialization seed as per the following discussion:

> [Louis Bettens](https://app.slack.com/team/U02UCPFGWCB)
 [8. Juni um 13:35 Uhr](https://dedis.slack.com/archives/C033PBYELRM/p1654688129723629)
Oh while I'm at it: copypastability of the 12 words. Generally, especially with big time cryptocurrencies, the interface shouldn't  allow you to use the clipboard. Why is there an icon to do it? For debugging convenience? https://github.com/spesmilo/electrum/pull/1492