### PR TITLE
[BE2] scalatest: 3.0.9 -> 3.2.12

### DIFF
--- a/be2-scala/build.sbt
+++ b/be2-scala/build.sbt
@@ -151,7 +151,7 @@ libraryDependencies += "com.google.crypto.tink" % "tink" % "1.5.0"
 libraryDependencies += "ch.epfl.dedis" % "cothority" % "3.3.1"
 
 // Scala unit tests
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.9" % Test
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.12" % Test
 
 // Json Schema Validator w/ Jackson Databind
 libraryDependencies += "com.networknt" % "json-schema-validator" % "1.0.60"

--- a/be2-scala/src/test/scala/ch/epfl/pop/json/HighLevelProtocolSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/json/HighLevelProtocolSuite.scala
@@ -3,7 +3,8 @@ package ch.epfl.pop.json
 import ch.epfl.pop.model.network.method.message.Message
 import ch.epfl.pop.model.objects._
 import org.scalatest.Inspectors.forEvery
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 
 class HighLevelProtocolSuite extends FunSuite with Matchers {
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/json/MessageDataProtocolSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/json/MessageDataProtocolSuite.scala
@@ -3,7 +3,8 @@ package ch.epfl.pop.json
 import ch.epfl.pop.model.network.method.message.data.election._
 import ch.epfl.pop.model.network.method.message.data.lao.CreateLao
 import ch.epfl.pop.model.objects._
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 
 import scala.io.{BufferedSource, Source}
 import ch.epfl.pop.model.network.method.message.data.coin.PostTransaction

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/network/JsonRpcRequestSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/network/JsonRpcRequestSuite.scala
@@ -5,7 +5,8 @@ import ch.epfl.pop.model.network.method.message.data.lao.CreateLao
 import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType}
 import ch.epfl.pop.model.network.method.{Params, ParamsWithMessage}
 import ch.epfl.pop.model.objects._
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 import util.examples.{JsonRpcRequestExample, MessageExample}
 
 class JsonRpcRequestSuite extends FunSuite with Matchers {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/network/JsonRpcResponseSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/network/JsonRpcResponseSuite.scala
@@ -1,6 +1,7 @@
 package ch.epfl.pop.model.network
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 
 class JsonRpcResponseSuite extends FunSuite with Matchers {
   test("Constructor/apply works as intended") {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/network/ResultObjectSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/network/ResultObjectSuite.scala
@@ -1,6 +1,7 @@
 package ch.epfl.pop.model.network
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 
 class ResultObjectSuite extends FunSuite with Matchers {
   test("Int constructor works") {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/network/method/message/data/socialMedia/AddChirpSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/network/method/message/data/socialMedia/AddChirpSuite.scala
@@ -4,7 +4,8 @@ import ch.epfl.pop.json.MessageDataProtocol._
 import ch.epfl.pop.model.network.method.message.data.socialMedia.AddChirpExample._
 import ch.epfl.pop.model.network.method.message.data.{ActionType, ObjectType}
 import ch.epfl.pop.model.objects.Timestamp
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 import spray.json._
 
 class AddChirpSuite extends FunSuite with Matchers {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/network/method/message/data/socialMedia/AddReactionSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/network/method/message/data/socialMedia/AddReactionSuite.scala
@@ -4,7 +4,8 @@ import ch.epfl.pop.json.MessageDataProtocol._
 import ch.epfl.pop.model.network.method.message.data.socialMedia.AddReactionExample._
 import ch.epfl.pop.model.network.method.message.data.{ActionType, ObjectType}
 import ch.epfl.pop.model.objects.{Base64Data, Hash, Timestamp}
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 import spray.json._
 
 class AddReactionSuite extends FunSuite with Matchers {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/network/method/message/data/socialMedia/DeleteChirpSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/network/method/message/data/socialMedia/DeleteChirpSuite.scala
@@ -4,7 +4,8 @@ import ch.epfl.pop.json.MessageDataProtocol._
 import ch.epfl.pop.model.network.method.message.data.socialMedia.DeleteChirpExample._
 import ch.epfl.pop.model.network.method.message.data.{ActionType, ObjectType}
 import ch.epfl.pop.model.objects.{Base64Data, Hash, Timestamp}
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 import spray.json._
 
 class DeleteChirpSuite extends FunSuite with Matchers {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/network/method/message/data/socialMedia/DeleteReactionSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/network/method/message/data/socialMedia/DeleteReactionSuite.scala
@@ -4,7 +4,8 @@ import ch.epfl.pop.json.MessageDataProtocol._
 import ch.epfl.pop.model.network.method.message.data.socialMedia.DeleteReactionExample._
 import ch.epfl.pop.model.network.method.message.data.{ActionType, ObjectType}
 import ch.epfl.pop.model.objects.{Base64Data, Hash, Timestamp}
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 import spray.json._
 
 class DeleteReactionSuite extends FunSuite with Matchers {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/network/method/message/data/socialMedia/NotifyAddChirpSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/network/method/message/data/socialMedia/NotifyAddChirpSuite.scala
@@ -3,7 +3,8 @@ package ch.epfl.pop.model.network.method.message.data.socialMedia
 import ch.epfl.pop.json.MessageDataProtocol._
 import ch.epfl.pop.model.network.method.message.data.{ActionType, ObjectType}
 import ch.epfl.pop.model.objects.{Base64Data, Channel, Hash, Timestamp}
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 import spray.json._
 
 class NotifyAddChirpSuite extends FunSuite with Matchers {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/network/method/message/data/socialMedia/NotifyDeleteChirpSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/network/method/message/data/socialMedia/NotifyDeleteChirpSuite.scala
@@ -3,7 +3,8 @@ package ch.epfl.pop.model.network.method.message.data.socialMedia
 import ch.epfl.pop.json.MessageDataProtocol._
 import ch.epfl.pop.model.network.method.message.data.{ActionType, ObjectType}
 import ch.epfl.pop.model.objects.{Base64Data, Channel, Hash, Timestamp}
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 import spray.json._
 
 class NotifyDeleteChirpSuite extends FunSuite with Matchers {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/AddressSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/AddressSuite.scala
@@ -1,6 +1,7 @@
 package ch.epfl.pop.model.objects
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 import util.examples.LaoDataExample
 
 class AddressSuite extends FunSuite with Matchers {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/ChannelDataSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/ChannelDataSuite.scala
@@ -1,7 +1,8 @@
 package ch.epfl.pop.model.objects
 
 import ch.epfl.pop.model.network.method.message.data.ObjectType
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 
 class ChannelDataSuite extends FunSuite with Matchers {
   test("Apply works with empty/full list for ChannelData") {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/ChannelSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/ChannelSuite.scala
@@ -1,6 +1,7 @@
 package ch.epfl.pop.model.objects
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 
 class ChannelSuite extends FunSuite with Matchers {
   test("Root/Sub channel test (1)") {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/HashSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/HashSuite.scala
@@ -1,6 +1,7 @@
 package ch.epfl.pop.model.objects
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 
 class HashSuite extends FunSuite with Matchers {
   test("Hash 'fromString' works for a random string") {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/KeyPairSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/KeyPairSuite.scala
@@ -1,6 +1,7 @@
 package ch.epfl.pop.model.objects
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 
 class KeyPairSuite extends FunSuite with Matchers {
   test("Encrypt and decrypt a message return the original message") {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/LaoDataSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/LaoDataSuite.scala
@@ -2,7 +2,8 @@ package ch.epfl.pop.model.objects
 
 import ch.epfl.pop.model.network.method.message.Message
 import com.google.crypto.tink.subtle.Ed25519Sign
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 import util.examples.MessageExample
 
 class LaoDataSuite extends FunSuite with Matchers {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/PrivateKeySuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/PrivateKeySuite.scala
@@ -1,7 +1,8 @@
 package ch.epfl.pop.model.objects
 
 import com.google.crypto.tink.subtle.Ed25519Sign
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 
 class PrivateKeySuite extends FunSuite with Matchers {
   test("Constructor/apply works as intended") {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/PublicKeySuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/PublicKeySuite.scala
@@ -1,6 +1,7 @@
 package ch.epfl.pop.model.objects
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 import spray.json._
 
 class PublicKeySuite extends FunSuite with Matchers {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/SignatureSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/SignatureSuite.scala
@@ -4,7 +4,9 @@ import java.nio.charset.StandardCharsets
 
 import com.google.crypto.tink.subtle.Ed25519Sign
 import org.scalatest.Inspectors.forEvery
-import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 
 /*Helper object for testing*/
 case class TestObj(ed_signer: Ed25519Sign, keyPair: Ed25519Sign.KeyPair)

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/TransactionSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/TransactionSuite.scala
@@ -1,6 +1,7 @@
 package ch.epfl.pop.model.objects
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 import util.examples.data.PostTransactionMessages
 import util.examples.data.TestKeyPairs._
 import ch.epfl.pop.model.objects.Transaction

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/Uint53Suite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/Uint53Suite.scala
@@ -1,6 +1,7 @@
 package ch.epfl.pop.model.objects
 
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 
 class Uint53Suite extends FunSuite with Matchers {
   import Uint53._

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/MessageRegistrySuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/MessageRegistrySuite.scala
@@ -7,7 +7,8 @@ import ch.epfl.pop.model.network.method.message.data.rollCall.CreateRollCall
 import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType}
 import ch.epfl.pop.pubsub.MessageRegistry.RegisterEntry
 import ch.epfl.pop.pubsub.graph.{GraphMessage, JsonString, MessageDecoder}
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.{Success, Try}
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/AnswerGeneratorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/AnswerGeneratorSuite.scala
@@ -10,7 +10,9 @@ import ch.epfl.pop.model.objects.DbActorNAckException
 import ch.epfl.pop.pubsub.graph.validators.RpcValidator
 import ch.epfl.pop.pubsub.graph.validators.SchemaVerifierSuite._
 import ch.epfl.pop.storage.DbActor
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 import util.examples.MessageExample
 
 import scala.concurrent.duration.FiniteDuration

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/CoinHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/CoinHandlerSuite.scala
@@ -7,7 +7,9 @@ import akka.util.Timeout
 import ch.epfl.pop.model.objects.DbActorNAckException
 import ch.epfl.pop.pubsub.graph.PipelineError
 import ch.epfl.pop.storage.DbActor
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 import util.examples.LaoDataExample
 import util.examples.data.PostTransactionMessages._
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandlerTest.scala
@@ -9,7 +9,9 @@ import ch.epfl.pop.model.network.method.message.data.ObjectType
 import ch.epfl.pop.model.objects._
 import ch.epfl.pop.pubsub.graph.PipelineError
 import ch.epfl.pop.storage.DbActor
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 import util.examples.Election.CastVoteElectionExamples._
 import util.examples.Election.EndElectionExamples._
 import util.examples.Election.OpenElectionExamples._

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandlerTest.scala
@@ -7,7 +7,9 @@ import akka.util.Timeout
 import ch.epfl.pop.model.objects.DbActorNAckException
 import ch.epfl.pop.pubsub.graph.PipelineError
 import ch.epfl.pop.storage.DbActor
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 import util.examples.data.{CreateRollCallMessages, OpenRollCallMessages}
 
 import scala.concurrent.duration.FiniteDuration

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandlerSuite.scala
@@ -7,7 +7,9 @@ import akka.util.Timeout
 import ch.epfl.pop.model.objects.DbActorNAckException
 import ch.epfl.pop.pubsub.graph.PipelineError
 import ch.epfl.pop.storage.DbActor
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 import util.examples.LaoDataExample
 import util.examples.data.{AddChirpMessages, AddReactionMessages, DeleteChirpMessages, DeleteReactionMessages}
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandlerTest.scala
@@ -9,7 +9,9 @@ import ch.epfl.pop.model.objects.{Base64Data, DbActorNAckException, Hash, Signat
 import ch.epfl.pop.pubsub.graph.PipelineError
 import ch.epfl.pop.storage.DbActor
 import ch.epfl.pop.storage.DbActor.DbActorAddWitnessSignatureAck
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 import util.examples.data.WitnessMessages
 import util.examples.lao.CreateLaoExamples.{SENDER, createLao}
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/CoinValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/CoinValidatorSuite.scala
@@ -12,7 +12,9 @@ import ch.epfl.pop.model.objects._
 import ch.epfl.pop.pubsub.graph.{GraphMessage, PipelineError}
 import ch.epfl.pop.pubsub.{AskPatternConstants, PubSubMediator}
 import ch.epfl.pop.storage.{DbActor, InMemoryStorage}
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 import util.examples.data.PostTransactionMessages._
 
 import scala.reflect.io.Directory

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/ElectionValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/ElectionValidatorSuite.scala
@@ -10,7 +10,9 @@ import ch.epfl.pop.model.objects._
 import ch.epfl.pop.pubsub.graph.{GraphMessage, PipelineError}
 import ch.epfl.pop.pubsub.{AskPatternConstants, MessageRegistry, PubSubMediator}
 import ch.epfl.pop.storage.{DbActor, InMemoryStorage}
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 import util.examples.Election.CastVoteElectionExamples._
 import util.examples.Election.EndElectionExamples._
 import util.examples.Election.OpenElectionExamples._

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/Lao/CreateLaoContentSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/Lao/CreateLaoContentSuite.scala
@@ -5,7 +5,9 @@ import ch.epfl.pop.model.network.method.message.Message
 import ch.epfl.pop.model.network.method.message.data.{ActionType, ObjectType}
 import ch.epfl.pop.pubsub.MessageRegistry
 import ch.epfl.pop.pubsub.graph.{GraphMessage, MessageDecoder, Validator}
-import org.scalatest.{FlatSpec, GivenWhenThen, Inside, Matchers}
+import org.scalatest.{GivenWhenThen, Inside}
+import org.scalatest.flatspec.{AnyFlatSpec => FlatSpec}
+import org.scalatest.matchers.should.Matchers
 import util.examples.lao.CreateLaoExamples
 
 class CreateLaoContentSuite extends FlatSpec with Matchers with Inside with GivenWhenThen {

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/Lao/CreateLaoDecoderSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/Lao/CreateLaoDecoderSuite.scala
@@ -6,7 +6,9 @@ import ch.epfl.pop.model.network.method.message.data.lao.CreateLao
 import ch.epfl.pop.model.network.method.message.data.{ActionType, ObjectType}
 import ch.epfl.pop.pubsub.MessageRegistry
 import ch.epfl.pop.pubsub.graph.{ErrorCodes, GraphMessage, MessageDecoder, PipelineError}
-import org.scalatest._
+import org.scalatest.{Assertion, GivenWhenThen, Inside}
+import org.scalatest.flatspec.{AnyFlatSpec => FlatSpec}
+import org.scalatest.matchers.should.Matchers
 import util.examples.lao.CreateLaoExamples
 
 class CreateLaoDecoderSuite extends FlatSpec with Matchers with Inside with GivenWhenThen {

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
@@ -14,7 +14,9 @@ import ch.epfl.pop.pubsub.{AskPatternConstants, MessageRegistry, PubSubMediator}
 import java.io.File
 import java.util.concurrent.TimeUnit
 
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 import util.examples.JsonRpcRequestExample._
 
 import scala.reflect.io.Directory

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/MeetingValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/MeetingValidatorSuite.scala
@@ -10,7 +10,9 @@ import ch.epfl.pop.model.objects._
 import ch.epfl.pop.pubsub.graph.{GraphMessage, PipelineError}
 import ch.epfl.pop.pubsub.{AskPatternConstants, MessageRegistry, PubSubMediator}
 import ch.epfl.pop.storage.{DbActor, InMemoryStorage}
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 import util.examples.Election.CastVoteElectionExamples._
 import util.examples.Election.EndElectionExamples._
 import util.examples.Election.OpenElectionExamples._

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidatorSuite.scala
@@ -10,7 +10,9 @@ import ch.epfl.pop.pubsub.graph.PipelineError
 import ch.epfl.pop.storage.DbActor
 
 //import util.examples.MessageExample._
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 import util.examples.JsonRpcRequestExample._
 
 import scala.concurrent.duration.FiniteDuration

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidatorSuite.scala
@@ -9,7 +9,9 @@ import ch.epfl.pop.model.objects._
 import ch.epfl.pop.pubsub.graph.{GraphMessage, PipelineError}
 import ch.epfl.pop.pubsub.{AskPatternConstants, MessageRegistry, PubSubMediator}
 import ch.epfl.pop.storage.{DbActor, InMemoryStorage}
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 import util.examples.Election.CastVoteElectionExamples._
 import util.examples.Election.EndElectionExamples._
 import util.examples.Election.OpenElectionExamples._

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SchemaVerifierSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SchemaVerifierSuite.scala
@@ -4,7 +4,8 @@ import ch.epfl.pop.model.network.method.message.data.{ActionType, ObjectType}
 import ch.epfl.pop.pubsub.MessageRegistry
 import ch.epfl.pop.pubsub.graph.PipelineError
 import ch.epfl.pop.pubsub.graph.SchemaVerifier._
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 
 import scala.io.Source
 import scala.util.{Failure, Success}

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SocialMediaValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SocialMediaValidatorSuite.scala
@@ -12,7 +12,9 @@ import ch.epfl.pop.model.objects._
 import ch.epfl.pop.pubsub.graph.{GraphMessage, PipelineError}
 import ch.epfl.pop.pubsub.{AskPatternConstants, MessageRegistry, PubSubMediator}
 import ch.epfl.pop.storage.{DbActor, InMemoryStorage}
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 import util.examples.JsonRpcRequestExample._
 import util.examples.socialMedia.AddChirpExamples
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidatorSuite.scala
@@ -8,7 +8,9 @@ import ch.epfl.pop.model.objects._
 import ch.epfl.pop.pubsub.graph.{GraphMessage, PipelineError}
 import ch.epfl.pop.pubsub.{AskPatternConstants, MessageRegistry, PubSubMediator}
 import ch.epfl.pop.storage.{DbActor, InMemoryStorage}
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 import util.examples.JsonRpcRequestExample._
 import util.examples.Witness.WitnessMessageExamples
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/storage/DbActorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/storage/DbActorSuite.scala
@@ -10,7 +10,9 @@ import ch.epfl.pop.model.objects.Channel.ROOT_CHANNEL_PREFIX
 import ch.epfl.pop.model.objects._
 import ch.epfl.pop.pubsub.{AskPatternConstants, MessageRegistry, PubSubMediator}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 import util.examples.MessageExample
 import util.examples.RollCall.{CreateRollCallExamples, OpenRollCallExamples}
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/storage/DiskStorageSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/storage/DiskStorageSuite.scala
@@ -3,7 +3,9 @@ package ch.epfl.pop.storage
 import java.io.File
 
 import ch.epfl.pop.model.objects.DbActorNAckException
-import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.concurrent.TrieMap
 import scala.reflect.io.Directory


### PR DESCRIPTION
Originally part of #1111

NOTE: all changes except the `build.sbt` change were done with the following sed script followed by 1 manual adjustment.

```sed
/import org.scalatest.{FunSuite, Matchers}/ {
c \
import org.scalatest.funsuite.{AnyFunSuite => FunSuite} \
import org.scalatest.matchers.should.Matchers
}

/import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}/ {
c \
import org.scalatest.BeforeAndAfterAll \
import org.scalatest.funsuite.{AnyFunSuite => FunSuite} \
import org.scalatest.matchers.should.Matchers
}

/import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, Matchers}/ {
c \
import org.scalatest.BeforeAndAfterAll \
import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike} \
import org.scalatest.matchers.should.Matchers
}

/import org.scalatest.{FlatSpec, GivenWhenThen, Inside, Matchers}/ {
c \
import org.scalatest.{GivenWhenThen, Inside} \
import org.scalatest.flatspec.{AnyFlatSpec => FlatSpec} \
import org.scalatest.matchers.should.Matchers
}

/import org.scalatest._/ {
c \
import org.scalatest.{GivenWhenThen, Inside} \
import org.scalatest.flatspec.{AnyFlatSpec => FlatSpec} \
import org.scalatest.matchers.should.Matchers
}
