### PR TITLE
Add disposables in handlers to message sender container

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/LAONetworkManager.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/LAONetworkManager.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.*;
 import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.disposables.Disposable;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.subjects.Subject;
 
@@ -158,6 +159,11 @@ public class LAONetworkManager implements MessageSender {
   @Override
   public Observable<WebSocket.Event> getConnectEvents() {
     return connection.observeConnectionEvents();
+  }
+
+  @Override
+  public void addToDisposableContainer(Disposable disposable) {
+    disposables.add(disposable);
   }
 
   private void handleBroadcast(Broadcast broadcast) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/MessageSender.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/MessageSender.java
@@ -67,4 +67,11 @@ public interface MessageSender extends Disposable {
    * @return an Observable of WebSocket events of the underlying connection
    */
   Observable<WebSocket.Event> getConnectEvents();
+
+  /**
+   * Adds the disposable to the container of disposables of the message sender
+   *
+   * @param disposable the disposable to add
+   */
+  void addToDisposableContainer(Disposable disposable);
 }


### PR DESCRIPTION
This adds the disposables of the handlers to the disposables container of the `LaoNetworkManager`. Previously those were unused which can lead to some unpleasantness (an example [here](https://stackoverflow.com/a/49523600/18580049)).