### PR TITLE
Rework data storage in the Lao repository

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
@@ -16,37 +16,27 @@ import javax.inject.Singleton;
 
 import io.reactivex.Observable;
 import io.reactivex.subjects.BehaviorSubject;
+import io.reactivex.subjects.Subject;
 
 @Singleton
 public class LAORepository {
 
   private static final String TAG = LAORepository.class.getSimpleName();
 
-  // State for LAO
-  private final Map<String, LAOState> laoById;
+  private final HashMap<String, Lao> laoById = new HashMap<>();
+  private final HashMap<String, Subject<Lao>> subjectById = new HashMap<>();
+  private final BehaviorSubject<Set<String>> laosSubject = BehaviorSubject.create();
 
+  // ============ Lao Unrelated data ===============
   // State for Messages
-  private final Map<MessageID, MessageGeneral> messageById;
-
-  // Observable for view models that need access to all LAO Names
-  private final BehaviorSubject<List<Lao>> allLaoSubject;
-
+  private final Map<MessageID, MessageGeneral> messageById = new HashMap<>();
   // Observable for view models that need access to all Nodes
-  private final Map<Channel, BehaviorSubject<List<ConsensusNode>>> channelToNodesSubject;
+  private final Map<Channel, BehaviorSubject<List<ConsensusNode>>> channelToNodesSubject =
+      new HashMap<>();
 
   @Inject
   public LAORepository() {
-    laoById = new HashMap<>();
-    messageById = new HashMap<>();
-    allLaoSubject = BehaviorSubject.create();
-    channelToNodesSubject = new HashMap<>();
-  }
-
-  /** Set allLaoSubject to contain all LAOs */
-  public void setAllLaoSubject() {
-    Log.d(TAG, "posted allLaos to allLaoSubject");
-    allLaoSubject.onNext(
-        laoById.values().stream().map(LAOState::getLao).collect(Collectors.toList()));
+    // Constructor required by Hilt
   }
 
   /**
@@ -77,21 +67,62 @@ public class LAORepository {
    */
   public Lao getLaoByChannel(Channel channel) {
     Log.d(TAG, "querying lao for channel " + channel);
-    return laoById.get(channel.extractLaoId()).getLao();
+    return laoById.get(channel.extractLaoId());
   }
 
+  public Observable<Set<String>> getAllLaoIds() {
+    return laosSubject;
+  }
+
+  @Deprecated
   public Observable<List<Lao>> getAllLaos() {
-    return allLaoSubject;
+    return laosSubject.map(set -> set.stream().map(laoById::get).collect(Collectors.toList()));
   }
 
   public Observable<Lao> getLaoObservable(String laoId) {
     Log.d(TAG, "LaoIds we have are: " + laoById.keySet());
-    return laoById.get(laoId).getObservable();
+    if (!subjectById.containsKey(laoId)) {
+      subjectById.put(laoId, BehaviorSubject.create());
+    }
+
+    return subjectById.get(laoId);
   }
 
-  public Map<String, LAOState> getLaoById() {
-    return laoById;
+  public LaoView getLaoView(String id) throws UnknownLaoException {
+    Lao lao = laoById.get(id);
+    if (lao == null) {
+      throw new UnknownLaoException(id);
+    }
+
+    return new LaoView(lao);
   }
+
+  public LaoView getLaoViewByChannel(Channel channel) throws UnknownLaoException {
+    return getLaoView(channel.extractLaoId());
+  }
+
+  public synchronized void updateLao(Lao lao) {
+    if (lao == null) {
+      throw new IllegalArgumentException();
+    }
+
+    if (laoById.containsKey(lao.getId())) {
+      // If the lao already exists, we can push the next update
+      laoById.put(lao.getId(), lao);
+      // Update observer if present
+      Subject<Lao> subject = subjectById.get(lao.getId());
+      if (subject != null) {
+        subject.onNext(lao);
+      }
+    } else {
+      // Otherwise, create the entry
+      laoById.put(lao.getId(), lao);
+      // Update lao list
+      laosSubject.onNext(laoById.keySet());
+    }
+  }
+
+  // ============ Lao Unrelated functions ===============
 
   /**
    * Return an Observable to the list of nodes in a given channel.
@@ -117,31 +148,5 @@ public class LAORepository {
 
   public Map<MessageID, MessageGeneral> getMessageById() {
     return messageById;
-  }
-
-  public Optional<LaoView> getLao(String id) {
-    if (laoById.containsKey(id)) {
-      return Optional.of(new LaoView(laoById.get(id).getLao()));
-    }
-    return Optional.empty();
-  }
-
-  public LaoView getLaoViewByChannel(Channel channel) throws UnknownLaoException {
-    return getLao(channel.extractLaoId())
-        .orElseThrow(() -> new UnknownLaoException(channel.extractLaoId()));
-  }
-
-  public synchronized void updateLao(Lao lao) {
-    if (lao == null) {
-      throw new IllegalArgumentException();
-    }
-
-    if (laoById.containsKey(lao.getId())) {
-      // If the lao already exists, we can push the next update
-      laoById.get(lao.getId()).publish(lao);
-    } else {
-      // Otherwise, create the state
-      laoById.put(lao.getId(), new LAOState(lao));
-    }
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAOState.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAOState.java
@@ -5,7 +5,6 @@ import android.util.Log;
 import com.github.dedis.popstellar.model.objects.Lao;
 
 import io.reactivex.Observable;
-import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.Subject;
 
 /**
@@ -22,9 +21,9 @@ public class LAOState {
    *
    * @param lao the lao
    */
-  public LAOState(Lao lao) {
+  public LAOState(Lao lao, Subject<Lao> publisher) {
     this.lao = lao;
-    this.publisher = BehaviorSubject.createDefault(lao);
+    this.publisher = publisher;
   }
 
   /**

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/socialmedia/SocialMediaViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/socialmedia/SocialMediaViewModel.java
@@ -16,10 +16,10 @@ import com.github.dedis.popstellar.model.objects.*;
 import com.github.dedis.popstellar.model.objects.security.MessageID;
 import com.github.dedis.popstellar.model.objects.security.PoPToken;
 import com.github.dedis.popstellar.repository.LAORepository;
-import com.github.dedis.popstellar.repository.LAOState;
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 import com.github.dedis.popstellar.ui.navigation.NavigationViewModel;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
+import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 import com.github.dedis.popstellar.utility.error.keys.KeyException;
 import com.github.dedis.popstellar.utility.security.KeyManager;
 import com.google.gson.Gson;
@@ -235,9 +235,11 @@ public class SocialMediaViewModel extends NavigationViewModel<SocialMediaTab> {
 
   @Nullable
   private Lao getLao(String laoId) {
-    LAOState laoState = laoRepository.getLaoById().get(laoId);
-    if (laoState == null) return null;
-
-    return laoState.getLao();
+    // TODO Fully move to an LaoView here (and throw the exception further)
+    try {
+      return laoRepository.getLaoView(laoId).createLaoCopy();
+    } catch (UnknownLaoException e) {
+      return null;
+    }
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
@@ -47,7 +47,6 @@ public final class LaoHandler {
 
     // Adding the newly created LAO to the repository
     laoRepository.updateLao(lao);
-    laoRepository.setAllLaoSubject();
 
     PublicKey publicKey = context.getKeyManager().getMainPublicKey();
     if (lao.getOrganizer().equals(publicKey) || lao.getWitnesses().contains(publicKey)) {

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/ui/detail/event/consensus/ElectionStartFragmentTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/ui/detail/event/consensus/ElectionStartFragmentTest.java
@@ -13,7 +13,6 @@ import com.github.dedis.popstellar.model.network.serializer.JsonUtils;
 import com.github.dedis.popstellar.model.objects.*;
 import com.github.dedis.popstellar.model.objects.security.KeyPair;
 import com.github.dedis.popstellar.repository.LAORepository;
-import com.github.dedis.popstellar.repository.LAOState;
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.testutils.fragment.FragmentScenarioRule;
@@ -118,7 +117,7 @@ public class ElectionStartFragmentTest {
               node3Pos = i;
             }
           }
-          laoRepository.getLaoById().put(LAO_ID, new LAOState(lao));
+          laoRepository.updateLao(lao);
           laoRepository.updateNodes(lao.getChannel());
 
           when(globalNetworkManager.getMessageSender()).thenReturn(messageSender);

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/ui/digitalcash/DigitalCashActivityTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/ui/digitalcash/DigitalCashActivityTest.java
@@ -10,7 +10,6 @@ import com.github.dedis.popstellar.model.objects.digitalcash.*;
 import com.github.dedis.popstellar.model.objects.event.EventState;
 import com.github.dedis.popstellar.model.objects.security.*;
 import com.github.dedis.popstellar.repository.LAORepository;
-import com.github.dedis.popstellar.repository.LAOState;
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.testutils.*;
@@ -127,8 +126,6 @@ public class DigitalCashActivityTest {
               .thenReturn(BehaviorSubject.createDefault(LAO));
           when(repository.getAllLaos())
               .thenReturn(BehaviorSubject.createDefault(Collections.singletonList(LAO)));
-          when(repository.getLaoById())
-              .thenReturn(Collections.singletonMap(LAO_ID, new LAOState(LAO)));
           when(keyManager.getValidPoPToken(any())).thenReturn(POP_TOKEN);
           when(keyManager.getMainPublicKey()).thenReturn(POP_TOKEN.getPublicKey());
           when(networkManager.getMessageSender()).thenReturn(messageSender);

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/ConsensusHandlerTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/ConsensusHandlerTest.java
@@ -8,7 +8,8 @@ import com.github.dedis.popstellar.model.network.method.message.data.consensus.*
 import com.github.dedis.popstellar.model.network.method.message.data.lao.CreateLao;
 import com.github.dedis.popstellar.model.objects.*;
 import com.github.dedis.popstellar.model.objects.security.*;
-import com.github.dedis.popstellar.repository.*;
+import com.github.dedis.popstellar.repository.LAORepository;
+import com.github.dedis.popstellar.repository.ServerRepository;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.security.KeyManager;
@@ -69,11 +70,9 @@ public class ConsensusHandlerTest {
 
   private LAORepository laoRepository;
   private MessageHandler messageHandler;
-  private ServerRepository serverRepository;
 
   private MessageGeneral electMsg;
   private MessageID messageId;
-  private Lao lao;
 
   @Mock MessageSender messageSender;
   @Mock KeyManager keyManager;
@@ -88,7 +87,8 @@ public class ConsensusHandlerTest {
 
     laoRepository = new LAORepository();
     messageHandler =
-        new MessageHandler(DataRegistryModule.provideDataRegistry(), keyManager, serverRepository);
+        new MessageHandler(
+            DataRegistryModule.provideDataRegistry(), keyManager, new ServerRepository());
 
     Channel channel = Channel.getLaoChannel(LAO_ID);
     MessageGeneral createLaoMessage = getMsg(ORGANIZER_KEY, CREATE_LAO);
@@ -96,7 +96,6 @@ public class ConsensusHandlerTest {
 
     electMsg = getMsg(NODE_2_KEY, elect);
     messageId = electMsg.getMessageId();
-    lao = laoRepository.getLaoById().get(LAO_ID).getLao();
   }
 
   /**
@@ -279,8 +278,6 @@ public class ConsensusHandlerTest {
       throws DataHandlingException, UnknownLaoException {
     LAORepository mockLAORepository = mock(LAORepository.class);
     Map<MessageID, MessageGeneral> messageById = new HashMap<>();
-    Map<String, LAOState> laoStateMap = new HashMap<>();
-    laoStateMap.put(lao.getId(), new LAOState(lao));
     when(mockLAORepository.getMessageById()).thenReturn(messageById);
 
     ConsensusPrepare prepare = new ConsensusPrepare(INSTANCE_ID, messageId, CREATION_TIME, 3);

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/ElectionHandlerTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/ElectionHandlerTest.java
@@ -12,7 +12,8 @@ import com.github.dedis.popstellar.model.objects.event.EventState;
 import com.github.dedis.popstellar.model.objects.security.*;
 import com.github.dedis.popstellar.model.objects.security.elGamal.ElectionKeyPair;
 import com.github.dedis.popstellar.model.objects.security.elGamal.ElectionPublicKey;
-import com.github.dedis.popstellar.repository.*;
+import com.github.dedis.popstellar.repository.LAORepository;
+import com.github.dedis.popstellar.repository.ServerRepository;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.utility.error.DataHandlingException;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
@@ -124,9 +125,8 @@ public class ElectionHandlerTest extends TestCase {
           }
         });
 
-    // Add the LAO to the LAORepository
-    laoRepository.getLaoById().put(lao.getId(), new LAOState(lao));
-    laoRepository.setAllLaoSubject();
+    // Add the Lao to the repository
+    laoRepository.updateLao(lao);
 
     // Add the CreateLao message to the LAORepository
     MessageGeneral createLaoMessage = new MessageGeneral(SENDER_KEY, CREATE_LAO, GSON);

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/LaoHandlerTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/LaoHandlerTest.java
@@ -8,7 +8,8 @@ import com.github.dedis.popstellar.model.objects.*;
 import com.github.dedis.popstellar.model.objects.security.KeyPair;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.model.objects.view.LaoView;
-import com.github.dedis.popstellar.repository.*;
+import com.github.dedis.popstellar.repository.LAORepository;
+import com.github.dedis.popstellar.repository.ServerRepository;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.utility.error.DataHandlingException;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
@@ -75,8 +76,7 @@ public class LaoHandlerTest {
     // Create one LAO and add it to the LAORepository
     lao = new Lao(CREATE_LAO.getName(), CREATE_LAO.getOrganizer(), CREATE_LAO.getCreation());
     lao.setLastModified(lao.getCreation());
-    laoRepository.getLaoById().put(lao.getId(), new LAOState(lao));
-    laoRepository.setAllLaoSubject();
+    laoRepository.updateLao(lao);
 
     // Add the CreateLao message to the LAORepository
     createLaoMessage = new MessageGeneral(SENDER_KEY, CREATE_LAO, GSON);

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/RollCallHandlerTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/RollCallHandlerTest.java
@@ -10,7 +10,8 @@ import com.github.dedis.popstellar.model.network.method.message.data.rollcall.*;
 import com.github.dedis.popstellar.model.objects.*;
 import com.github.dedis.popstellar.model.objects.event.EventState;
 import com.github.dedis.popstellar.model.objects.security.*;
-import com.github.dedis.popstellar.repository.*;
+import com.github.dedis.popstellar.repository.LAORepository;
+import com.github.dedis.popstellar.repository.ServerRepository;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.utility.error.DataHandlingException;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
@@ -53,7 +54,6 @@ public class RollCallHandlerTest {
 
   private LAORepository laoRepository;
   private MessageHandler messageHandler;
-  private ServerRepository serverRepository;
 
   private RollCall rollCall;
 
@@ -72,7 +72,8 @@ public class RollCallHandlerTest {
 
     laoRepository = new LAORepository();
     messageHandler =
-        new MessageHandler(DataRegistryModule.provideDataRegistry(), keyManager, serverRepository);
+        new MessageHandler(
+            DataRegistryModule.provideDataRegistry(), keyManager, new ServerRepository());
 
     // Create one LAO
     Lao lao = new Lao(CREATE_LAO.getName(), CREATE_LAO.getOrganizer(), CREATE_LAO.getCreation());
@@ -89,8 +90,7 @@ public class RollCallHandlerTest {
         });
 
     // Add the LAO to the LAORepository
-    laoRepository.getLaoById().put(lao.getId(), new LAOState(lao));
-    laoRepository.setAllLaoSubject();
+    laoRepository.updateLao(lao);
 
     // Add the CreateLao message to the LAORepository
     MessageGeneral createLaoMessage = new MessageGeneral(SENDER_KEY, CREATE_LAO, GSON);

--- a/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/TransactionCoinHandlerTest.java
+++ b/fe2-android/app/src/test/java/com/github/dedis/popstellar/utility/handler/TransactionCoinHandlerTest.java
@@ -9,7 +9,8 @@ import com.github.dedis.popstellar.model.network.method.message.data.rollcall.Cl
 import com.github.dedis.popstellar.model.objects.*;
 import com.github.dedis.popstellar.model.objects.digitalcash.TransactionObject;
 import com.github.dedis.popstellar.model.objects.security.*;
-import com.github.dedis.popstellar.repository.*;
+import com.github.dedis.popstellar.repository.LAORepository;
+import com.github.dedis.popstellar.repository.ServerRepository;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.utility.error.DataHandlingException;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
@@ -106,8 +107,7 @@ public class TransactionCoinHandlerTest {
         });
 
     // Add the LAO to the LAORepository
-    laoRepository.getLaoById().put(lao.getId(), new LAOState(lao));
-    laoRepository.setAllLaoSubject();
+    laoRepository.updateLao(lao);
 
     // Add the CreateLao message to the LAORepository
     MessageGeneral createLaoMessage = new MessageGeneral(SENDER_KEY, CREATE_LAO, GSON);


### PR DESCRIPTION
This PR is the second part of the refactor of the Lao repository.

It is made to be an intermediate step that refactored the repository data storage to its final form without touching the UI (if possible)

That is why I kept the function `getAllLaos` but it will be removed in a subsequent PR.