### PR TITLE
Fix an issue with LAONetworkManager

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/LAONetworkManager.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/LAONetworkManager.java
@@ -182,36 +182,35 @@ public class LAONetworkManager implements MessageSender {
   }
 
   private Single<Answer> request(Query query) {
-    Single<Answer> answerSingle =
-        connection
-            .observeMessage() // Observe incoming messages
-            .filter(Answer.class::isInstance) // Filter the Answers
-            .map(Answer.class::cast)
-            // This specific request has an id, only let the related Answer pass
-            .filter(answer -> answer.getId() == query.getRequestId())
-            .doOnNext(answer -> Log.d(TAG, "request id: " + answer.getId()))
-            // Transform from an Observable to a Single
-            // This Means that we expect a result before the source is disposed and an error will be
-            // produced if no value is received.
-            .firstOrError()
-            // If we receive an error, transform the flow to a Failure
-            .flatMap(
-                answer -> {
-                  if (answer instanceof Error) {
-                    return Single.error(new JsonRPCErrorException((Error) answer));
-                  } else {
-                    return Single.just(answer);
-                  }
-                })
-            .subscribeOn(schedulerProvider.io())
-            .observeOn(schedulerProvider.mainThread())
-            // Add a timeout to automatically dispose of the flow and end with a failure
-            .timeout(5, TimeUnit.SECONDS)
-            .cache();
-    // Only send the message after the single is created to make sure it is already waiting
-    // before the answer is received
-    connection.sendMessage(query);
-    return answerSingle;
+    // First send the message (embedded in the completable so that it is only sent upon subscription
+    return Completable.fromAction(() -> connection.sendMessage(query))
+        .andThen(
+            connection
+                .observeMessage() // Observe incoming messages
+                .filter(Answer.class::isInstance) // Filter the Answers
+                .map(Answer.class::cast)
+                // This specific request has an id, only let the related Answer pass
+                .filter(answer -> answer.getId() == query.getRequestId())
+                .doOnNext(answer -> Log.d(TAG, "request id: " + answer.getId()))
+                // Transform from an Observable to a Single
+                // This Means that we expect a result before the source is disposed and an error
+                // will be
+                // produced if no value is received.
+                .firstOrError()
+                // If we receive an error, transform the flow to a Failure
+                .flatMap(
+                    answer -> {
+                      if (answer instanceof Error) {
+                        return Single.error(new JsonRPCErrorException((Error) answer));
+                      } else {
+                        return Single.just(answer);
+                      }
+                    })
+                .subscribeOn(schedulerProvider.io())
+                .observeOn(schedulerProvider.mainThread())
+                // Add a timeout to automatically dispose of the flow and end with a failure
+                .timeout(5, TimeUnit.SECONDS)
+                .cache());
   }
 
   @Override

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/LAONetworkManager.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/LAONetworkManager.java
@@ -182,35 +182,35 @@ public class LAONetworkManager implements MessageSender {
   }
 
   private Single<Answer> request(Query query) {
-    // First send the message (embedded in the completable so that it is only sent upon subscription
-    return Completable.fromAction(() -> connection.sendMessage(query))
-        .andThen(
-            connection
-                .observeMessage() // Observe incoming messages
-                .filter(Answer.class::isInstance) // Filter the Answers
-                .map(Answer.class::cast)
-                // This specific request has an id, only let the related Answer pass
-                .filter(answer -> answer.getId() == query.getRequestId())
-                .doOnNext(answer -> Log.d(TAG, "request id: " + answer.getId()))
-                // Transform from an Observable to a Single
-                // This Means that we expect a result before the source is disposed and an error
-                // will be
-                // produced if no value is received.
-                .firstOrError()
-                // If we receive an error, transform the flow to a Failure
-                .flatMap(
-                    answer -> {
-                      if (answer instanceof Error) {
-                        return Single.error(new JsonRPCErrorException((Error) answer));
-                      } else {
-                        return Single.just(answer);
-                      }
-                    })
-                .subscribeOn(schedulerProvider.io())
-                .observeOn(schedulerProvider.mainThread())
-                // Add a timeout to automatically dispose of the flow and end with a failure
-                .timeout(5, TimeUnit.SECONDS)
-                .cache());
+    return connection
+        .observeMessage() // Observe incoming messages
+        // Send the message upon subscription the the incoming messages. That way we are
+        // certain the reply will be processed and the message is only sent when an observer
+        // subscribes to the request answer.
+        .doOnSubscribe(d -> connection.sendMessage(query))
+        .filter(Answer.class::isInstance) // Filter for Answers
+        .map(Answer.class::cast)
+        // This specific request has an id, only let the related Answer pass
+        .filter(answer -> answer.getId() == query.getRequestId())
+        .doOnNext(answer -> Log.d(TAG, "request id: " + answer.getId()))
+        // Transform from an Observable to a Single
+        // This Means that we expect a result before the source is disposed and an error
+        // will be produced if no value is received.
+        .firstOrError()
+        // If we receive an error, transform the flow to a Failure
+        .flatMap(
+            answer -> {
+              if (answer instanceof Error) {
+                return Single.error(new JsonRPCErrorException((Error) answer));
+              } else {
+                return Single.just(answer);
+              }
+            })
+        .subscribeOn(schedulerProvider.io())
+        .observeOn(schedulerProvider.mainThread())
+        // Add a timeout to automatically dispose of the flow and end with a failure
+        .timeout(5, TimeUnit.SECONDS)
+        .cache();
   }
 
   @Override

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/repository/remote/GlobalNetworkManagerTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/repository/remote/GlobalNetworkManagerTest.java
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import io.reactivex.Completable;
 import io.reactivex.subjects.BehaviorSubject;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -38,7 +39,9 @@ public class GlobalNetworkManagerTest {
         new GlobalNetworkManager(repository, handler, factory, gson, new TestSchedulerProvider());
     verify(factory).createConnection(anyString());
 
-    networkManager.getMessageSender().unsubscribe(Channel.ROOT);
+    Completable sendMessage = networkManager.getMessageSender().unsubscribe(Channel.ROOT);
+    verify(firstConnection, never()).sendMessage(any());
+    sendMessage.subscribe();
     verify(firstConnection).sendMessage(any());
   }
 


### PR DESCRIPTION
Currently, the messages are sent when the Completable are created
The fix makes sure they are sent only when the subscription is done

This was not an issue, but with #1177 I started chaining requests, and in that scenario, we need to delay the sending of the second message.
What this simple fix achieves