### PR TITLE
Fixing some scala tests(checking for now)

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidator.scala
@@ -82,7 +82,7 @@ case object LaoValidator extends MessageDataContentValidator {
         val expectedLaoId: Hash = rpcMessage.extractLaoId
 
         if (expectedLaoId != data.lao) {
-          Right(validationError("unexpected id"))
+          Right(validationError("unexpected id "+ expectedLaoId+ "1111111"+data.lao))
         } else if (data.frontend != message.sender) {
           Right(validationError("unexpected frontend"))
         } else if (!data.address.startsWith("ws://")) {

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidator.scala
@@ -82,7 +82,7 @@ case object LaoValidator extends MessageDataContentValidator {
         val expectedLaoId: Hash = rpcMessage.extractLaoId
 
         if (expectedLaoId != data.lao) {
-          Right(validationError("unexpected id "+ expectedLaoId+ "1111111"+data.lao))
+          Right(validationError("unexpected id, was " + data.lao + " but expected " + expectedLaoId))
         } else if (data.frontend != message.sender) {
           Right(validationError("unexpected frontend"))
         } else if (!data.address.startsWith("ws://")) {

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
@@ -108,7 +108,7 @@ class LaoValidatorSuite extends TestKit(ActorSystem("laoValidatorTestActorSystem
 
   test("LAO greeting fails with wrong channel") {
     val message: GraphMessage = LaoValidator.validateGreetLao(GREET_LAO_WRONG_CHANNEL_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+     message should equal(Left(GREET_LAO_RPC))
   }
 
   test("LAO greeting fails without ParamsWithMessage") {

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
@@ -67,7 +67,7 @@ class LaoValidatorSuite extends TestKit(ActorSystem("laoValidatorTestActorSystem
 
   test("LAO creation fails with wrong sender") {
     val message: GraphMessage = LaoValidator.validateCreateLao(CREATE_LAO_WRONG_SENDER_RPC)
-    message should equal(Left(CREATE_LAO_RPC))
+    message shouldBe a[Right[_, PipelineError]]
   }
 
   test("LAO creation fails with empty name") {
@@ -83,7 +83,7 @@ class LaoValidatorSuite extends TestKit(ActorSystem("laoValidatorTestActorSystem
   //GreetLao tests
   test("LAO greeting works as intended") {
     val message: GraphMessage = LaoValidator.validateGreetLao(GREET_LAO_RPC)
-     message shouldBe a[Right[_, PipelineError]]
+    message should equal(Left(GREET_LAO_RPC))
   }
 
   test("LAO greeting fails with wrong lao id") {

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
@@ -83,7 +83,7 @@ class LaoValidatorSuite extends TestKit(ActorSystem("laoValidatorTestActorSystem
   //GreetLao tests
   test("LAO greeting works as intended") {
     val message: GraphMessage = LaoValidator.validateGreetLao(GREET_LAO_RPC)
-    message should equal(Left(GREET_LAO_RPC))
+     message shouldBe a[Right[_, PipelineError]]
   }
 
   test("LAO greeting fails with wrong lao id") {

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
@@ -108,7 +108,7 @@ class LaoValidatorSuite extends TestKit(ActorSystem("laoValidatorTestActorSystem
 
   test("LAO greeting fails with wrong channel") {
     val message: GraphMessage = LaoValidator.validateGreetLao(GREET_LAO_WRONG_CHANNEL_RPC)
-     message should equal(Left(GREET_LAO_RPC))
+     message shouldBe a[Right[_, PipelineError]]
   }
 
   test("LAO greeting fails without ParamsWithMessage") {

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
@@ -72,7 +72,7 @@ class LaoValidatorSuite extends TestKit(ActorSystem("laoValidatorTestActorSystem
 
   test("LAO creation fails with empty name") {
     val message: GraphMessage = LaoValidator.validateCreateLao(CREATE_LAO_EMPTY_NAME_RPC)
-    message should equal(Left(CREATE_LAO_RPC))
+    message shouldBe a[Right[_, PipelineError]]
   }
 
   test("LAO creation fails without ParamsWithMessage") {

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
@@ -67,12 +67,12 @@ class LaoValidatorSuite extends TestKit(ActorSystem("laoValidatorTestActorSystem
 
   test("LAO creation fails with wrong sender") {
     val message: GraphMessage = LaoValidator.validateCreateLao(CREATE_LAO_WRONG_SENDER_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message should equal(Left(CREATE_LAO_RPC))
   }
 
   test("LAO creation fails with empty name") {
     val message: GraphMessage = LaoValidator.validateCreateLao(CREATE_LAO_EMPTY_NAME_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message should equal(Left(CREATE_LAO_RPC))
   }
 
   test("LAO creation fails without ParamsWithMessage") {

--- a/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
+++ b/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
@@ -55,12 +55,13 @@ object JsonRpcRequestExample {
 
   //for GreetLao testing
   private final val laoChannel: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + Base64Data.encode("laoId"))
+  private final val wrongLaoChannel: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + Base64Data.encode("wrong_lao"))
   private final val paramsWithGreetLao: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_GREET_LAO)
   private final val paramsWithGreetLaoWrongFrontend: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_GREET_LAO_WRONG_FRONTEND)
   private final val paramsWithGreetLaoWrongAddress: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_GREET_LAO_WRONG_ADDRESS)
   private final val paramsWithGreetLaoWrongLao: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_GREET_LAO_WRONG_LAO)
   private final val paramsWithGreetLaoWrongSender: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_GREET_LAO_WRONG_OWNER)
-  private final val paramsWithGreetLaoWrongChannel: ParamsWithMessage = new ParamsWithMessage(channel, MESSAGE_GREET_LAO)
+  private final val paramsWithGreetLaoWrongChannel: ParamsWithMessage = new ParamsWithMessage(wrongLaoChannel, MESSAGE_GREET_LAO_WRONG_CHANNEL)
   final val GREET_LAO_RPC: JsonRpcRequest = JsonRpcRequest(rpc, methodType, paramsWithGreetLao, id)
   final val GREET_LAO_WRONG_FRONTEND_RPC: JsonRpcRequest = JsonRpcRequest(rpc, methodType, paramsWithGreetLaoWrongFrontend, id)
   final val GREET_LAO_WRONG_ADDRESS_RPC: JsonRpcRequest = JsonRpcRequest(rpc, methodType, paramsWithGreetLaoWrongAddress, id)

--- a/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
+++ b/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
@@ -55,13 +55,13 @@ object JsonRpcRequestExample {
 
   //for GreetLao testing
   private final val laoChannel: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + Base64Data.encode("laoId"))
-  private final val wrongLaoChannel: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + Base64Data.encode("wrong_lao"))
+  private final val electionChannel: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + Base64Data.encode("laoId") + Channel.CHANNEL_SEPARATOR + Base64Data.encode("election"))
   private final val paramsWithGreetLao: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_GREET_LAO)
   private final val paramsWithGreetLaoWrongFrontend: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_GREET_LAO_WRONG_FRONTEND)
   private final val paramsWithGreetLaoWrongAddress: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_GREET_LAO_WRONG_ADDRESS)
   private final val paramsWithGreetLaoWrongLao: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_GREET_LAO_WRONG_LAO)
   private final val paramsWithGreetLaoWrongSender: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_GREET_LAO_WRONG_OWNER)
-  private final val paramsWithGreetLaoWrongChannel: ParamsWithMessage = new ParamsWithMessage(wrongLaoChannel, MESSAGE_GREET_LAO_WRONG_CHANNEL)
+  private final val paramsWithGreetLaoWrongChannel: ParamsWithMessage = new ParamsWithMessage(electionChannel, MESSAGE_GREET_LAO_WRONG_CHANNEL)
   final val GREET_LAO_RPC: JsonRpcRequest = JsonRpcRequest(rpc, methodType, paramsWithGreetLao, id)
   final val GREET_LAO_WRONG_FRONTEND_RPC: JsonRpcRequest = JsonRpcRequest(rpc, methodType, paramsWithGreetLaoWrongFrontend, id)
   final val GREET_LAO_WRONG_ADDRESS_RPC: JsonRpcRequest = JsonRpcRequest(rpc, methodType, paramsWithGreetLaoWrongAddress, id)

--- a/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
+++ b/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
@@ -55,13 +55,13 @@ object JsonRpcRequestExample {
 
   //for GreetLao testing
   private final val laoChannel: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + Base64Data.encode("laoId"))
-  private final val electionChannel: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + Base64Data.encode("laoId") + Channel.CHANNEL_SEPARATOR + Base64Data.encode("election"))
+  private final val electionChannelGreet: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + Base64Data.encode("laoId") + Channel.CHANNEL_SEPARATOR + Base64Data.encode("election"))
   private final val paramsWithGreetLao: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_GREET_LAO)
   private final val paramsWithGreetLaoWrongFrontend: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_GREET_LAO_WRONG_FRONTEND)
   private final val paramsWithGreetLaoWrongAddress: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_GREET_LAO_WRONG_ADDRESS)
   private final val paramsWithGreetLaoWrongLao: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_GREET_LAO_WRONG_LAO)
   private final val paramsWithGreetLaoWrongSender: ParamsWithMessage = new ParamsWithMessage(laoChannel, MESSAGE_GREET_LAO_WRONG_OWNER)
-  private final val paramsWithGreetLaoWrongChannel: ParamsWithMessage = new ParamsWithMessage(electionChannel, MESSAGE_GREET_LAO_WRONG_CHANNEL)
+  private final val paramsWithGreetLaoWrongChannel: ParamsWithMessage = new ParamsWithMessage(electionChannelGreet, MESSAGE_GREET_LAO_WRONG_CHANNEL)
   final val GREET_LAO_RPC: JsonRpcRequest = JsonRpcRequest(rpc, methodType, paramsWithGreetLao, id)
   final val GREET_LAO_WRONG_FRONTEND_RPC: JsonRpcRequest = JsonRpcRequest(rpc, methodType, paramsWithGreetLaoWrongFrontend, id)
   final val GREET_LAO_WRONG_ADDRESS_RPC: JsonRpcRequest = JsonRpcRequest(rpc, methodType, paramsWithGreetLaoWrongAddress, id)

--- a/be2-scala/src/test/scala/util/examples/Lao/GreetLaoExamples.scala
+++ b/be2-scala/src/test/scala/util/examples/Lao/GreetLaoExamples.scala
@@ -36,6 +36,15 @@ object GreetLaoExamples {
     List.empty,
     Some(greetLaoWrongFrontend))
 
+  final val greetLaoWrongChannel: GreetLao = GreetLao(wrongLao, wrongSender, ADDRESS, PEERS)
+  final val MESSAGE_GREET_LAO_WRONG_CHANNEL: Message = new Message(
+    Base64Data.encode(GreetLaoFormat.write(greetLaoWrongChannel).toString),
+    SENDER,
+    SIGNATURE,
+    Hash(Base64Data("")),
+    List.empty,
+    Some(greetLaoWrongChannel))  
+
   final val greetLaoWrongLao: GreetLao = GreetLao(wrongLao, SENDER, ADDRESS, PEERS)
   final val MESSAGE_GREET_LAO_WRONG_LAO: Message = new Message(
     Base64Data.encode(greetLaoWrongLao.toJson.toString),

--- a/be2-scala/src/test/scala/util/examples/Lao/GreetLaoExamples.scala
+++ b/be2-scala/src/test/scala/util/examples/Lao/GreetLaoExamples.scala
@@ -27,7 +27,7 @@ object GreetLaoExamples {
     List.empty,
     Some(greetLao))
 
-  final val greetLaoWrongFrontend: GreetLao = GreetLao(LAO, SENDER, ADDRESS, PEERS)
+  final val greetLaoWrongFrontend: GreetLao = GreetLao(LAO, wrongSender, ADDRESS, PEERS)
   final val MESSAGE_GREET_LAO_WRONG_FRONTEND: Message = new Message(
     Base64Data.encode(GreetLaoFormat.write(greetLaoWrongFrontend).toString),
     SENDER,
@@ -36,7 +36,7 @@ object GreetLaoExamples {
     List.empty,
     Some(greetLaoWrongFrontend))
 
-  final val greetLaoWrongChannel: GreetLao = GreetLao(wrongLao, wrongSender, ADDRESS, PEERS)
+  final val greetLaoWrongChannel: GreetLao = GreetLao(wrongLao, SENDER, ADDRESS, PEERS)
   final val MESSAGE_GREET_LAO_WRONG_CHANNEL: Message = new Message(
     Base64Data.encode(GreetLaoFormat.write(greetLaoWrongChannel).toString),
     SENDER,

--- a/be2-scala/src/test/scala/util/examples/Lao/GreetLaoExamples.scala
+++ b/be2-scala/src/test/scala/util/examples/Lao/GreetLaoExamples.scala
@@ -27,7 +27,7 @@ object GreetLaoExamples {
     List.empty,
     Some(greetLao))
 
-  final val greetLaoWrongFrontend: GreetLao = GreetLao(LAO, wrongSender, ADDRESS, PEERS)
+  final val greetLaoWrongFrontend: GreetLao = GreetLao(LAO, SENDER, ADDRESS, PEERS)
   final val MESSAGE_GREET_LAO_WRONG_FRONTEND: Message = new Message(
     Base64Data.encode(GreetLaoFormat.write(greetLaoWrongFrontend).toString),
     SENDER,

--- a/be2-scala/src/test/scala/util/examples/Lao/GreetLaoExamples.scala
+++ b/be2-scala/src/test/scala/util/examples/Lao/GreetLaoExamples.scala
@@ -35,8 +35,9 @@ object GreetLaoExamples {
     Hash(Base64Data("")),
     List.empty,
     Some(greetLaoWrongFrontend))
-
-  final val greetLaoWrongChannel: GreetLao = GreetLao(wrongLao, SENDER, ADDRESS, PEERS)
+  
+  final val wronLaoGreet: Hash = Hash(Base64Data.encode("laoId/election")) 
+  final val greetLaoWrongChannel: GreetLao = GreetLao(wronLaoGreet, SENDER, ADDRESS, PEERS)
   final val MESSAGE_GREET_LAO_WRONG_CHANNEL: Message = new Message(
     Base64Data.encode(GreetLaoFormat.write(greetLaoWrongChannel).toString),
     SENDER,

--- a/be2-scala/src/test/scala/util/examples/MessageExample.scala
+++ b/be2-scala/src/test/scala/util/examples/MessageExample.scala
@@ -121,7 +121,7 @@ object MessageExample {
   private final val createLaoWrongSender: CreateLao = CreateLao(idWrongSender, name, creationWorking, wrongSender, workingWitnessList)
   final val MESSAGE_CREATELAO_WRONG_SENDER: Message = new Message(
     Base64Data.encode(createLaoWrongSender.toJson.toString),
-    wrongSender,
+    organizer,
     Signature(Base64Data("")),
     Hash(Base64Data("")),
     workingWSPairList,

--- a/be2-scala/src/test/scala/util/examples/MessageExample.scala
+++ b/be2-scala/src/test/scala/util/examples/MessageExample.scala
@@ -116,8 +116,11 @@ object MessageExample {
     Some(createLaoWrongId)
   )
 
+  private final val wrongSender: PublicKey =  PublicKey(Base64Data.encode("wrong"))
+  private final val idWrongSender: Hash = Hash.fromStrings(wrongSender.base64Data.toString, creationWorking.toString, name)
+  private final val createLaoWrongSender: CreateLao = CreateLao(idWrongSender, name, creationWorking, wrongSender, workingWitnessList)
   final val MESSAGE_CREATELAO_WRONG_SENDER: Message = new Message(
-    Base64Data.encode(createLaoCorrect.toJson.toString),
+    Base64Data.encode(createLaoWrongSender.toJson.toString),
     PublicKey(Base64Data.encode("wrong")),
     Signature(Base64Data("")),
     Hash(Base64Data("")),
@@ -125,7 +128,8 @@ object MessageExample {
     Some(createLaoWrongId)
   )
 
-  private final val createLaoEmptyName: CreateLao = createLaoCorrect.copy(name="")
+  private final val emptyNameId: Hash = Hash.fromStrings(organizer.base64Data.toString, creationWorking.toString, "")
+  private final val createLaoEmptyName: CreateLao = CreateLao(emptyNameId, "", creationWorking, organizer, workingWitnessList)
   final val MESSAGE_CREATELAO_EMPTY_NAME: Message = new Message(
     Base64Data.encode(createLaoEmptyName.toJson.toString),
     organizer,

--- a/be2-scala/src/test/scala/util/examples/MessageExample.scala
+++ b/be2-scala/src/test/scala/util/examples/MessageExample.scala
@@ -121,11 +121,11 @@ object MessageExample {
   private final val createLaoWrongSender: CreateLao = CreateLao(idWrongSender, name, creationWorking, wrongSender, workingWitnessList)
   final val MESSAGE_CREATELAO_WRONG_SENDER: Message = new Message(
     Base64Data.encode(createLaoWrongSender.toJson.toString),
-    PublicKey(Base64Data.encode("wrong")),
+    wrongSender,
     Signature(Base64Data("")),
     Hash(Base64Data("")),
     workingWSPairList,
-    Some(createLaoWrongId)
+    Some(createLaoWrongSender)
   )
 
   private final val emptyNameId: Hash = Hash.fromStrings(organizer.base64Data.toString, creationWorking.toString, "")


### PR DESCRIPTION
Some LAO creation tests were passing but not testing the right functionality. Lao creation with wrong sender and empty LAO name were correctly failing but due to the id being wrongly computer and not because of the previously mentioned reasons, this PR fixes that and introduces an additional test for lao greet message.