### PR TITLE
Migrate handlers to object rather than static methods

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/di/DataRegistryModule.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/di/DataRegistryModule.java
@@ -30,15 +30,21 @@ public abstract class DataRegistryModule {
 
   @Provides
   @Singleton
-  public static DataRegistry provideDataRegistry() {
+  public static DataRegistry provideDataRegistry(
+      LaoHandler laoHandler,
+      RollCallHandler rollCallHandler,
+      ElectionHandler electionHandler,
+      ConsensusHandler consensusHandler,
+      ChirpHandler chirpHandler,
+      TransactionCoinHandler transactionCoinHandler) {
     DataRegistry.Builder builder = new DataRegistry.Builder();
 
     // Lao
     builder
-        .add(LAO, CREATE, CreateLao.class, LaoHandler::handleCreateLao)
-        .add(LAO, UPDATE, UpdateLao.class, LaoHandler::handleUpdateLao)
-        .add(LAO, STATE, StateLao.class, LaoHandler::handleStateLao)
-        .add(LAO, GREET, GreetLao.class, LaoHandler::handleGreetLao);
+        .add(LAO, CREATE, CreateLao.class, laoHandler::handleCreateLao)
+        .add(LAO, UPDATE, UpdateLao.class, laoHandler::handleUpdateLao)
+        .add(LAO, STATE, StateLao.class, laoHandler::handleStateLao)
+        .add(LAO, GREET, GreetLao.class, laoHandler::handleGreetLao);
 
     // Meeting
     builder
@@ -50,40 +56,40 @@ public abstract class DataRegistryModule {
 
     // Roll Call
     builder
-        .add(ROLL_CALL, CREATE, CreateRollCall.class, RollCallHandler::handleCreateRollCall)
-        .add(ROLL_CALL, OPEN, OpenRollCall.class, RollCallHandler::handleOpenRollCall)
-        .add(ROLL_CALL, REOPEN, OpenRollCall.class, RollCallHandler::handleOpenRollCall)
-        .add(ROLL_CALL, CLOSE, CloseRollCall.class, RollCallHandler::handleCloseRollCall);
+        .add(ROLL_CALL, CREATE, CreateRollCall.class, rollCallHandler::handleCreateRollCall)
+        .add(ROLL_CALL, OPEN, OpenRollCall.class, rollCallHandler::handleOpenRollCall)
+        .add(ROLL_CALL, REOPEN, OpenRollCall.class, rollCallHandler::handleOpenRollCall)
+        .add(ROLL_CALL, CLOSE, CloseRollCall.class, rollCallHandler::handleCloseRollCall);
 
     // Election
     builder
-        .add(ELECTION, SETUP, ElectionSetup.class, ElectionHandler::handleElectionSetup)
-        .add(ELECTION, OPEN, OpenElection.class, ElectionHandler::handleElectionOpen)
-        .add(ELECTION, CAST_VOTE, CastVote.class, ElectionHandler::handleCastVote)
-        .add(ELECTION, END, ElectionEnd.class, ElectionHandler::handleElectionEnd)
-        .add(ELECTION, RESULT, ElectionResult.class, ElectionHandler::handleElectionResult)
-        .add(ELECTION, KEY, ElectionKey.class, ElectionHandler::handleElectionKey);
+        .add(ELECTION, SETUP, ElectionSetup.class, electionHandler::handleElectionSetup)
+        .add(ELECTION, OPEN, OpenElection.class, electionHandler::handleElectionOpen)
+        .add(ELECTION, CAST_VOTE, CastVote.class, electionHandler::handleCastVote)
+        .add(ELECTION, END, ElectionEnd.class, electionHandler::handleElectionEnd)
+        .add(ELECTION, RESULT, ElectionResult.class, electionHandler::handleElectionResult)
+        .add(ELECTION, KEY, ElectionKey.class, electionHandler::handleElectionKey);
 
     // Consensus
     builder
-        .add(CONSENSUS, ELECT, ConsensusElect.class, ConsensusHandler::handleElect)
+        .add(CONSENSUS, ELECT, ConsensusElect.class, consensusHandler::handleElect)
         .add(
             CONSENSUS,
             ELECT_ACCEPT,
             ConsensusElectAccept.class,
-            ConsensusHandler::handleElectAccept)
-        .add(CONSENSUS, PREPARE, ConsensusPrepare.class, ConsensusHandler::handleBackend)
-        .add(CONSENSUS, PROMISE, ConsensusPromise.class, ConsensusHandler::handleBackend)
-        .add(CONSENSUS, PROPOSE, ConsensusPropose.class, ConsensusHandler::handleBackend)
-        .add(CONSENSUS, ACCEPT, ConsensusAccept.class, ConsensusHandler::handleBackend)
-        .add(CONSENSUS, LEARN, ConsensusLearn.class, ConsensusHandler::handleLearn)
-        .add(CONSENSUS, FAILURE, ConsensusFailure.class, ConsensusHandler::handleConsensusFailure);
+            consensusHandler::handleElectAccept)
+        .add(CONSENSUS, PREPARE, ConsensusPrepare.class, consensusHandler::handleBackend)
+        .add(CONSENSUS, PROMISE, ConsensusPromise.class, consensusHandler::handleBackend)
+        .add(CONSENSUS, PROPOSE, ConsensusPropose.class, consensusHandler::handleBackend)
+        .add(CONSENSUS, ACCEPT, ConsensusAccept.class, consensusHandler::handleBackend)
+        .add(CONSENSUS, LEARN, ConsensusLearn.class, consensusHandler::handleLearn)
+        .add(CONSENSUS, FAILURE, ConsensusFailure.class, consensusHandler::handleConsensusFailure);
 
     // Social Media
     builder
-        .add(CHIRP, ADD, AddChirp.class, ChirpHandler::handleChirpAdd)
+        .add(CHIRP, ADD, AddChirp.class, chirpHandler::handleChirpAdd)
         .add(CHIRP, NOTIFY_ADD, NotifyAddChirp.class, null)
-        .add(CHIRP, DELETE, DeleteChirp.class, ChirpHandler::handleDeleteChirp)
+        .add(CHIRP, DELETE, DeleteChirp.class, chirpHandler::handleDeleteChirp)
         .add(CHIRP, NOTIFY_DELETE, NotifyDeleteChirp.class, null);
 
     // Digital Cash
@@ -91,7 +97,7 @@ public abstract class DataRegistryModule {
         COIN,
         POST_TRANSACTION,
         PostTransactionCoin.class,
-        TransactionCoinHandler::handlePostTransactionCoin);
+        transactionCoinHandler::handlePostTransactionCoin);
 
     return builder.build();
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/GlobalNetworkManager.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/GlobalNetworkManager.java
@@ -2,8 +2,6 @@ package com.github.dedis.popstellar.repository.remote;
 
 import androidx.annotation.NonNull;
 
-import com.github.dedis.popstellar.repository.LAORepository;
-import com.github.dedis.popstellar.repository.MessageRepository;
 import com.github.dedis.popstellar.utility.handler.MessageHandler;
 import com.github.dedis.popstellar.utility.scheduler.SchedulerProvider;
 import com.google.gson.Gson;
@@ -20,8 +18,6 @@ public class GlobalNetworkManager implements Disposable {
 
   private static final String DEFAULT_URL = "ws://10.0.2.2:9000/organizer/client";
 
-  private final MessageRepository messageRepo;
-  private final LAORepository laoRepo;
   private final MessageHandler messageHandler;
   private final ConnectionFactory connectionFactory;
   private final Gson gson;
@@ -32,14 +28,10 @@ public class GlobalNetworkManager implements Disposable {
 
   @Inject
   public GlobalNetworkManager(
-      MessageRepository messageRepo,
-      LAORepository laoRepo,
       MessageHandler messageHandler,
       ConnectionFactory connectionFactory,
       Gson gson,
       SchedulerProvider schedulerProvider) {
-    this.messageRepo = messageRepo;
-    this.laoRepo = laoRepo;
     this.messageHandler = messageHandler;
     this.connectionFactory = connectionFactory;
     this.gson = gson;
@@ -52,9 +44,7 @@ public class GlobalNetworkManager implements Disposable {
     if (networkManager != null) networkManager.dispose();
 
     Connection connection = connectionFactory.createConnection(url);
-    networkManager =
-        new LAONetworkManager(
-            messageRepo, laoRepo, messageHandler, connection, gson, schedulerProvider);
+    networkManager = new LAONetworkManager(messageHandler, connection, gson, schedulerProvider);
     currentURL = url;
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/LAONetworkManager.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/LAONetworkManager.java
@@ -10,8 +10,6 @@ import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
 import com.github.dedis.popstellar.model.network.method.message.data.Data;
 import com.github.dedis.popstellar.model.objects.Channel;
 import com.github.dedis.popstellar.model.objects.security.KeyPair;
-import com.github.dedis.popstellar.repository.LAORepository;
-import com.github.dedis.popstellar.repository.MessageRepository;
 import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.handler.MessageHandler;
 import com.github.dedis.popstellar.utility.scheduler.SchedulerProvider;
@@ -33,8 +31,6 @@ public class LAONetworkManager implements MessageSender {
 
   private static final String TAG = LAONetworkManager.class.getSimpleName();
 
-  private final MessageRepository messageRepo;
-  private final LAORepository laoRepo;
   private final MessageHandler messageHandler;
   private final Connection connection;
   public final AtomicInteger requestCounter = new AtomicInteger();
@@ -47,14 +43,10 @@ public class LAONetworkManager implements MessageSender {
   private final CompositeDisposable disposables = new CompositeDisposable();
 
   public LAONetworkManager(
-      MessageRepository messageRepo,
-      LAORepository laoRepo,
       MessageHandler messageHandler,
       Connection connection,
       Gson gson,
       SchedulerProvider schedulerProvider) {
-    this.messageRepo = messageRepo;
-    this.laoRepo = laoRepo;
     this.messageHandler = messageHandler;
     this.connection = connection;
     this.gson = gson;
@@ -173,8 +165,7 @@ public class LAONetworkManager implements MessageSender {
   private void handleBroadcast(Broadcast broadcast) {
     Log.d(TAG, "handling broadcast msg : " + broadcast);
     try {
-      messageHandler.handleMessage(
-          messageRepo, laoRepo, this, broadcast.getChannel(), broadcast.getMessage());
+      messageHandler.handleMessage(this, broadcast.getChannel(), broadcast.getMessage());
     } catch (DataHandlingException | UnknownLaoException e) {
       Log.e(TAG, "Error while handling received message", e);
       unprocessed.onNext(broadcast);
@@ -184,7 +175,7 @@ public class LAONetworkManager implements MessageSender {
   private void handleMessages(List<MessageGeneral> messages, Channel channel) {
     for (MessageGeneral msg : messages) {
       try {
-        messageHandler.handleMessage(messageRepo, laoRepo, this, channel, msg);
+        messageHandler.handleMessage(this, channel, msg);
       } catch (DataHandlingException | UnknownLaoException e) {
         Log.e(TAG, "Error while handling received catchup message", e);
       }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ChirpHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ChirpHandler.java
@@ -14,13 +14,18 @@ import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 
 import java.util.Optional;
 
+import javax.inject.Inject;
+
 /** Chirp messages handler class */
 public final class ChirpHandler {
 
   public static final String TAG = ChirpHandler.class.getSimpleName();
 
-  private ChirpHandler() {
-    throw new IllegalArgumentException("Utility class");
+  private final LAORepository laoRepo;
+
+  @Inject
+  public ChirpHandler(LAORepository laoRepo) {
+    this.laoRepo = laoRepo;
   }
 
   /**
@@ -29,15 +34,13 @@ public final class ChirpHandler {
    * @param context the HandlerContext of the message
    * @param addChirp the data of the message that was received
    */
-  public static void handleChirpAdd(HandlerContext context, AddChirp addChirp)
-      throws UnknownLaoException {
-    LAORepository laoRepository = context.getLaoRepository();
+  public void handleChirpAdd(HandlerContext context, AddChirp addChirp) throws UnknownLaoException {
     Channel channel = context.getChannel();
     MessageID messageId = context.getMessageId();
     PublicKey senderPk = context.getSenderPk();
 
     Log.d(TAG, "handleChirpAdd: " + channel + " id " + addChirp.getParentId());
-    LaoView laoView = laoRepository.getLaoViewByChannel(channel);
+    LaoView laoView = laoRepo.getLaoViewByChannel(channel);
     Chirp chirp = new Chirp(messageId);
 
     chirp.setChannel(channel);
@@ -48,7 +51,7 @@ public final class ChirpHandler {
 
     Lao lao = laoView.createLaoCopy();
     lao.updateChirpList(messageId, chirp);
-    laoRepository.updateLao(lao);
+    laoRepo.updateLao(lao);
   }
 
   /**
@@ -57,14 +60,12 @@ public final class ChirpHandler {
    * @param context the HandlerContext of the message
    * @param deleteChirp the data of the message that was received
    */
-  public static void handleDeleteChirp(HandlerContext context, DeleteChirp deleteChirp)
+  public void handleDeleteChirp(HandlerContext context, DeleteChirp deleteChirp)
       throws UnknownLaoException, InvalidMessageIdException {
-    LAORepository laoRepository = context.getLaoRepository();
     Channel channel = context.getChannel();
 
     Log.d(TAG, "handleDeleteChirp: " + channel + " id " + deleteChirp.getChirpId());
-
-    LaoView laoView = laoRepository.getLaoViewByChannel(channel);
+    LaoView laoView = laoRepo.getLaoViewByChannel(channel);
     Optional<Chirp> chirpOptional = laoView.getChirp(deleteChirp.getChirpId());
 
     if (!chirpOptional.isPresent()) {
@@ -81,6 +82,6 @@ public final class ChirpHandler {
 
     Lao lao = laoView.createLaoCopy();
     lao.updateChirpList(chirp.getId(), chirp);
-    laoRepository.updateLao(lao);
+    laoRepo.updateLao(lao);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ConsensusHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ConsensusHandler.java
@@ -14,13 +14,18 @@ import com.github.dedis.popstellar.utility.error.*;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.inject.Inject;
+
 public final class ConsensusHandler {
 
-  private ConsensusHandler() {
-    throw new IllegalStateException("Utility class");
-  }
-
   public static final String TAG = ConsensusHandler.class.getSimpleName();
+
+  private final LAORepository laoRepo;
+
+  @Inject
+  public ConsensusHandler(LAORepository laoRepo) {
+    this.laoRepo = laoRepo;
+  }
 
   /**
    * Process an Elect message.
@@ -28,16 +33,15 @@ public final class ConsensusHandler {
    * @param context the HandlerContext of the message
    * @param consensusElect the data of the message that was received
    */
-  public static void handleElect(HandlerContext context, ConsensusElect consensusElect)
+  public void handleElect(HandlerContext context, ConsensusElect consensusElect)
       throws UnknownLaoException {
-    LAORepository laoRepository = context.getLaoRepository();
     Channel channel = context.getChannel();
     MessageID messageId = context.getMessageId();
     PublicKey senderPk = context.getSenderPk();
 
     Log.d(TAG, "handleElect: " + channel + " id " + consensusElect.getInstanceId());
 
-    LaoView laoView = laoRepository.getLaoViewByChannel(channel);
+    LaoView laoView = laoRepo.getLaoViewByChannel(channel);
     Set<PublicKey> nodes = laoView.getWitnesses();
     nodes.add(laoView.getOrganizer());
 
@@ -46,20 +50,18 @@ public final class ConsensusHandler {
     Lao lao = laoView.createLaoCopy();
     lao.updateElectInstance(electInstance);
 
-    laoRepository.updateNodes(laoView.getChannel());
-    laoRepository.updateLao(lao);
+    laoRepo.updateNodes(laoView.getChannel());
+    laoRepo.updateLao(lao);
   }
 
-  public static void handleElectAccept(
-      HandlerContext context, ConsensusElectAccept consensusElectAccept)
+  public void handleElectAccept(HandlerContext context, ConsensusElectAccept consensusElectAccept)
       throws DataHandlingException, UnknownLaoException {
-    LAORepository laoRepository = context.getLaoRepository();
     Channel channel = context.getChannel();
     MessageID messageId = context.getMessageId();
     PublicKey senderPk = context.getSenderPk();
 
     Log.d(TAG, "handleElectAccept: " + channel + " id " + consensusElectAccept.getInstanceId());
-    LaoView laoView = laoRepository.getLaoViewByChannel(channel);
+    LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     Optional<ElectInstance> electInstanceOpt =
         laoView.getElectInstance(consensusElectAccept.getMessageId());
@@ -74,22 +76,21 @@ public final class ConsensusHandler {
     Lao lao = laoView.createLaoCopy();
     lao.updateElectInstance(electInstance);
 
-    laoRepository.updateLao(lao);
-    laoRepository.updateNodes(laoView.getChannel());
+    laoRepo.updateLao(lao);
+    laoRepo.updateNodes(laoView.getChannel());
   }
 
   @SuppressWarnings("unused")
-  public static <T extends Data> void handleBackend(HandlerContext context, T data) {
+  public <T extends Data> void handleBackend(HandlerContext context, T data) {
     Log.w(TAG, "Received a consensus message only for backend with action=" + data.getAction());
   }
 
-  public static void handleLearn(HandlerContext context, ConsensusLearn consensusLearn)
+  public void handleLearn(HandlerContext context, ConsensusLearn consensusLearn)
       throws DataHandlingException, UnknownLaoException {
-    LAORepository laoRepository = context.getLaoRepository();
     Channel channel = context.getChannel();
 
     Log.d(TAG, "handleLearn: " + channel + " id " + consensusLearn.getInstanceId());
-    LaoView laoView = laoRepository.getLaoViewByChannel(channel);
+    LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     Optional<ElectInstance> electInstanceOpt =
         laoView.getElectInstance(consensusLearn.getMessageId());
@@ -106,17 +107,16 @@ public final class ConsensusHandler {
     Lao lao = laoView.createLaoCopy();
     lao.updateElectInstance(electInstance);
 
-    laoRepository.updateLao(lao);
-    laoRepository.updateNodes(laoView.getChannel());
+    laoRepo.updateLao(lao);
+    laoRepo.updateNodes(laoView.getChannel());
   }
 
-  public static void handleConsensusFailure(HandlerContext context, ConsensusFailure failure)
+  public void handleConsensusFailure(HandlerContext context, ConsensusFailure failure)
       throws UnknownLaoException, InvalidMessageIdException {
-    LAORepository laoRepository = context.getLaoRepository();
     Channel channel = context.getChannel();
 
     Log.d(TAG, "handleConsensusFailure: " + channel + " id " + failure.getInstanceId());
-    LaoView laoView = laoRepository.getLaoViewByChannel(channel);
+    LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     Optional<ElectInstance> electInstanceOpt = laoView.getElectInstance(failure.getMessageId());
     if (!electInstanceOpt.isPresent()) {
@@ -129,7 +129,7 @@ public final class ConsensusHandler {
     Lao lao = laoView.createLaoCopy();
     lao.updateElectInstance(electInstance);
 
-    laoRepository.updateLao(lao);
-    laoRepository.updateNodes(laoView.getChannel());
+    laoRepo.updateLao(lao);
+    laoRepo.updateNodes(laoView.getChannel());
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
@@ -29,7 +29,7 @@ public final class ElectionHandler {
   private final MessageRepository messageRepo;
 
   @Inject
-  public ElectionHandler(LAORepository laoRepo, MessageRepository messageRepo) {
+  public ElectionHandler(MessageRepository messageRepo, LAORepository laoRepo) {
     this.laoRepo = laoRepo;
     this.messageRepo = messageRepo;
   }
@@ -207,7 +207,7 @@ public final class ElectionHandler {
     laoRepo.updateLao(lao);
   }
 
-  public WitnessMessage electionSetupWitnessMessage(MessageID messageId, Election election) {
+  public static WitnessMessage electionSetupWitnessMessage(MessageID messageId, Election election) {
     WitnessMessage message = new WitnessMessage(messageId);
     message.setTitle("New Election Setup");
     message.setDescription(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
@@ -16,6 +16,8 @@ import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 import java.time.Instant;
 import java.util.*;
 
+import javax.inject.Inject;
+
 import static com.github.dedis.popstellar.model.objects.event.EventState.*;
 
 /** Election messages handler class */
@@ -23,8 +25,13 @@ public final class ElectionHandler {
 
   public static final String TAG = ElectionHandler.class.getSimpleName();
 
-  private ElectionHandler() {
-    throw new IllegalStateException("Utility class");
+  private final LAORepository laoRepo;
+  private final MessageRepository messageRepo;
+
+  @Inject
+  public ElectionHandler(LAORepository laoRepo, MessageRepository messageRepo) {
+    this.laoRepo = laoRepo;
+    this.messageRepo = messageRepo;
   }
 
   /**
@@ -33,9 +40,8 @@ public final class ElectionHandler {
    * @param context the HandlerContext of the message
    * @param electionSetup the message that was received
    */
-  public static void handleElectionSetup(HandlerContext context, ElectionSetup electionSetup)
+  public void handleElectionSetup(HandlerContext context, ElectionSetup electionSetup)
       throws UnknownLaoException {
-    LAORepository laoRepo = context.getLaoRepository();
     Channel channel = context.getChannel();
     MessageID messageId = context.getMessageId();
 
@@ -74,9 +80,8 @@ public final class ElectionHandler {
    * @param context the HandlerContext of the message
    * @param electionResult the message that was received
    */
-  public static void handleElectionResult(HandlerContext context, ElectionResult electionResult)
+  public void handleElectionResult(HandlerContext context, ElectionResult electionResult)
       throws UnknownLaoException, DataHandlingException {
-    LAORepository laoRepo = context.getLaoRepository();
     Channel channel = context.getChannel();
 
     Log.d(TAG, "handling election result");
@@ -105,9 +110,8 @@ public final class ElectionHandler {
    * @param openElection the message that was received
    */
   @SuppressWarnings("unused")
-  public static void handleElectionOpen(HandlerContext context, OpenElection openElection)
+  public void handleElectionOpen(HandlerContext context, OpenElection openElection)
       throws UnknownLaoException {
-    LAORepository laoRepo = context.getLaoRepository();
     Channel channel = context.getChannel();
 
     Log.d(TAG, "handleOpenElection: channel " + channel);
@@ -136,9 +140,8 @@ public final class ElectionHandler {
    * @param electionEnd the message that was received
    */
   @SuppressWarnings("unused")
-  public static void handleElectionEnd(HandlerContext context, ElectionEnd electionEnd)
+  public void handleElectionEnd(HandlerContext context, ElectionEnd electionEnd)
       throws UnknownLaoException {
-    LAORepository laoRepo = context.getLaoRepository();
     Channel channel = context.getChannel();
 
     Log.d(TAG, "handleElectionEnd: channel " + channel);
@@ -159,10 +162,8 @@ public final class ElectionHandler {
    * @param castVote the message that was received
    */
   @SuppressWarnings("unchecked") // Because of the way CastVote is designed, this must be done
-  public static void handleCastVote(HandlerContext context, CastVote<?> castVote)
+  public void handleCastVote(HandlerContext context, CastVote<?> castVote)
       throws UnknownLaoException {
-    LAORepository laoRepo = context.getLaoRepository();
-    MessageRepository messageRepo = context.getMessageRepository();
     Channel channel = context.getChannel();
     MessageID messageId = context.getMessageId();
     PublicKey senderPk = context.getSenderPk();
@@ -206,7 +207,7 @@ public final class ElectionHandler {
     laoRepo.updateLao(lao);
   }
 
-  public static WitnessMessage electionSetupWitnessMessage(MessageID messageId, Election election) {
+  public WitnessMessage electionSetupWitnessMessage(MessageID messageId, Election election) {
     WitnessMessage message = new WitnessMessage(messageId);
     message.setTitle("New Election Setup");
     message.setDescription(
@@ -230,8 +231,7 @@ public final class ElectionHandler {
    * @param context context
    * @param electionKey key to add
    */
-  public static void handleElectionKey(HandlerContext context, ElectionKey electionKey) {
-    LAORepository laoRepo = context.getLaoRepository();
+  public void handleElectionKey(HandlerContext context, ElectionKey electionKey) {
     Channel channel = context.getChannel();
 
     Log.d(TAG, "handleElectionKey: channel " + channel);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/HandlerContext.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/HandlerContext.java
@@ -2,51 +2,27 @@ package com.github.dedis.popstellar.utility.handler.data;
 
 import androidx.annotation.NonNull;
 
-import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
 import com.github.dedis.popstellar.model.objects.Channel;
 import com.github.dedis.popstellar.model.objects.security.MessageID;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
-import com.github.dedis.popstellar.repository.*;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
-import com.github.dedis.popstellar.utility.security.KeyManager;
 
 public final class HandlerContext {
 
-  private final MessageRepository messageRepo;
-  private final LAORepository laoRepo;
-  private final KeyManager keyManager;
+  private final MessageID messageId;
+  private final PublicKey senderPk;
   private final MessageSender messageSender;
   private final Channel channel;
-  private final MessageGeneral message;
-  private final ServerRepository serverRepository;
 
   public HandlerContext(
-      @NonNull MessageRepository messageRepo,
-      @NonNull LAORepository laoRepo,
-      @NonNull KeyManager keyManager,
-      @NonNull MessageSender messageSender,
+      @NonNull MessageID messageId,
+      @NonNull PublicKey senderPk,
       @NonNull Channel channel,
-      @NonNull MessageGeneral message,
-      @NonNull ServerRepository serverRepository) {
-    this.messageRepo = messageRepo;
-    this.laoRepo = laoRepo;
-    this.keyManager = keyManager;
+      @NonNull MessageSender messageSender) {
+    this.messageId = messageId;
+    this.senderPk = senderPk;
     this.messageSender = messageSender;
     this.channel = channel;
-    this.message = message;
-    this.serverRepository = serverRepository;
-  }
-
-  public MessageRepository getMessageRepository() {
-    return messageRepo;
-  }
-
-  public LAORepository getLaoRepository() {
-    return laoRepo;
-  }
-
-  public KeyManager getKeyManager() {
-    return keyManager;
   }
 
   public MessageSender getMessageSender() {
@@ -57,19 +33,11 @@ public final class HandlerContext {
     return channel;
   }
 
-  public MessageGeneral getMessage() {
-    return message;
-  }
-
   public MessageID getMessageId() {
-    return message.getMessageId();
+    return messageId;
   }
 
   public PublicKey getSenderPk() {
-    return message.getSender();
-  }
-
-  public ServerRepository getServerRepository() {
-    return serverRepository;
+    return senderPk;
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
@@ -11,16 +11,32 @@ import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.repository.*;
 import com.github.dedis.popstellar.utility.error.*;
+import com.github.dedis.popstellar.utility.security.KeyManager;
 
 import java.util.*;
+
+import javax.inject.Inject;
 
 /** Lao messages handler class */
 public final class LaoHandler {
 
   public static final String TAG = LaoHandler.class.getSimpleName();
 
-  private LaoHandler() {
-    throw new IllegalStateException("Utility class");
+  private final MessageRepository messageRepo;
+  private final LAORepository laoRepo;
+  private final KeyManager keyManager;
+  private final ServerRepository serverRepo;
+
+  @Inject
+  public LaoHandler(
+      MessageRepository messageRepo,
+      LAORepository laoRepo,
+      KeyManager keyManager,
+      ServerRepository serverRepo) {
+    this.messageRepo = messageRepo;
+    this.laoRepo = laoRepo;
+    this.keyManager = keyManager;
+    this.serverRepo = serverRepo;
   }
 
   /**
@@ -30,8 +46,7 @@ public final class LaoHandler {
    * @param createLao the message that was received
    */
   @SuppressLint("CheckResult") // for now concerns Consensus which is not a priority this semester
-  public static void handleCreateLao(HandlerContext context, CreateLao createLao) {
-    LAORepository laoRepo = context.getLaoRepository();
+  public void handleCreateLao(HandlerContext context, CreateLao createLao) {
     Channel channel = context.getChannel();
 
     Log.d(TAG, "handleCreateLao: channel " + channel + ", msg=" + createLao);
@@ -46,7 +61,7 @@ public final class LaoHandler {
 
     laoRepo.updateLao(lao);
 
-    PublicKey publicKey = context.getKeyManager().getMainPublicKey();
+    PublicKey publicKey = keyManager.getMainPublicKey();
     if (lao.getOrganizer().equals(publicKey) || lao.getWitnesses().contains(publicKey)) {
       context
           .getMessageSender()
@@ -54,7 +69,7 @@ public final class LaoHandler {
           .subscribe( // For now if we receive an error, we assume that it is because the server
               // running is the scala one which does not implement consensus
               () -> Log.d(TAG, "subscription to consensus channel was a success"),
-              error -> Log.d(TAG, "error while trying to subscribe to consensus channel"));
+              error -> Log.d(TAG, "error while trying to subscribe to consensus channel", error));
     }
 
     /* Creation channel coin*/
@@ -63,7 +78,7 @@ public final class LaoHandler {
         .subscribe(channel.subChannel("coin"))
         .subscribe(
             () -> Log.d(TAG, "subscription to the coin channel was a success"),
-            error -> Log.d(TAG, "error while trying  to subscribe to coin channel"));
+            error -> Log.d(TAG, "error while trying  to subscribe to coin channel", error));
 
     laoRepo.updateNodes(channel);
   }
@@ -74,9 +89,8 @@ public final class LaoHandler {
    * @param context the HandlerContext of the message
    * @param updateLao the message that was received
    */
-  public static void handleUpdateLao(HandlerContext context, UpdateLao updateLao)
+  public void handleUpdateLao(HandlerContext context, UpdateLao updateLao)
       throws DataHandlingException, UnknownLaoException {
-    LAORepository laoRepo = context.getLaoRepository();
     Channel channel = context.getChannel();
     MessageID messageId = context.getMessageId();
 
@@ -119,10 +133,8 @@ public final class LaoHandler {
    * @param stateLao the message that was received
    */
   @SuppressLint("CheckResult")
-  public static void handleStateLao(HandlerContext context, StateLao stateLao)
+  public void handleStateLao(HandlerContext context, StateLao stateLao)
       throws DataHandlingException, UnknownLaoException {
-    MessageRepository messageRepo = context.getMessageRepository();
-    LAORepository laoRepo = context.getLaoRepository();
     Channel channel = context.getChannel();
 
     Log.d(TAG, "Receive State Lao Broadcast msg=" + stateLao);
@@ -154,9 +166,8 @@ public final class LaoHandler {
     lao.setLastModified(stateLao.getLastModified());
     lao.setModificationId(stateLao.getModificationId());
 
-    PublicKey publicKey = context.getKeyManager().getMainPublicKey();
+    PublicKey publicKey = keyManager.getMainPublicKey();
     if (laoView.isOrganizer(publicKey) || laoView.isWitness(publicKey)) {
-
       context
           .getMessageSender()
           .subscribe(laoView.getChannel().subChannel("consensus"))
@@ -190,7 +201,7 @@ public final class LaoHandler {
     return message;
   }
 
-  public static WitnessMessage updateLaoWitnessesWitnessMessage(
+  public WitnessMessage updateLaoWitnessesWitnessMessage(
       MessageID messageId, UpdateLao updateLao, LaoView laoView) {
     WitnessMessage message = new WitnessMessage(messageId);
     List<PublicKey> tempList = new ArrayList<>(updateLao.getWitnesses());
@@ -207,9 +218,7 @@ public final class LaoHandler {
     return message;
   }
 
-  public static void handleGreetLao(HandlerContext context, GreetLao greetLao)
-      throws UnknownLaoException {
-    LAORepository laoRepo = context.getLaoRepository();
+  public void handleGreetLao(HandlerContext context, GreetLao greetLao) throws UnknownLaoException {
     Channel channel = context.getChannel();
 
     Log.d(TAG, "handleGreetLao: channel " + channel + ", msg=" + greetLao);
@@ -232,8 +241,7 @@ public final class LaoHandler {
     Server server = new Server(greetLao.getAddress(), greetLao.getFrontendKey());
 
     Log.d(TAG, "Adding the server to the repository for lao id : " + laoView.getId());
-    ServerRepository serverRepository = context.getServerRepository();
-    serverRepository.addServer(greetLao.getId(), server);
+    serverRepo.addServer(greetLao.getId(), server);
 
     // In the future, implement automatic connection to all the peers contained in the peers
     // message

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
@@ -29,9 +29,9 @@ public final class LaoHandler {
 
   @Inject
   public LaoHandler(
+      KeyManager keyManager,
       MessageRepository messageRepo,
       LAORepository laoRepo,
-      KeyManager keyManager,
       ServerRepository serverRepo) {
     this.messageRepo = messageRepo;
     this.laoRepo = laoRepo;

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.java
@@ -31,7 +31,7 @@ public final class RollCallHandler {
   private final KeyManager keyManager;
 
   @Inject
-  public RollCallHandler(LAORepository laoRepo, KeyManager keyManager) {
+  public RollCallHandler(KeyManager keyManager, LAORepository laoRepo) {
     this.laoRepo = laoRepo;
     this.keyManager = keyManager;
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.java
@@ -13,8 +13,11 @@ import com.github.dedis.popstellar.repository.LAORepository;
 import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.error.keys.InvalidPoPTokenException;
 import com.github.dedis.popstellar.utility.error.keys.KeyException;
+import com.github.dedis.popstellar.utility.security.KeyManager;
 
 import java.util.Optional;
+
+import javax.inject.Inject;
 
 /** Roll Call messages handler class */
 public final class RollCallHandler {
@@ -24,8 +27,13 @@ public final class RollCallHandler {
   private static final String ROLL_CALL_NAME = "Roll Call Name : ";
   private static final String MESSAGE_ID = "Message ID : ";
 
-  private RollCallHandler() {
-    throw new IllegalStateException("Utility class");
+  private final LAORepository laoRepo;
+  private final KeyManager keyManager;
+
+  @Inject
+  public RollCallHandler(LAORepository laoRepo, KeyManager keyManager) {
+    this.laoRepo = laoRepo;
+    this.keyManager = keyManager;
   }
 
   /**
@@ -34,14 +42,13 @@ public final class RollCallHandler {
    * @param context the HandlerContext of the message
    * @param createRollCall the message that was received
    */
-  public static void handleCreateRollCall(HandlerContext context, CreateRollCall createRollCall)
+  public void handleCreateRollCall(HandlerContext context, CreateRollCall createRollCall)
       throws UnknownLaoException {
-    LAORepository laoRepository = context.getLaoRepository();
     Channel channel = context.getChannel();
     MessageID messageId = context.getMessageId();
 
     Log.d(TAG, "handleCreateRollCall: " + channel + " name " + createRollCall.getName());
-    LaoView laoView = laoRepository.getLaoViewByChannel(channel);
+    LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     RollCall rollCall = new RollCall(createRollCall.getId());
     rollCall.setCreation(createRollCall.getCreation());
@@ -57,7 +64,7 @@ public final class RollCallHandler {
     lao.updateRollCall(rollCall.getId(), rollCall);
     lao.updateWitnessMessage(messageId, createRollCallWitnessMessage(messageId, rollCall));
 
-    laoRepository.updateLao(lao);
+    laoRepo.updateLao(lao);
   }
 
   /**
@@ -66,14 +73,13 @@ public final class RollCallHandler {
    * @param context the HandlerContext of the message
    * @param openRollCall the message that was received
    */
-  public static void handleOpenRollCall(HandlerContext context, OpenRollCall openRollCall)
+  public void handleOpenRollCall(HandlerContext context, OpenRollCall openRollCall)
       throws DataHandlingException, UnknownLaoException {
-    LAORepository laoRepository = context.getLaoRepository();
     Channel channel = context.getChannel();
     MessageID messageId = context.getMessageId();
 
     Log.d(TAG, "handleOpenRollCall: " + channel + " msg=" + openRollCall);
-    LaoView laoView = laoRepository.getLaoViewByChannel(channel);
+    LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     String updateId = openRollCall.getUpdateId();
     String opens = openRollCall.getOpens();
@@ -93,7 +99,7 @@ public final class RollCallHandler {
     lao.updateRollCall(opens, rollCall);
     lao.updateWitnessMessage(messageId, openRollCallWitnessMessage(messageId, rollCall));
 
-    laoRepository.updateLao(lao);
+    laoRepo.updateLao(lao);
   }
 
   /**
@@ -103,14 +109,13 @@ public final class RollCallHandler {
    * @param closeRollCall the message that was received
    */
   @SuppressLint("CheckResult")
-  public static void handleCloseRollCall(HandlerContext context, CloseRollCall closeRollCall)
+  public void handleCloseRollCall(HandlerContext context, CloseRollCall closeRollCall)
       throws DataHandlingException, UnknownLaoException {
-    LAORepository laoRepository = context.getLaoRepository();
     Channel channel = context.getChannel();
     MessageID messageId = context.getMessageId();
 
     Log.d(TAG, "handleCloseRollCall: " + channel);
-    LaoView laoView = laoRepository.getLaoViewByChannel(channel);
+    LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     String updateId = closeRollCall.getUpdateId();
     String closes = closeRollCall.getCloses();
@@ -133,9 +138,8 @@ public final class RollCallHandler {
     lao.updateWitnessMessage(messageId, closeRollCallWitnessMessage(messageId, rollCall));
 
     // Subscribe to the social media channels
-    // Subscribe to the digital cash channels
     try {
-      PoPToken token = context.getKeyManager().getValidPoPToken(laoView.getId(), rollCall);
+      PoPToken token = keyManager.getValidPoPToken(laoView.getId(), rollCall);
       context
           .getMessageSender()
           .subscribe(channel.subChannel("social").subChannel(token.getPublicKey().getEncoded()))
@@ -152,7 +156,7 @@ public final class RollCallHandler {
           e);
     }
 
-    laoRepository.updateLao(lao);
+    laoRepo.updateLao(lao);
   }
 
   public static WitnessMessage createRollCallWitnessMessage(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/TransactionCoinHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/TransactionCoinHandler.java
@@ -11,11 +11,15 @@ import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 
 import java.util.*;
 
+import javax.inject.Inject;
+
 public class TransactionCoinHandler {
   public static final String TAG = TransactionCoinHandler.class.getSimpleName();
+  private final LAORepository laoRepo;
 
-  private TransactionCoinHandler() {
-    throw new IllegalArgumentException("Utility class");
+  @Inject
+  public TransactionCoinHandler(LAORepository laoRepo) {
+    this.laoRepo = laoRepo;
   }
 
   /**
@@ -24,14 +28,13 @@ public class TransactionCoinHandler {
    * @param context the HandlerContext of the message
    * @param postTransactionCoin the data of the message that was received
    */
-  public static void handlePostTransactionCoin(
+  public void handlePostTransactionCoin(
       HandlerContext context, PostTransactionCoin postTransactionCoin) throws UnknownLaoException {
-    LAORepository laoRepository = context.getLaoRepository();
     Channel channel = context.getChannel();
 
     Log.d(TAG, "handlePostTransactionCoin: " + channel + " msg=" + postTransactionCoin);
 
-    LaoView laoView = laoRepository.getLaoViewByChannel(channel);
+    LaoView laoView = laoRepo.getLaoViewByChannel(channel);
     TransactionObjectBuilder builder = new TransactionObjectBuilder();
 
     // inputs and outputs for the creation
@@ -87,6 +90,6 @@ public class TransactionCoinHandler {
 
     // lao update the history / lao update the last transaction per public key
     lao.updateTransactionMaps(builder.build());
-    laoRepository.updateLao(lao);
+    laoRepo.updateLao(lao);
   }
 }

--- a/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/di/DataRegistryModuleHelper.java
+++ b/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/di/DataRegistryModuleHelper.java
@@ -1,0 +1,42 @@
+package com.github.dedis.popstellar.di;
+
+import com.github.dedis.popstellar.model.network.method.message.data.DataRegistry;
+import com.github.dedis.popstellar.repository.*;
+import com.github.dedis.popstellar.utility.handler.data.*;
+import com.github.dedis.popstellar.utility.security.KeyManager;
+
+import org.mockito.Mockito;
+
+/** This class helps in the creation of the DataRegistry */
+public class DataRegistryModuleHelper {
+
+  public static DataRegistry buildRegistry() {
+    return buildRegistry(new LAORepository(), Mockito.mock(KeyManager.class));
+  }
+
+  public static DataRegistry buildRegistry(LAORepository laoRepository, KeyManager keyManager) {
+    return buildRegistry(
+        laoRepository, new MessageRepository(), keyManager, new ServerRepository());
+  }
+
+  public static DataRegistry buildRegistry(
+      LAORepository laoRepo,
+      MessageRepository msgRepo,
+      KeyManager keyManager,
+      ServerRepository serverRepo) {
+    LaoHandler laoHandler = new LaoHandler(keyManager, msgRepo, laoRepo, serverRepo);
+    RollCallHandler rollCallHandler = new RollCallHandler(keyManager, laoRepo);
+    ElectionHandler electionHandler = new ElectionHandler(msgRepo, laoRepo);
+    ConsensusHandler consensusHandler = new ConsensusHandler(laoRepo);
+    ChirpHandler chirpHandler = new ChirpHandler(laoRepo);
+    TransactionCoinHandler transactionCoinHandler = new TransactionCoinHandler(laoRepo);
+
+    return DataRegistryModule.provideDataRegistry(
+        laoHandler,
+        rollCallHandler,
+        electionHandler,
+        consensusHandler,
+        chirpHandler,
+        transactionCoinHandler);
+  }
+}

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/detail/event/consensus/ElectionStartFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/detail/event/consensus/ElectionStartFragmentTest.java
@@ -223,12 +223,12 @@ public class ElectionStartFragmentTest {
 
     // Nodes 3 try to start
     MessageGeneral elect3Msg = createMsg(node3KeyPair, elect);
-    messageHandler.handleMessage(messageRepo, laoRepo, messageSender, consensusChannel, elect3Msg);
+    messageHandler.handleMessage(messageSender, consensusChannel, elect3Msg);
     nodeAssertions(grid, node3Pos, "Approve Start by\n" + node3, true);
 
     // We try to start (it should disable the start button)
     MessageGeneral elect1Msg = createMsg(mainKeyPair, elect);
-    messageHandler.handleMessage(messageRepo, laoRepo, messageSender, consensusChannel, elect1Msg);
+    messageHandler.handleMessage(messageSender, consensusChannel, elect1Msg);
     displayAssertions(STATUS_READY, START_START, false);
     nodeAssertions(grid, ownPos, "Approve Start by\n" + publicKey, true);
 
@@ -236,7 +236,7 @@ public class ElectionStartFragmentTest {
     ConsensusElectAccept electAccept3 =
         new ConsensusElectAccept(INSTANCE_ID, elect3Msg.getMessageId(), true);
     MessageGeneral accept3Msg = createMsg(mainKeyPair, electAccept3);
-    messageHandler.handleMessage(messageRepo, laoRepo, messageSender, consensusChannel, accept3Msg);
+    messageHandler.handleMessage(messageSender, consensusChannel, accept3Msg);
     nodeAssertions(grid, node3Pos, "Approve Start by\n" + node3, false);
 
     // Receive a learn message => node3 was accepted and has started the election
@@ -244,7 +244,7 @@ public class ElectionStartFragmentTest {
         new ConsensusLearn(
             INSTANCE_ID, elect3Msg.getMessageId(), PAST_TIME, true, Collections.emptyList());
     MessageGeneral learn3Msg = createMsg(node3KeyPair, learn3);
-    messageHandler.handleMessage(messageRepo, laoRepo, messageSender, consensusChannel, learn3Msg);
+    messageHandler.handleMessage(messageSender, consensusChannel, learn3Msg);
     displayAssertions(STATUS_STARTED, START_STARTED, false);
     nodeAssertions(grid, node3Pos, "Started by\n" + node3, false);
   }
@@ -302,7 +302,7 @@ public class ElectionStartFragmentTest {
 
     // Nodes 3 try to start
     MessageGeneral elect3Msg = createMsg(node3KeyPair, elect);
-    messageHandler.handleMessage(messageRepo, laoRepo, messageSender, consensusChannel, elect3Msg);
+    messageHandler.handleMessage(messageSender, consensusChannel, elect3Msg);
 
     // We try to accept node3
     nodesGrid().atPosition(node3Pos).perform(ViewActions.click());
@@ -323,29 +323,26 @@ public class ElectionStartFragmentTest {
 
     // Nodes 3 try to start and failed
     MessageGeneral elect3Msg = createMsg(node3KeyPair, elect);
-    messageHandler.handleMessage(messageRepo, laoRepo, messageSender, consensusChannel, elect3Msg);
+    messageHandler.handleMessage(messageSender, consensusChannel, elect3Msg);
     ConsensusFailure failure3 =
         new ConsensusFailure(INSTANCE_ID, elect3Msg.getMessageId(), PAST_TIME);
     MessageGeneral failure3Msg = createMsg(node3KeyPair, failure3);
-    messageHandler.handleMessage(
-        messageRepo, laoRepo, messageSender, consensusChannel, failure3Msg);
+    messageHandler.handleMessage(messageSender, consensusChannel, failure3Msg);
 
     nodeAssertions(nodesGrid(), node3Pos, "Start Failed\n" + node3, false);
 
     // We try to start and failed
     MessageGeneral elect1Msg = createMsg(mainKeyPair, elect);
-    messageHandler.handleMessage(messageRepo, laoRepo, messageSender, consensusChannel, elect1Msg);
+    messageHandler.handleMessage(messageSender, consensusChannel, elect1Msg);
     ConsensusFailure failure1 =
         new ConsensusFailure(INSTANCE_ID, elect1Msg.getMessageId(), PAST_TIME);
     MessageGeneral failure1Msg = createMsg(mainKeyPair, failure1);
-    messageHandler.handleMessage(
-        messageRepo, laoRepo, messageSender, consensusChannel, failure1Msg);
+    messageHandler.handleMessage(messageSender, consensusChannel, failure1Msg);
     InstrumentationRegistry.getInstrumentation().waitForIdleSync();
     displayAssertions(STATUS_READY, START_START, true);
     nodeAssertions(nodesGrid(), node3Pos, "Start Failed\n" + node3, false);
     nodeAssertions(nodesGrid(), node2Pos, "Waiting\n" + node2, false);
     nodeAssertions(nodesGrid(), ownPos, "Start Failed\n" + publicKey, false);
-
   }
 
   private void displayAssertions(String expectedStatus, String expectedStart, boolean enabled) {

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/network/JsonTestUtils.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/network/JsonTestUtils.java
@@ -1,6 +1,6 @@
 package com.github.dedis.popstellar.model.network;
 
-import com.github.dedis.popstellar.di.DataRegistryModule;
+import com.github.dedis.popstellar.di.DataRegistryModuleHelper;
 import com.github.dedis.popstellar.di.JsonModule;
 import com.github.dedis.popstellar.model.network.method.message.data.Data;
 import com.github.dedis.popstellar.model.network.serializer.JsonUtils;
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertEquals;
 
 public class JsonTestUtils {
 
-  private static final Gson GSON = JsonModule.provideGson(DataRegistryModule.provideDataRegistry());
+  private static final Gson GSON = JsonModule.provideGson(DataRegistryModuleHelper.buildRegistry());
 
   public static String loadFile(String path) {
     InputStream is = JsonTestUtils.class.getClassLoader().getResourceAsStream(path);

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/network/method/message/MessageGeneralTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/network/method/message/MessageGeneralTest.java
@@ -1,6 +1,6 @@
 package com.github.dedis.popstellar.model.network.method.message;
 
-import com.github.dedis.popstellar.di.DataRegistryModule;
+import com.github.dedis.popstellar.di.DataRegistryModuleHelper;
 import com.github.dedis.popstellar.di.JsonModule;
 import com.github.dedis.popstellar.model.network.method.message.data.Data;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.CreateLao;
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 public class MessageGeneralTest {
 
-  private static final Gson GSON = JsonModule.provideGson(DataRegistryModule.provideDataRegistry());
+  private static final Gson GSON = JsonModule.provideGson(DataRegistryModuleHelper.buildRegistry());
 
   private static final PublicKey ORGANIZER =
       new PublicKey("Z3DYtBxooGs6KxOAqCWD3ihR8M6ZPBjAmWp_w5VBaws=");

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/network/method/message/data/digitalcash/PostTransactionCoinTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/network/method/message/data/digitalcash/PostTransactionCoinTest.java
@@ -1,6 +1,6 @@
 package com.github.dedis.popstellar.model.network.method.message.data.digitalcash;
 
-import com.github.dedis.popstellar.di.DataRegistryModule;
+import com.github.dedis.popstellar.di.DataRegistryModuleHelper;
 import com.github.dedis.popstellar.di.JsonModule;
 import com.github.dedis.popstellar.model.network.method.message.data.*;
 import com.github.dedis.popstellar.model.network.serializer.JsonUtils;
@@ -77,7 +77,7 @@ public class PostTransactionCoinTest {
 
   @Test
   public void jsonValidationTest() {
-    Gson GSON = JsonModule.provideGson(DataRegistryModule.provideDataRegistry());
+    Gson GSON = JsonModule.provideGson(DataRegistryModuleHelper.buildRegistry());
     String json = GSON.toJson(POST_TRANSACTION, Data.class);
     JsonUtils.verifyJson("protocol/query/method/message/data/dataPostTransactionCoin.json", json);
     PostTransactionCoin res = GSON.fromJson(json, PostTransactionCoin.class);

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/network/method/message/data/election/CastVoteTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/network/method/message/data/election/CastVoteTest.java
@@ -1,6 +1,6 @@
 package com.github.dedis.popstellar.model.network.method.message.data.election;
 
-import com.github.dedis.popstellar.di.DataRegistryModule;
+import com.github.dedis.popstellar.di.DataRegistryModuleHelper;
 import com.github.dedis.popstellar.di.JsonModule;
 import com.github.dedis.popstellar.model.network.JsonTestUtils;
 import com.google.gson.Gson;
@@ -23,7 +23,7 @@ public class CastVoteTest {
   private final boolean writeInEnabled = false;
   private final long timestamp = 10;
   private final String write_in = "My write in ballot option";
-  private static final Gson GSON = JsonModule.provideGson(DataRegistryModule.provideDataRegistry());
+  private static final Gson GSON = JsonModule.provideGson(DataRegistryModuleHelper.buildRegistry());
 
   // Set up a open ballot election
   private final ElectionVote electionVote1 =

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/remote/GlobalNetworkManagerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/remote/GlobalNetworkManagerTest.java
@@ -1,8 +1,6 @@
 package com.github.dedis.popstellar.repository.remote;
 
 import com.github.dedis.popstellar.model.objects.Channel;
-import com.github.dedis.popstellar.repository.LAORepository;
-import com.github.dedis.popstellar.repository.MessageRepository;
 import com.github.dedis.popstellar.utility.handler.MessageHandler;
 import com.github.dedis.popstellar.utility.scheduler.TestSchedulerProvider;
 import com.google.gson.Gson;
@@ -26,8 +24,6 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class GlobalNetworkManagerTest {
 
-  @Mock MessageRepository messageRepo;
-  @Mock LAORepository laoRepo;
   @Mock MessageHandler handler;
   @Mock Gson gson;
 
@@ -44,7 +40,7 @@ public class GlobalNetworkManagerTest {
     when(factory.createConnection(anyString())).thenReturn(firstConnection);
 
     GlobalNetworkManager networkManager =
-        new GlobalNetworkManager(messageRepo, laoRepo, handler, factory, gson, schedulerProvider);
+        new GlobalNetworkManager(handler, factory, gson, schedulerProvider);
     verify(factory).createConnection(anyString());
 
     Completable sendMessage = networkManager.getMessageSender().unsubscribe(Channel.ROOT);
@@ -68,8 +64,7 @@ public class GlobalNetworkManagerTest {
     when(factory.createConnection(anyString())).thenReturn(firstConnection);
 
     GlobalNetworkManager networkManager =
-        new GlobalNetworkManager(
-            messageRepo, laoRepo, handler, factory, gson, new TestSchedulerProvider());
+        new GlobalNetworkManager(handler, factory, gson, new TestSchedulerProvider());
     verify(factory).createConnection(anyString());
 
     Connection secondConnection = mock(Connection.class);

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/remote/LAONetworkManagerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/remote/LAONetworkManagerTest.java
@@ -1,6 +1,6 @@
 package com.github.dedis.popstellar.repository.remote;
 
-import com.github.dedis.popstellar.di.DataRegistryModule;
+import com.github.dedis.popstellar.di.DataRegistryModuleHelper;
 import com.github.dedis.popstellar.di.JsonModule;
 import com.github.dedis.popstellar.model.network.GenericMessage;
 import com.github.dedis.popstellar.model.network.answer.Error;
@@ -11,8 +11,6 @@ import com.github.dedis.popstellar.model.network.method.message.data.Data;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.CreateLao;
 import com.github.dedis.popstellar.model.objects.Channel;
 import com.github.dedis.popstellar.model.objects.security.KeyPair;
-import com.github.dedis.popstellar.repository.LAORepository;
-import com.github.dedis.popstellar.repository.MessageRepository;
 import com.github.dedis.popstellar.testutils.Base64DataUtils;
 import com.github.dedis.popstellar.utility.error.JsonRPCErrorException;
 import com.github.dedis.popstellar.utility.handler.MessageHandler;
@@ -49,8 +47,6 @@ public class LAONetworkManagerTest {
   private final BehaviorSubject<WebSocket.Event> events = BehaviorSubject.create();
   private final BehaviorSubject<GenericMessage> messages = BehaviorSubject.create();
 
-  @Mock MessageRepository messageRepo;
-  @Mock LAORepository laoRepo;
   @Mock MessageHandler handler;
   @Mock Connection connection;
 
@@ -80,11 +76,9 @@ public class LAONetworkManagerTest {
     TestScheduler testScheduler = schedulerProvider.getTestScheduler();
     LAONetworkManager networkManager =
         new LAONetworkManager(
-            messageRepo,
-            laoRepo,
             handler,
             connection,
-            JsonModule.provideGson(DataRegistryModule.provideDataRegistry()),
+            JsonModule.provideGson(DataRegistryModuleHelper.buildRegistry()),
             schedulerProvider);
 
     Answer<?> answer =
@@ -117,11 +111,9 @@ public class LAONetworkManagerTest {
     TestScheduler testScheduler = schedulerProvider.getTestScheduler();
     LAONetworkManager networkManager =
         new LAONetworkManager(
-            messageRepo,
-            laoRepo,
             handler,
             connection,
-            JsonModule.provideGson(DataRegistryModule.provideDataRegistry()),
+            JsonModule.provideGson(DataRegistryModuleHelper.buildRegistry()),
             schedulerProvider);
 
     Answer<?> answer =
@@ -153,11 +145,9 @@ public class LAONetworkManagerTest {
     TestScheduler testScheduler = schedulerProvider.getTestScheduler();
     LAONetworkManager networkManager =
         new LAONetworkManager(
-            messageRepo,
-            laoRepo,
             handler,
             connection,
-            JsonModule.provideGson(DataRegistryModule.provideDataRegistry()),
+            JsonModule.provideGson(DataRegistryModuleHelper.buildRegistry()),
             schedulerProvider);
 
     Answer<?> answer =
@@ -191,11 +181,9 @@ public class LAONetworkManagerTest {
     TestScheduler testScheduler = schedulerProvider.getTestScheduler();
     LAONetworkManager networkManager =
         new LAONetworkManager(
-            messageRepo,
-            laoRepo,
             handler,
             connection,
-            JsonModule.provideGson(DataRegistryModule.provideDataRegistry()),
+            JsonModule.provideGson(DataRegistryModuleHelper.buildRegistry()),
             schedulerProvider);
 
     ErrorCode error = new ErrorCode(3, "error");
@@ -235,11 +223,9 @@ public class LAONetworkManagerTest {
     TestScheduler testScheduler = schedulerProvider.getTestScheduler();
     LAONetworkManager networkManager =
         new LAONetworkManager(
-            messageRepo,
-            laoRepo,
             handler,
             connection,
-            JsonModule.provideGson(DataRegistryModule.provideDataRegistry()),
+            JsonModule.provideGson(DataRegistryModuleHelper.buildRegistry()),
             schedulerProvider);
 
     networkManager.subscribe(CHANNEL).subscribe(); // First subscribe
@@ -278,11 +264,9 @@ public class LAONetworkManagerTest {
     TestScheduler testScheduler = schedulerProvider.getTestScheduler();
     LAONetworkManager networkManager =
         new LAONetworkManager(
-            messageRepo,
-            laoRepo,
             handler,
             connection,
-            JsonModule.provideGson(DataRegistryModule.provideDataRegistry()),
+            JsonModule.provideGson(DataRegistryModuleHelper.buildRegistry()),
             schedulerProvider);
 
     // Set a response that stores requested ids

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ElectionHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ElectionHandlerTest.java
@@ -2,9 +2,10 @@ package com.github.dedis.popstellar.utility.handler;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 
-import com.github.dedis.popstellar.di.DataRegistryModule;
+import com.github.dedis.popstellar.di.DataRegistryModuleHelper;
 import com.github.dedis.popstellar.di.JsonModule;
 import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
+import com.github.dedis.popstellar.model.network.method.message.data.DataRegistry;
 import com.github.dedis.popstellar.model.network.method.message.data.election.*;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.CreateLao;
 import com.github.dedis.popstellar.model.objects.*;
@@ -12,7 +13,8 @@ import com.github.dedis.popstellar.model.objects.event.EventState;
 import com.github.dedis.popstellar.model.objects.security.*;
 import com.github.dedis.popstellar.model.objects.security.elGamal.ElectionKeyPair;
 import com.github.dedis.popstellar.model.objects.security.elGamal.ElectionPublicKey;
-import com.github.dedis.popstellar.repository.*;
+import com.github.dedis.popstellar.repository.LAORepository;
+import com.github.dedis.popstellar.repository.MessageRepository;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.utility.error.DataHandlingException;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
@@ -49,8 +51,6 @@ public class ElectionHandlerTest extends TestCase {
   private static final CreateLao CREATE_LAO = new CreateLao("lao", SENDER);
   private static final Channel LAO_CHANNEL = Channel.ROOT.subChannel(CREATE_LAO.getId());
 
-  private static final Gson GSON = JsonModule.provideGson(DataRegistryModule.provideDataRegistry());
-
   private static final long openedAt = 1633099883;
   private Lao lao;
   private RollCall rollCall;
@@ -58,10 +58,9 @@ public class ElectionHandlerTest extends TestCase {
   private Election electionEncrypted;
   private ElectionQuestion electionQuestion;
 
-  private MessageRepository messageRepo;
   private LAORepository laoRepo;
   private MessageHandler messageHandler;
-  private ServerRepository serverRepository;
+  private Gson gson;
 
   @Mock MessageSender messageSender;
   @Mock KeyManager keyManager;
@@ -75,10 +74,11 @@ public class ElectionHandlerTest extends TestCase {
 
     when(messageSender.subscribe(any())).then(args -> Completable.complete());
 
-    messageRepo = new MessageRepository();
     laoRepo = new LAORepository();
-    messageHandler =
-        new MessageHandler(DataRegistryModule.provideDataRegistry(), keyManager, serverRepository);
+    DataRegistry dataRegistry = DataRegistryModuleHelper.buildRegistry(laoRepo, keyManager);
+    MessageRepository messageRepo = new MessageRepository();
+    gson = JsonModule.provideGson(dataRegistry);
+    messageHandler = new MessageHandler(messageRepo, dataRegistry);
 
     // Create one LAO
     lao = new Lao(CREATE_LAO.getName(), CREATE_LAO.getOrganizer(), CREATE_LAO.getCreation());
@@ -128,7 +128,7 @@ public class ElectionHandlerTest extends TestCase {
     laoRepo.updateLao(lao);
 
     // Add the CreateLao message to the LAORepository
-    MessageGeneral createLaoMessage = new MessageGeneral(SENDER_KEY, CREATE_LAO, GSON);
+    MessageGeneral createLaoMessage = new MessageGeneral(SENDER_KEY, CREATE_LAO, gson);
     messageRepo.addMessage(createLaoMessage);
   }
 
@@ -147,10 +147,10 @@ public class ElectionHandlerTest extends TestCase {
             Collections.singletonList(electionQuestion.getBallotOptions()),
             Collections.singletonList(electionQuestion.getQuestion()),
             ElectionVersion.OPEN_BALLOT);
-    MessageGeneral message = new MessageGeneral(SENDER_KEY, electionSetupOpenBallot, GSON);
+    MessageGeneral message = new MessageGeneral(SENDER_KEY, electionSetupOpenBallot, gson);
 
     // Call the message handler
-    messageHandler.handleMessage(messageRepo, laoRepo, messageSender, LAO_CHANNEL, message);
+    messageHandler.handleMessage(messageSender, LAO_CHANNEL, message);
 
     // Check the Election is present with state OPENED and the correct ID
     Optional<Election> electionOpt =
@@ -184,11 +184,10 @@ public class ElectionHandlerTest extends TestCase {
         new ElectionResultQuestion("id", Collections.singletonList(questionResult));
     ElectionResult electionResult =
         new ElectionResult(Collections.singletonList(electionResultQuestion));
-    MessageGeneral message = new MessageGeneral(SENDER_KEY, electionResult, GSON);
+    MessageGeneral message = new MessageGeneral(SENDER_KEY, electionResult, gson);
 
     // Call the message handler
-    messageHandler.handleMessage(
-        messageRepo, laoRepo, messageSender, LAO_CHANNEL.subChannel(election.getId()), message);
+    messageHandler.handleMessage(messageSender, LAO_CHANNEL.subChannel(election.getId()), message);
 
     // Check the Election is present with state RESULTS_READY and the results
     Optional<Election> electionOpt =
@@ -203,11 +202,10 @@ public class ElectionHandlerTest extends TestCase {
   public void testHandleElectionEnd() throws DataHandlingException, UnknownLaoException {
     // Create the end Election message
     ElectionEnd electionEnd = new ElectionEnd(election.getId(), lao.getId(), "");
-    MessageGeneral message = new MessageGeneral(SENDER_KEY, electionEnd, GSON);
+    MessageGeneral message = new MessageGeneral(SENDER_KEY, electionEnd, gson);
 
     // Call the message handler
-    messageHandler.handleMessage(
-        messageRepo, laoRepo, messageSender, LAO_CHANNEL.subChannel(election.getId()), message);
+    messageHandler.handleMessage(messageSender, LAO_CHANNEL.subChannel(election.getId()), message);
 
     // Check the Election is present with state CLOSED and the results
     Optional<Election> electionOpt =
@@ -219,12 +217,11 @@ public class ElectionHandlerTest extends TestCase {
   @Test
   public void testHandleElectionOpen() throws DataHandlingException, UnknownLaoException {
     OpenElection openElection = new OpenElection(lao.getId(), election.getId(), openedAt);
-    MessageGeneral message = new MessageGeneral(SENDER_KEY, openElection, GSON);
+    MessageGeneral message = new MessageGeneral(SENDER_KEY, openElection, gson);
 
     for (EventState state : EventState.values()) {
       election.setEventState(state);
-      messageHandler.handleMessage(
-          messageRepo, laoRepo, messageSender, election.getChannel(), message);
+      messageHandler.handleMessage(messageSender, election.getChannel(), message);
       if (state == EventState.CREATED) {
         // Test for current TimeStamp
         assertEquals(EventState.OPENED, election.getState());
@@ -240,11 +237,10 @@ public class ElectionHandlerTest extends TestCase {
     // Create the election key message
     String key = "JsS0bXJU8yMT9jvIeTfoS6RJPZ8YopuAUPkxssHaoTQ";
     ElectionKey electionKey = new ElectionKey(election.getId(), key);
-    MessageGeneral message = new MessageGeneral(SENDER_KEY, electionKey, GSON);
+    MessageGeneral message = new MessageGeneral(SENDER_KEY, electionKey, gson);
 
     // Call the message handler
-    messageHandler.handleMessage(
-        messageRepo, laoRepo, messageSender, LAO_CHANNEL.subChannel(election.getId()), message);
+    messageHandler.handleMessage(messageSender, LAO_CHANNEL.subChannel(election.getId()), message);
 
     assertEquals(key, election.getElectionKey());
   }
@@ -261,10 +257,9 @@ public class ElectionHandlerTest extends TestCase {
     CastVote<ElectionVote> electionVote =
         new CastVote<>(electionVotes, election.getId(), CREATE_LAO.getId());
 
-    MessageGeneral message1 = new MessageGeneral(SENDER_KEY, electionVote, GSON);
+    MessageGeneral message1 = new MessageGeneral(SENDER_KEY, electionVote, gson);
     // Test the whole process
-    messageHandler.handleMessage(
-        messageRepo, laoRepo, messageSender, LAO_CHANNEL.subChannel(election.getId()), message1);
+    messageHandler.handleMessage(messageSender, LAO_CHANNEL.subChannel(election.getId()), message1);
     List<String> listOfVoteIds = new ArrayList<>();
     // Since messageMap is a TreeMap, votes will already be sorted in the alphabetical order of
     // messageIds
@@ -288,15 +283,11 @@ public class ElectionHandlerTest extends TestCase {
         Arrays.asList(electionEncryptedVote1, electionEncryptedVote2);
     CastVote<ElectionEncryptedVote> encryptedCastVote =
         new CastVote<>(electionEncryptedVote, electionEncrypted.getId(), CREATE_LAO.getId());
-    MessageGeneral message2 = new MessageGeneral(SENDER_KEY, encryptedCastVote, GSON);
+    MessageGeneral message2 = new MessageGeneral(SENDER_KEY, encryptedCastVote, gson);
     // Test the handling, it no error are thrown it means that the validation happened without
     // problems
     messageHandler.handleMessage(
-        messageRepo,
-        laoRepo,
-        messageSender,
-        LAO_CHANNEL.subChannel(electionEncrypted.getId()),
-        message2);
+        messageSender, LAO_CHANNEL.subChannel(electionEncrypted.getId()), message2);
     List<String> listOfVoteIds2 = new ArrayList<>();
     listOfVoteIds2.add(electionEncryptedVote2.getId());
     listOfVoteIds2.add(electionEncryptedVote1.getId());

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/RollCallHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/RollCallHandlerTest.java
@@ -2,15 +2,17 @@ package com.github.dedis.popstellar.utility.handler;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 
-import com.github.dedis.popstellar.di.DataRegistryModule;
+import com.github.dedis.popstellar.di.DataRegistryModuleHelper;
 import com.github.dedis.popstellar.di.JsonModule;
 import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
+import com.github.dedis.popstellar.model.network.method.message.data.DataRegistry;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.CreateLao;
 import com.github.dedis.popstellar.model.network.method.message.data.rollcall.*;
 import com.github.dedis.popstellar.model.objects.*;
 import com.github.dedis.popstellar.model.objects.event.EventState;
 import com.github.dedis.popstellar.model.objects.security.*;
-import com.github.dedis.popstellar.repository.*;
+import com.github.dedis.popstellar.repository.LAORepository;
+import com.github.dedis.popstellar.repository.MessageRepository;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.utility.error.DataHandlingException;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
@@ -49,11 +51,9 @@ public class RollCallHandlerTest {
   private static final CreateLao CREATE_LAO = new CreateLao("lao", SENDER);
   private static final Channel LAO_CHANNEL = Channel.getLaoChannel(CREATE_LAO.getId());
 
-  private static final Gson GSON = JsonModule.provideGson(DataRegistryModule.provideDataRegistry());
-
-  private MessageRepository messageRepo;
   private LAORepository laoRepo;
   private MessageHandler messageHandler;
+  private Gson gson;
 
   private RollCall rollCall;
 
@@ -70,11 +70,11 @@ public class RollCallHandlerTest {
 
     when(messageSender.subscribe(any())).then(args -> Completable.complete());
 
-    messageRepo = new MessageRepository();
     laoRepo = new LAORepository();
-    messageHandler =
-        new MessageHandler(
-            DataRegistryModule.provideDataRegistry(), keyManager, new ServerRepository());
+    DataRegistry dataRegistry = DataRegistryModuleHelper.buildRegistry(laoRepo, keyManager);
+    MessageRepository messageRepo = new MessageRepository();
+    gson = JsonModule.provideGson(dataRegistry);
+    messageHandler = new MessageHandler(messageRepo, dataRegistry);
 
     // Create one LAO
     Lao lao = new Lao(CREATE_LAO.getName(), CREATE_LAO.getOrganizer(), CREATE_LAO.getCreation());
@@ -94,7 +94,7 @@ public class RollCallHandlerTest {
     laoRepo.updateLao(lao);
 
     // Add the CreateLao message to the LAORepository
-    MessageGeneral createLaoMessage = new MessageGeneral(SENDER_KEY, CREATE_LAO, GSON);
+    MessageGeneral createLaoMessage = new MessageGeneral(SENDER_KEY, CREATE_LAO, gson);
     messageRepo.addMessage(createLaoMessage);
   }
 
@@ -110,10 +110,10 @@ public class RollCallHandlerTest {
             rollCall.getLocation(),
             rollCall.getDescription(),
             CREATE_LAO.getId());
-    MessageGeneral message = new MessageGeneral(SENDER_KEY, createRollCall, GSON);
+    MessageGeneral message = new MessageGeneral(SENDER_KEY, createRollCall, gson);
 
     // Call the message handler
-    messageHandler.handleMessage(messageRepo, laoRepo, messageSender, LAO_CHANNEL, message);
+    messageHandler.handleMessage(messageSender, LAO_CHANNEL, message);
 
     // Check the new Roll Call is present with state CREATED and the correct ID
     Optional<RollCall> rollCallOpt =
@@ -140,10 +140,10 @@ public class RollCallHandlerTest {
     OpenRollCall openRollCall =
         new OpenRollCall(
             CREATE_LAO.getId(), rollCall.getId(), rollCall.getStart(), EventState.CREATED);
-    MessageGeneral message = new MessageGeneral(SENDER_KEY, openRollCall, GSON);
+    MessageGeneral message = new MessageGeneral(SENDER_KEY, openRollCall, gson);
 
     // Call the message handler
-    messageHandler.handleMessage(messageRepo, laoRepo, messageSender, LAO_CHANNEL, message);
+    messageHandler.handleMessage(messageSender, LAO_CHANNEL, message);
 
     // Check the Roll Call is present with state OPENED and the correct ID
     Optional<RollCall> rollCallOpt =
@@ -170,10 +170,10 @@ public class RollCallHandlerTest {
     CloseRollCall closeRollCall =
         new CloseRollCall(
             CREATE_LAO.getId(), rollCall.getId(), rollCall.getEnd(), new ArrayList<>());
-    MessageGeneral message = new MessageGeneral(SENDER_KEY, closeRollCall, GSON);
+    MessageGeneral message = new MessageGeneral(SENDER_KEY, closeRollCall, gson);
 
     // Call the message handler
-    messageHandler.handleMessage(messageRepo, laoRepo, messageSender, LAO_CHANNEL, message);
+    messageHandler.handleMessage(messageSender, LAO_CHANNEL, message);
 
     // Check the Roll Call is present with state CLOSED and the correct ID
     Optional<RollCall> rollCallOpt =

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/TransactionCoinHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/TransactionCoinHandlerTest.java
@@ -1,15 +1,17 @@
 package com.github.dedis.popstellar.utility.handler;
 
-import com.github.dedis.popstellar.di.DataRegistryModule;
+import com.github.dedis.popstellar.di.DataRegistryModuleHelper;
 import com.github.dedis.popstellar.di.JsonModule;
 import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
+import com.github.dedis.popstellar.model.network.method.message.data.DataRegistry;
 import com.github.dedis.popstellar.model.network.method.message.data.digitalcash.*;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.CreateLao;
 import com.github.dedis.popstellar.model.network.method.message.data.rollcall.CloseRollCall;
 import com.github.dedis.popstellar.model.objects.*;
 import com.github.dedis.popstellar.model.objects.digitalcash.TransactionObject;
 import com.github.dedis.popstellar.model.objects.security.*;
-import com.github.dedis.popstellar.repository.*;
+import com.github.dedis.popstellar.repository.LAORepository;
+import com.github.dedis.popstellar.repository.MessageRepository;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.utility.error.DataHandlingException;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
@@ -36,7 +38,6 @@ public class TransactionCoinHandlerTest {
   private static final KeyPair SENDER_KEY = generateKeyPair();
   private static final PublicKey SENDER = SENDER_KEY.getPublicKey();
   private static final CreateLao CREATE_LAO = new CreateLao("lao", SENDER);
-  private static final Gson GSON = JsonModule.provideGson(DataRegistryModule.provideDataRegistry());
 
   // Version
   private static final int VERSION = 1;
@@ -71,14 +72,12 @@ public class TransactionCoinHandlerTest {
   private Lao lao;
   private RollCall rollCall;
 
-  private MessageRepository messageRepo;
   private LAORepository laoRepo;
   private MessageHandler messageHandler;
   private Channel coinChannel;
+  private Gson gson;
 
   private PostTransactionCoin postTransactionCoin;
-
-  private ServerRepository serverRepository;
 
   @Mock MessageSender messageSender;
   @Mock KeyManager keyManager;
@@ -89,10 +88,12 @@ public class TransactionCoinHandlerTest {
     lenient().when(keyManager.getMainPublicKey()).thenReturn(SENDER);
 
     postTransactionCoin = new PostTransactionCoin(TRANSACTION);
+
     laoRepo = new LAORepository();
-    messageRepo = new MessageRepository();
-    messageHandler =
-        new MessageHandler(DataRegistryModule.provideDataRegistry(), keyManager, serverRepository);
+    DataRegistry dataRegistry = DataRegistryModuleHelper.buildRegistry(laoRepo, keyManager);
+    MessageRepository messageRepo = new MessageRepository();
+    gson = JsonModule.provideGson(dataRegistry);
+    messageHandler = new MessageHandler(messageRepo, dataRegistry);
 
     // Create one LAO
     lao = new Lao(CREATE_LAO.getName(), CREATE_LAO.getOrganizer(), CREATE_LAO.getCreation());
@@ -111,21 +112,21 @@ public class TransactionCoinHandlerTest {
     laoRepo.updateLao(lao);
 
     // Add the CreateLao message to the LAORepository
-    MessageGeneral createLaoMessage = new MessageGeneral(SENDER_KEY, CREATE_LAO, GSON);
+    MessageGeneral createLaoMessage = new MessageGeneral(SENDER_KEY, CREATE_LAO, gson);
     messageRepo.addMessage(createLaoMessage);
 
     CloseRollCall closeRollCall =
         new CloseRollCall(
             CREATE_LAO.getId(), rollCall.getId(), rollCall.getEnd(), new ArrayList<>());
-    MessageGeneral message = new MessageGeneral(SENDER_KEY, closeRollCall, GSON);
+    MessageGeneral message = new MessageGeneral(SENDER_KEY, closeRollCall, gson);
     messageRepo.addMessage(message);
     coinChannel = lao.getChannel().subChannel("coin").subChannel(SENDER.getEncoded());
   }
 
   @Test
   public void testHandlePostTransactionCoin() throws DataHandlingException, UnknownLaoException {
-    MessageGeneral message = new MessageGeneral(SENDER_KEY, postTransactionCoin, GSON);
-    messageHandler.handleMessage(messageRepo, laoRepo, messageSender, coinChannel, message);
+    MessageGeneral message = new MessageGeneral(SENDER_KEY, postTransactionCoin, gson);
+    messageHandler.handleMessage(messageSender, coinChannel, message);
 
     Lao updatedLao = laoRepo.getLaoViewByChannel(lao.getChannel()).createLaoCopy();
 


### PR DESCRIPTION
This migration provides a way to inject dependencies inside handlers.

But this dependency injection makes tests more difficult to handle, as it needs to be done manually.

The result shown in this PR is the best I could come up with, the solution is simply to move the problem in one specific place (`DataRegistryModuleHelper`)

This also made me realize that the current handler tests are more instrumented tests that put the whole process from the receiving of a message to its handling into tests. This is a good idea, but it creates a lot of hard to read setup, and I think it would be beneficial to test the handlers as units.