### PR TITLE
Re-add the add witness feature

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailFragment.java
@@ -123,8 +123,6 @@ public class LaoDetailFragment extends Fragment {
     setupEventListAdapter();
     setupEventListUpdates();
 
-    // TODO: Add witness handler
-
     mLaoDetailViewModel
         .getLaoEvents()
         .observe(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailViewModel.java
@@ -661,6 +661,10 @@ public class LaoDetailViewModel extends AndroidViewModel implements QRCodeScanni
     return scanningAction;
   }
 
+  public void setScanningAction(ScanningAction scanningAction) {
+    this.scanningAction = scanningAction;
+  }
+
   public LiveData<List<com.github.dedis.popstellar.model.objects.event.Event>> getLaoEvents() {
     return mLaoEvents;
   }
@@ -944,11 +948,11 @@ public class LaoDetailViewModel extends AndroidViewModel implements QRCodeScanni
           new SingleEvent<>("This attendee key has already been scanned. Please try again."));
       return false;
     }
-    if (scanningAction == (ScanningAction.ADD_ROLL_CALL_ATTENDEE)) {
+    if (scanningAction == ScanningAction.ADD_ROLL_CALL_ATTENDEE) {
       attendees.add(attendee);
       mAttendeeScanConfirmEvent.postValue(new SingleEvent<>("Attendee has been added."));
       mNbAttendees.postValue(attendees.size());
-    } else if (scanningAction == (ScanningAction.ADD_WITNESS)) {
+    } else if (scanningAction == ScanningAction.ADD_WITNESS) {
       witnesses.add(attendee);
       mWitnessScanConfirmEvent.postValue(new SingleEvent<>(true));
       updateLaoWitnesses();

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/witness/WitnessesFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/witness/WitnessesFragment.java
@@ -1,16 +1,26 @@
 package com.github.dedis.popstellar.ui.detail.witness;
 
+import android.Manifest;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.view.*;
 
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 import androidx.recyclerview.widget.*;
 
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.ui.detail.LaoDetailActivity;
 import com.github.dedis.popstellar.ui.detail.LaoDetailViewModel;
+import com.github.dedis.popstellar.ui.qrcode.*;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+import static androidx.core.content.ContextCompat.checkSelfPermission;
+import static com.github.dedis.popstellar.ui.detail.LaoDetailActivity.setCurrentFragment;
 
 public class WitnessesFragment extends Fragment {
+
+  private LaoDetailViewModel viewModel;
 
   public WitnessesFragment() {
     // Required empty public constructor
@@ -25,11 +35,10 @@ public class WitnessesFragment extends Fragment {
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     // Inflate the layout for this fragment
     View view = inflater.inflate(R.layout.witnesses_fragment, container, false);
-    LaoDetailViewModel viewModel = LaoDetailActivity.obtainViewModel(requireActivity());
+    viewModel = LaoDetailActivity.obtainViewModel(requireActivity());
 
-    // FIXME Was removed during refactor, the functionality needs to be added back
-    // FloatingActionButton fab = view.findViewById(R.id.add_witness_button);
-    // fab.setOnClickListener(v -> viewModel.openAddWitness());
+    FloatingActionButton fab = view.findViewById(R.id.add_witness_button);
+    fab.setOnClickListener(v -> openAddWitness());
 
     RecyclerView recyclerView = view.findViewById(R.id.witness_list);
 
@@ -46,5 +55,26 @@ public class WitnessesFragment extends Fragment {
     viewModel.getWitnesses().observe(getViewLifecycleOwner(), adapter::replaceList);
 
     return view;
+  }
+
+  private void openAddWitness() {
+    FragmentManager manager = getParentFragmentManager();
+
+    if (checkSelfPermission(requireContext(), Manifest.permission.CAMERA)
+        == PackageManager.PERMISSION_GRANTED) {
+
+      viewModel.setScanningAction(ScanningAction.ADD_WITNESS);
+      setCurrentFragment(manager, R.id.add_witness_button, QRCodeScanningFragment::new);
+    } else {
+      // Setup result listener to open the scanning tab once the permission is granted
+      manager.setFragmentResultListener(
+          CameraPermissionFragment.REQUEST_KEY, this, (k, b) -> openAddWitness());
+
+      setCurrentFragment(
+          manager,
+          R.id.fragment_camera_perm,
+          () ->
+              CameraPermissionFragment.newInstance(requireActivity().getActivityResultRegistry()));
+    }
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/ui/detail/witness/WitnessingFragmentNoPermissionTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/ui/detail/witness/WitnessingFragmentNoPermissionTest.java
@@ -1,0 +1,81 @@
+package com.github.dedis.popstellar.ui.detail.witness;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.github.dedis.popstellar.model.objects.Lao;
+import com.github.dedis.popstellar.model.objects.security.PublicKey;
+import com.github.dedis.popstellar.repository.LAORepository;
+import com.github.dedis.popstellar.testutils.Base64DataUtils;
+import com.github.dedis.popstellar.testutils.BundleBuilder;
+import com.github.dedis.popstellar.testutils.fragment.ActivityFragmentScenarioRule;
+import com.github.dedis.popstellar.ui.detail.LaoDetailActivity;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoTestRule;
+
+import dagger.hilt.android.testing.*;
+import io.reactivex.subjects.BehaviorSubject;
+
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.withChild;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static com.github.dedis.popstellar.ui.pages.detail.LaoDetailActivityPageObject.*;
+import static com.github.dedis.popstellar.ui.pages.detail.witness.WitnessFragmentPageObject.addWitnessButton;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for the Witnesses fragment
+ *
+ * <p>The test suite handles the cases where the camera permission is not granted at startup
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4.class)
+public class WitnessingFragmentNoPermissionTest {
+
+  private static final String LAO_NAME = "LAO";
+  private static final PublicKey ORGANIZER = Base64DataUtils.generatePublicKey();
+  private static final Lao LAO = new Lao(LAO_NAME, ORGANIZER, 10223421);
+  private static final String LAO_ID = LAO.getId();
+
+  @BindValue @Mock LAORepository repository;
+
+  @Rule(order = 0)
+  public final MockitoTestRule mockitoRule = MockitoJUnit.testRule(this);
+
+  @Rule(order = 1)
+  public final HiltAndroidRule hiltRule = new HiltAndroidRule(this);
+
+  @Rule(order = 2)
+  public final ExternalResource setupRule =
+      new ExternalResource() {
+        @Override
+        protected void before() {
+          when(repository.getLaoObservable(any())).thenReturn(BehaviorSubject.createDefault(LAO));
+        }
+      };
+
+  @Rule(order = 3)
+  public final ActivityFragmentScenarioRule<LaoDetailActivity, WitnessesFragment> scenarioRule =
+      ActivityFragmentScenarioRule.launchIn(
+          LaoDetailActivity.class,
+          new BundleBuilder()
+              .putString(laoIdExtra(), LAO_ID)
+              .putString(fragmentToOpenExtra(), laoDetailValue())
+              .build(),
+          containerId(),
+          WitnessesFragment.class,
+          WitnessesFragment::newInstance);
+
+  @Test
+  public void addWitnessOpenScanningNoPermission() {
+    addWitnessButton().perform(click());
+    fragmentContainer().check(matches(withChild(withId(cameraPermissionId()))));
+  }
+}

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/ui/detail/witness/WitnessingFragmentTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/ui/detail/witness/WitnessingFragmentTest.java
@@ -1,0 +1,76 @@
+package com.github.dedis.popstellar.ui.detail.witness;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.github.dedis.popstellar.model.objects.Lao;
+import com.github.dedis.popstellar.model.objects.security.PublicKey;
+import com.github.dedis.popstellar.repository.LAORepository;
+import com.github.dedis.popstellar.testutils.Base64DataUtils;
+import com.github.dedis.popstellar.testutils.BundleBuilder;
+import com.github.dedis.popstellar.testutils.fragment.ActivityFragmentScenarioRule;
+import com.github.dedis.popstellar.ui.detail.LaoDetailActivity;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoTestRule;
+
+import dagger.hilt.android.testing.*;
+import io.reactivex.subjects.BehaviorSubject;
+
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.withChild;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static com.github.dedis.popstellar.ui.pages.detail.LaoDetailActivityPageObject.*;
+import static com.github.dedis.popstellar.ui.pages.detail.witness.WitnessFragmentPageObject.addWitnessButton;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4.class)
+public class WitnessingFragmentTest {
+
+  private static final String LAO_NAME = "LAO";
+  private static final PublicKey ORGANIZER = Base64DataUtils.generatePublicKey();
+  private static final Lao LAO = new Lao(LAO_NAME, ORGANIZER, 10223421);
+  private static final String LAO_ID = LAO.getId();
+
+  @BindValue @Mock LAORepository repository;
+
+  @Rule(order = 0)
+  public final MockitoTestRule mockitoRule = MockitoJUnit.testRule(this);
+
+  @Rule(order = 1)
+  public final HiltAndroidRule hiltRule = new HiltAndroidRule(this);
+
+  @Rule(order = 2)
+  public final ExternalResource setupRule =
+      new ExternalResource() {
+        @Override
+        protected void before() {
+          when(repository.getLaoObservable(any())).thenReturn(BehaviorSubject.createDefault(LAO));
+        }
+      };
+
+  @Rule(order = 3)
+  public ActivityFragmentScenarioRule<LaoDetailActivity, WitnessingFragment> scenarioRule =
+      ActivityFragmentScenarioRule.launchIn(
+          LaoDetailActivity.class,
+          new BundleBuilder()
+              .putString(laoIdExtra(), LAO_ID)
+              .putString(fragmentToOpenExtra(), laoDetailValue())
+              .build(),
+          containerId(),
+          WitnessingFragment.class,
+          WitnessingFragment::newInstance);
+
+  @Test
+  public void addWitnessOpenScanning() {
+    addWitnessButton().perform(click());
+    fragmentContainer().check(matches(withChild(withId(cameraPermissionId()))));
+  }
+}

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/ui/detail/witness/WitnessingFragmentWithPermissionTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/ui/detail/witness/WitnessingFragmentWithPermissionTest.java
@@ -1,6 +1,9 @@
 package com.github.dedis.popstellar.ui.detail.witness;
 
+import android.Manifest;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.GrantPermissionRule;
 
 import com.github.dedis.popstellar.model.objects.Lao;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
@@ -30,9 +33,14 @@ import static com.github.dedis.popstellar.ui.pages.detail.witness.WitnessFragmen
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+/**
+ * Test for the Witnesses fragment
+ *
+ * <p>The test suite handles the cases where the camera permission is granted at startup
+ */
 @HiltAndroidTest
 @RunWith(AndroidJUnit4.class)
-public class WitnessingFragmentTest {
+public class WitnessingFragmentWithPermissionTest {
 
   private static final String LAO_NAME = "LAO";
   private static final PublicKey ORGANIZER = Base64DataUtils.generatePublicKey();
@@ -57,7 +65,7 @@ public class WitnessingFragmentTest {
       };
 
   @Rule(order = 3)
-  public ActivityFragmentScenarioRule<LaoDetailActivity, WitnessingFragment> scenarioRule =
+  public final ActivityFragmentScenarioRule<LaoDetailActivity, WitnessesFragment> scenarioRule =
       ActivityFragmentScenarioRule.launchIn(
           LaoDetailActivity.class,
           new BundleBuilder()
@@ -65,12 +73,15 @@ public class WitnessingFragmentTest {
               .putString(fragmentToOpenExtra(), laoDetailValue())
               .build(),
           containerId(),
-          WitnessingFragment.class,
-          WitnessingFragment::newInstance);
+          WitnessesFragment.class,
+          WitnessesFragment::newInstance);
+
+  @Rule(order = 4)
+  public final GrantPermissionRule rule = GrantPermissionRule.grant(Manifest.permission.CAMERA);
 
   @Test
-  public void addWitnessOpenScanning() {
+  public void addWitnessOpenScanningNoPermission() {
     addWitnessButton().perform(click());
-    fragmentContainer().check(matches(withChild(withId(cameraPermissionId()))));
+    fragmentContainer().check(matches(withChild(withId(qrCodeFragmentId()))));
   }
 }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/ui/pages/detail/LaoDetailActivityPageObject.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/ui/pages/detail/LaoDetailActivityPageObject.java
@@ -62,6 +62,11 @@ public class LaoDetailActivityPageObject {
     return R.id.fragment_camera_perm;
   }
 
+  @IdRes
+  public static int qrCodeFragmentId() {
+    return R.id.fragment_qrcode;
+  }
+
   public static int containerId() {
     return R.id.fragment_container_lao_detail;
   }

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/ui/pages/detail/witness/WitnessFragmentPageObject.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/ui/pages/detail/witness/WitnessFragmentPageObject.java
@@ -1,0 +1,15 @@
+package com.github.dedis.popstellar.ui.pages.detail.witness;
+
+import androidx.test.espresso.ViewInteraction;
+
+import com.github.dedis.popstellar.R;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+public class WitnessFragmentPageObject {
+
+  public static ViewInteraction addWitnessButton() {
+    return onView(withId(R.id.add_witness_button));
+  }
+}


### PR DESCRIPTION
During an earlier pull request, this feature was removed.

The PR therefore re-adds it in a ... clunky way.
With the current scanning system, I cannot write it in a way that I find clean enough.

But changing that would be a massive change to the codebase.