### PR TITLE
[BE1] validate sum of transaction outputs

### DIFF
--- a/be1-go/channel/coin/uint53/mod.go
+++ b/be1-go/channel/coin/uint53/mod.go
@@ -1,0 +1,35 @@
+// Package uint53 provides operations on 53-bits non-negative integers.
+//
+// These values can be handled without loss of precision in IEEE754 64-bit
+// floating-point numbers, and thus in JSON.
+
+package uint53
+
+import (
+	"errors"
+)
+
+// Uint53 defines the internal representation in this implementation
+type Uint53 = uint64
+
+// MaxUint53 is the highest allowed value for Uint53
+const MaxUint53 Uint53 = 0x1F_FF_FF_FF_FF_FF_FF
+
+// InRange check whether the value is in range for Uint53
+func InRange(a Uint53) bool {
+	return a <= MaxUint53
+}
+
+// SafePlus compute the sum of two Uint53 values, or indicate an overflow if
+// the sum is too large.
+func SafePlus(a, b Uint53) (Uint53, error) {
+	if !InRange(a) || !InRange(b) {
+		return 0, errors.New("Uint53.SafePlus: argument out of range")
+	}
+	r := a + b
+	if !InRange(r) {
+		return 0, errors.New("uint53 addition overflow")
+	}
+
+	return r, nil
+}

--- a/be1-go/channel/coin/uint53/mod_test.go
+++ b/be1-go/channel/coin/uint53/mod_test.go
@@ -1,0 +1,39 @@
+package uint53
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Uint53Max_Equivalent(t *testing.T) {
+	require.Equal(t, Uint53(1<<53-1), MaxUint53)
+}
+
+func Test_InRange_Examples(t *testing.T) {
+	require.True(t, InRange(0))
+	require.True(t, InRange(MaxUint53))
+	require.False(t, InRange(MaxUint53+1))
+}
+
+func Test_SafePlus_Examples(t *testing.T) {
+	r, err := SafePlus(0, 1)
+	require.NoError(t, err)
+	require.EqualValues(t, r, 1)
+
+	r, err = SafePlus(MaxUint53, 0)
+	require.NoError(t, err)
+	require.EqualValues(t, r, MaxUint53)
+
+	r, err = SafePlus(MaxUint53, 1)
+	require.EqualError(t, err, "uint53 addition overflow")
+	require.EqualValues(t, r, 0)
+
+	r, err = SafePlus(MaxUint53/2, MaxUint53/2)
+	require.NoError(t, err)
+	require.EqualValues(t, r, MaxUint53-1)
+
+	r, err = SafePlus(MaxUint53+1, 0)
+	require.EqualError(t, err, "Uint53.SafePlus: argument out of range")
+	require.EqualValues(t, r, 0)
+}

--- a/be1-go/message/test/messagedata/coin_post_transaction_test.go
+++ b/be1-go/message/test/messagedata/coin_post_transaction_test.go
@@ -36,7 +36,7 @@ func Test_Coin_Post_Transaction(t *testing.T) {
 	require.Equal(t, "P2PKH", msg.Transaction.Inputs[0].Script.Type)
 	require.Equal(t, "oKHk3AivbpNXk_SfFcHDaVHcCcY8IBfHE7auXJ7h4ms=", msg.Transaction.Inputs[0].Script.PubKey)
 	require.Equal(t, "6hY16bDKnb7bRA5j7IMDR1CJDqAJKOLuQRgKxdpYQIrtSTVTRjo5jigqPhYQEPcK5a1WAF86V739ENFnlp6YCw==", msg.Transaction.Inputs[0].Script.Sig)
-	require.Equal(t, 32, msg.Transaction.Outputs[0].Value)
+	require.EqualValues(t, 32, msg.Transaction.Outputs[0].Value)
 	require.Equal(t, "P2PKH", msg.Transaction.Outputs[0].Script.Type)
 	require.Equal(t, "-_qR4IHwsiq50raa8jURNArds54=", msg.Transaction.Outputs[0].Script.PubKeyHash)
 	require.Equal(t, 0, msg.Transaction.Locktime)
@@ -77,5 +77,4 @@ func Test_Coin_Post_Transaction_Verify(t *testing.T) {
 
 	t.Run("transaction id not base64", getTestBadExample("wrong_post_transaction_transaction_id_not_base_64.json"))
 	t.Run("transaction id is wrong", getTestBadExample("post_transaction_wrong_transaction_id.json"))
-	t.Run("amount is negative", getTestBadExample("post_transaction_negative_amount.json"))
 }

--- a/be1-go/message/test/messagedata/coin_post_transaction_test.go
+++ b/be1-go/message/test/messagedata/coin_post_transaction_test.go
@@ -75,6 +75,7 @@ func Test_Coin_Post_Transaction_Verify(t *testing.T) {
 		}
 	}
 
+	t.Run("output amount overflows", getTestBadExample("post_transaction_overflow_sum.json"))
 	t.Run("transaction id not base64", getTestBadExample("wrong_post_transaction_transaction_id_not_base_64.json"))
 	t.Run("transaction id is wrong", getTestBadExample("post_transaction_wrong_transaction_id.json"))
 }


### PR DESCRIPTION
Maxime requested I take care of this. Corresponds to #1077.

There's a transparent type alias for Uint53 along with a summation operation.

We check sum of outputs because it's possible in a stateless way. Conveniently, it's the one you should check to avoid ex-nihilo money bugs.