### PR TITLE
Add Scan button in the rollcall fragment to go back to the scanning fragment

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/rollcall/RollCallFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/rollcall/RollCallFragment.java
@@ -6,14 +6,16 @@ import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.*;
-import android.widget.*;
+import android.widget.ImageView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.core.widget.ImageViewCompat;
 import androidx.fragment.app.Fragment;
 
 import com.github.dedis.popstellar.R;
+import com.github.dedis.popstellar.databinding.RollCallFragmentBinding;
 import com.github.dedis.popstellar.model.objects.RollCall;
 import com.github.dedis.popstellar.model.objects.event.EventState;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
@@ -37,17 +39,16 @@ import static com.github.dedis.popstellar.utility.Constants.ID_NULL;
 
 @AndroidEntryPoint
 public class RollCallFragment extends Fragment {
+
   public static final String TAG = RollCallFragment.class.getSimpleName();
+
   private final SimpleDateFormat dateFormat =
       new SimpleDateFormat("dd/MM/yyyy HH:mm z", Locale.ENGLISH);
-  private LaoDetailViewModel laoDetailViewModel;
+
+  private RollCallFragmentBinding binding;
+
+  private LaoDetailViewModel viewModel;
   private RollCall rollCall;
-  private Button managementButton;
-  private TextView title;
-  private TextView statusText;
-  private ImageView statusIcon;
-  private TextView startTimeDisplay;
-  private TextView endTimeDisplay;
 
   private final EnumMap<EventState, Integer> managementTextMap = buildManagementTextMap();
   private final EnumMap<EventState, Integer> statusTextMap = buildStatusTextMap();
@@ -69,31 +70,22 @@ public class RollCallFragment extends Fragment {
 
   @Override
   public View onCreateView(
-      LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+      @NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     // Inflate the layout for this fragment
-    View view = inflater.inflate(R.layout.roll_call_fragment, container, false);
-
-    laoDetailViewModel = LaoDetailActivity.obtainViewModel(requireActivity());
-    if (rollCall == null) {
-      rollCall = laoDetailViewModel.getCurrentRollCall();
-    }
-    managementButton = view.findViewById(R.id.roll_call_management_button);
-    title = view.findViewById(R.id.roll_call_fragment_title);
-    statusText = view.findViewById(R.id.roll_call_fragment_status);
-    statusIcon = view.findViewById(R.id.roll_call_fragment_status_icon);
-    startTimeDisplay = view.findViewById(R.id.roll_call_fragment_start_time);
-    endTimeDisplay = view.findViewById(R.id.roll_call_fragment_end_time);
+    binding = RollCallFragmentBinding.inflate(inflater, container, false);
+    viewModel = LaoDetailActivity.obtainViewModel(requireActivity());
+    rollCall = viewModel.getCurrentRollCall();
 
     setUpStateDependantContent();
 
-    View.OnClickListener listener =
+    binding.rollCallManagementButton.setOnClickListener(
         v -> {
           EventState state = rollCall.getState();
           switch (state) {
             case CLOSED:
             case CREATED:
-              laoDetailViewModel.addDisposable(
-                  laoDetailViewModel
+              viewModel.addDisposable(
+                  viewModel
                       .openRollCall(rollCall.getId())
                       .subscribe(
                           this::openScanning,
@@ -103,8 +95,8 @@ public class RollCallFragment extends Fragment {
               break;
             case OPENED:
               // will add the scan to this fragment in the future
-              laoDetailViewModel.addDisposable(
-                  laoDetailViewModel
+              viewModel.addDisposable(
+                  viewModel
                       .closeRollCall()
                       .subscribe(
                           () ->
@@ -119,17 +111,17 @@ public class RollCallFragment extends Fragment {
             default:
               throw new IllegalStateException("Roll-Call should not be in a " + state + " state");
           }
-        };
+        });
 
-    managementButton.setOnClickListener(listener);
+    binding.rollCallScanningButton.setOnClickListener(b -> this.openScanning());
 
-    laoDetailViewModel
+    viewModel
         .getLaoEvents()
         .observe(getViewLifecycleOwner(), eventState -> setUpStateDependantContent());
 
-    retrieveAndDisplayPublicKey(view);
+    retrieveAndDisplayPublicKey();
 
-    return view;
+    return binding.getRoot();
   }
 
   private void openScanning() {
@@ -146,32 +138,40 @@ public class RollCallFragment extends Fragment {
   }
 
   private void setUpStateDependantContent() {
-    rollCall = laoDetailViewModel.getCurrentRollCall();
+    rollCall = viewModel.getCurrentRollCall();
     if (rollCall == null) {
       return;
     }
     setupTime(); // Suggested time is updated in case of early/late close/open/reopen
 
     EventState rcState = rollCall.getState();
-    boolean isOrganizer = laoDetailViewModel.isOrganizer().getValue();
+    boolean isOrganizer = Boolean.TRUE.equals(viewModel.isOrganizer().getValue());
 
-    title.setText(rollCall.getName());
-    managementButton.setVisibility(isOrganizer ? View.VISIBLE : View.GONE);
+    binding.rollCallFragmentTitle.setText(rollCall.getName());
+    binding.rollCallManagementButton.setVisibility(isOrganizer ? View.VISIBLE : View.GONE);
 
-    managementButton.setText(managementTextMap.getOrDefault(rcState, ID_NULL));
+    binding.rollCallManagementButton.setText(managementTextMap.getOrDefault(rcState, ID_NULL));
 
     Drawable imgManagement =
         AppCompatResources.getDrawable(
-            getContext(), managementIconMap.getOrDefault(rcState, ID_NULL));
-    managementButton.setCompoundDrawablesWithIntrinsicBounds(imgManagement, null, null, null);
+            requireContext(), managementIconMap.getOrDefault(rcState, ID_NULL));
+    binding.rollCallManagementButton.setCompoundDrawablesWithIntrinsicBounds(
+        imgManagement, null, null, null);
 
     Drawable imgStatus = getDrawableFromContext(statusIconMap.getOrDefault(rcState, ID_NULL));
-    statusIcon.setImageDrawable(imgStatus);
-    setImageColor(statusIcon, statusColorMap.getOrDefault(rcState, ID_NULL));
+    binding.rollCallStatusIcon.setImageDrawable(imgStatus);
+    setImageColor(binding.rollCallStatusIcon, statusColorMap.getOrDefault(rcState, ID_NULL));
 
-    statusText.setText(statusTextMap.getOrDefault(rcState, ID_NULL));
-    statusText.setTextColor(
+    binding.rollCallStatus.setText(statusTextMap.getOrDefault(rcState, ID_NULL));
+    binding.rollCallStatus.setTextColor(
         getResources().getColor(statusColorMap.getOrDefault(rcState, ID_NULL), null));
+
+    // Show scanning button only if the current state is Opened
+    if (rcState == EventState.OPENED) {
+      binding.rollCallScanningButton.setVisibility(View.VISIBLE);
+    } else {
+      binding.rollCallScanningButton.setVisibility(View.GONE);
+    }
   }
 
   private void setupTime() {
@@ -181,28 +181,25 @@ public class RollCallFragment extends Fragment {
     Date startTime = new Date(rollCall.getStartTimestampInMillis());
     Date endTime = new Date(rollCall.getEndTimestampInMillis());
 
-    startTimeDisplay.setText(dateFormat.format(startTime));
-    endTimeDisplay.setText(dateFormat.format(endTime));
+    binding.rollCallStartTime.setText(dateFormat.format(startTime));
+    binding.rollCallEndTime.setText(dateFormat.format(endTime));
   }
 
   private Drawable getDrawableFromContext(int id) {
-    return AppCompatResources.getDrawable(getContext(), id);
+    return AppCompatResources.getDrawable(requireContext(), id);
   }
 
   private void setImageColor(ImageView imageView, int colorId) {
     ImageViewCompat.setImageTintList(imageView, getResources().getColorStateList(colorId, null));
   }
 
-  private void retrieveAndDisplayPublicKey(View view) {
+  private void retrieveAndDisplayPublicKey() {
     String pk = requireArguments().getString(Constants.RC_PK_EXTRA);
-    ImageView qrCode = view.findViewById(R.id.roll_call_pk_qr_code);
     Log.d(TAG, "key displayed is " + pk);
     Bitmap myBitmap = QRCode.from(pk).bitmap();
-    qrCode.setImageBitmap(myBitmap);
-    qrCode.setVisibility(
-        Boolean.TRUE.equals(laoDetailViewModel.isOrganizer().getValue())
-            ? View.INVISIBLE
-            : View.VISIBLE);
+    binding.rollCallPkQrCode.setImageBitmap(myBitmap);
+    binding.rollCallPkQrCode.setVisibility(
+        Boolean.TRUE.equals(viewModel.isOrganizer().getValue()) ? View.INVISIBLE : View.VISIBLE);
   }
 
   private EnumMap<EventState, Integer> buildManagementTextMap() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/rollcall/RollCallFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/event/rollcall/RollCallFragment.java
@@ -167,7 +167,7 @@ public class RollCallFragment extends Fragment {
         getResources().getColor(statusColorMap.getOrDefault(rcState, ID_NULL), null));
 
     // Show scanning button only if the current state is Opened
-    if (rcState == EventState.OPENED) {
+    if (rcState == EventState.OPENED && isOrganizer) {
       binding.rollCallScanningButton.setVisibility(View.VISIBLE);
     } else {
       binding.rollCallScanningButton.setVisibility(View.GONE);

--- a/fe2-android/app/src/main/res/layout/roll_call_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/roll_call_fragment.xml
@@ -1,120 +1,136 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:id="@+id/fragment_roll_call"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
 
-  <TextView
-    android:id="@+id/roll_call_fragment_title"
-    style="@style/title_style"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/fragment_roll_call"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-  <TextView
-    android:id="@+id/roll_call_fragment_status"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginTop="@dimen/status_margin_top"
-    android:text="@string/closed"
-    android:textColor="@color/red"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/roll_call_fragment_title" />
+    <Button
+      android:id="@+id/roll_call_management_button"
+      android:layout_width="wrap_content"
+      android:layout_height="@dimen/event_button_height"
+      android:layout_margin="@dimen/event_button_margin"
+      android:backgroundTint="@color/colorPrimary"
+      android:drawableStart="@drawable/ic_unlock"
+      android:text="@string/open"
+      android:textColor="@color/white"
+      android:textSize="@dimen/event_button_text_size"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent" />
 
-  <ImageView
-    android:id="@+id/roll_call_fragment_status_icon"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:src="@drawable/ic_lock"
-    app:layout_constraintBottom_toBottomOf="@id/roll_call_fragment_status"
-    app:layout_constraintEnd_toStartOf="@id/roll_call_fragment_status"
-    app:layout_constraintTop_toTopOf="@id/roll_call_fragment_status"
-    android:contentDescription="@string/status_icon_description" />
+    <Button
+      android:id="@+id/roll_call_scanning_button"
+      android:layout_width="wrap_content"
+      android:layout_height="@dimen/event_button_height"
+      android:layout_margin="@dimen/event_button_margin"
+      android:backgroundTint="@color/colorPrimary"
+      android:drawableStart="@drawable/ic_unlock"
+      android:text="@string/scan"
+      android:textColor="@color/white"
+      android:textSize="@dimen/event_button_text_size"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintStart_toStartOf="parent" />
 
-  <ImageView
-    android:id="@+id/start_time_icon"
-    android:layout_width="@dimen/event_clock_icon_side"
-    android:layout_height="@dimen/event_clock_icon_side"
-    android:layout_marginTop="@dimen/clock_icon_margin_top"
-    android:src="@drawable/ic_time"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/roll_call_fragment_status"
-    android:contentDescription="@string/time_icon_description" />
+    <ImageView
+      android:id="@+id/roll_call_status_icon"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:contentDescription="@string/status_icon_description"
+      android:src="@drawable/ic_lock"
+      app:layout_constraintBottom_toBottomOf="@id/roll_call_status"
+      app:layout_constraintEnd_toStartOf="@id/roll_call_status"
+      app:layout_constraintTop_toTopOf="@id/roll_call_status" />
 
-  <TextView
-    android:id="@+id/roll_call_fragment_start_time_title"
-    style="@style/explication_text_style"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/clock_icon_margin_start"
-    android:text="@string/start"
-    app:layout_constraintBottom_toBottomOf="@id/start_time_icon"
-    app:layout_constraintStart_toEndOf="@id/start_time_icon"
-    app:layout_constraintTop_toTopOf="@id/start_time_icon" />
+    <ImageView
+      android:id="@+id/start_time_icon"
+      android:layout_width="@dimen/event_clock_icon_side"
+      android:layout_height="@dimen/event_clock_icon_side"
+      android:layout_marginTop="@dimen/clock_icon_margin_top"
+      android:contentDescription="@string/time_icon_description"
+      android:src="@drawable/ic_time"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/roll_call_status" />
 
-  <TextView
-    android:id="@+id/roll_call_fragment_start_time"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/clock_icon_margin_start"
-    app:layout_constraintBottom_toBottomOf="@id/start_time_icon"
-    app:layout_constraintStart_toEndOf="@id/roll_call_fragment_start_time_title"
-    app:layout_constraintTop_toTopOf="@id/start_time_icon" />
+    <ImageView
+      android:id="@+id/end_time_icon"
+      android:layout_width="@dimen/event_clock_icon_side"
+      android:layout_height="@dimen/event_clock_icon_side"
+      android:layout_marginTop="@dimen/in_between_clocks_icon_margin_top"
+      android:contentDescription="@string/time_icon_description"
+      android:src="@drawable/ic_time"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/start_time_icon" />
 
-  <ImageView
-    android:id="@+id/end_time_icon"
-    android:layout_width="@dimen/event_clock_icon_side"
-    android:layout_height="@dimen/event_clock_icon_side"
-    android:layout_marginTop="@dimen/in_between_clocks_icon_margin_top"
-    android:src="@drawable/ic_time"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/start_time_icon"
-    android:contentDescription="@string/time_icon_description" />
+    <ImageView
+      android:id="@+id/roll_call_pk_qr_code"
+      android:layout_width="@dimen/qr_rollcall_img"
+      android:layout_height="@dimen/qr_rollcall_img"
+      android:contentDescription="@string/rc_qr_description"
+      app:layout_constraintBottom_toTopOf="@+id/roll_call_management_button"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/roll_call_end_time" />
 
-  <TextView
-    android:id="@+id/roll_call_fragment_end_time_title"
-    style="@style/explication_text_style"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/clock_icon_margin_start"
-    android:text="@string/end"
-    app:layout_constraintBottom_toBottomOf="@id/end_time_icon"
-    app:layout_constraintStart_toEndOf="@id/end_time_icon"
-    app:layout_constraintTop_toTopOf="@id/end_time_icon" />
+    <TextView
+      android:id="@+id/roll_call_fragment_title"
+      style="@style/title_style"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
 
-  <TextView
-    android:id="@+id/roll_call_fragment_end_time"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    app:layout_constraintBottom_toBottomOf="@id/end_time_icon"
-    app:layout_constraintStart_toStartOf="@id/roll_call_fragment_start_time"
-    app:layout_constraintTop_toTopOf="@id/end_time_icon" />
+    <TextView
+      android:id="@+id/roll_call_status"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="@dimen/status_margin_top"
+      android:text="@string/closed"
+      android:textColor="@color/red"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/roll_call_fragment_title" />
 
-  <ImageView
-    android:id="@+id/roll_call_pk_qr_code"
-    android:layout_width="@dimen/qr_rollcall_img"
-    android:layout_height="@dimen/qr_rollcall_img"
-    app:layout_constraintBottom_toTopOf="@+id/roll_call_management_button"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/roll_call_fragment_end_time"
-    android:contentDescription="@string/rc_qr_description" />
+    <TextView
+      android:id="@+id/roll_call_fragment_start_time_title"
+      style="@style/explication_text_style"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="@dimen/clock_icon_margin_start"
+      android:text="@string/start"
+      app:layout_constraintBottom_toBottomOf="@id/start_time_icon"
+      app:layout_constraintStart_toEndOf="@id/start_time_icon"
+      app:layout_constraintTop_toTopOf="@id/start_time_icon" />
 
-  <Button
-    android:id="@+id/roll_call_management_button"
-    android:layout_width="wrap_content"
-    android:layout_height="@dimen/event_button_height"
-    android:layout_margin="@dimen/event_button_margin"
-    android:backgroundTint="@color/colorPrimary"
-    android:drawableStart="@drawable/ic_unlock"
-    android:text="@string/open"
-    android:textColor="@color/white"
-    android:textSize="@dimen/event_button_text_size"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent" />
+    <TextView
+      android:id="@+id/roll_call_start_time"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="@dimen/clock_icon_margin_start"
+      app:layout_constraintBottom_toBottomOf="@id/start_time_icon"
+      app:layout_constraintStart_toEndOf="@id/roll_call_fragment_start_time_title"
+      app:layout_constraintTop_toTopOf="@id/start_time_icon" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <TextView
+      android:id="@+id/roll_call_fragment_end_time_title"
+      style="@style/explication_text_style"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="@dimen/clock_icon_margin_start"
+      android:text="@string/end"
+      app:layout_constraintBottom_toBottomOf="@id/end_time_icon"
+      app:layout_constraintStart_toEndOf="@id/end_time_icon"
+      app:layout_constraintTop_toTopOf="@id/end_time_icon" />
+
+    <TextView
+      android:id="@+id/roll_call_end_time"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      app:layout_constraintBottom_toBottomOf="@id/end_time_icon"
+      app:layout_constraintStart_toStartOf="@id/roll_call_start_time"
+      app:layout_constraintTop_toTopOf="@id/end_time_icon" />
+
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -322,5 +322,6 @@
   <string name="uninitialized_wallet_exception">The wallet is not initialized</string>
   <string name="unknown_lao_exception">Unknown Lao</string>
   <string name="unknown_election_exception">Unknown election</string>
+  <string name="scan">Scan</string>
 
 </resources>

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/detail/event/rollcall/RollCallFragmentPageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/detail/event/rollcall/RollCallFragmentPageObject.java
@@ -32,4 +32,8 @@ public class RollCallFragmentPageObject {
   public static ViewInteraction managementButton() {
     return onView(withId(R.id.roll_call_management_button));
   }
+
+  public static ViewInteraction rollCallScanButton() {
+    return onView(withId(R.id.roll_call_scanning_button));
+  }
 }

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/detail/event/rollcall/RollCallFragmentPageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/detail/event/rollcall/RollCallFragmentPageObject.java
@@ -18,15 +18,15 @@ public class RollCallFragmentPageObject {
   }
 
   public static ViewInteraction rollCallStatusText() {
-    return onView(withId(R.id.roll_call_fragment_status));
+    return onView(withId(R.id.roll_call_status));
   }
 
   public static ViewInteraction rollCallStartTime() {
-    return onView(withId(R.id.roll_call_fragment_start_time));
+    return onView(withId(R.id.roll_call_start_time));
   }
 
   public static ViewInteraction rollCallEndTime() {
-    return onView(withId(R.id.roll_call_fragment_end_time));
+    return onView(withId(R.id.roll_call_end_time));
   }
 
   public static ViewInteraction managementButton() {

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/detail/event/rollcall/RollCallFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/detail/event/rollcall/RollCallFragmentTest.java
@@ -41,8 +41,7 @@ import io.reactivex.subjects.BehaviorSubject;
 
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.matcher.ViewMatchers.*;
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generateKeyPair;
 import static com.github.dedis.popstellar.testutils.pages.detail.LaoDetailActivityPageObject.*;
 import static com.github.dedis.popstellar.testutils.pages.detail.event.rollcall.RollCallFragmentPageObject.*;
@@ -156,6 +155,12 @@ public class RollCallFragmentTest {
   }
 
   @Test
+  public void scanButtonIsNotDisplayedWhenCreatedTest() {
+    setupViewModel();
+    rollCallScanButton().check(matches(withEffectiveVisibility(Visibility.GONE)));
+  }
+
+  @Test
   public void managementButtonOpensRollCallWhenCreated() {
     setupViewModel();
     managementButton().check(matches(withText("OPEN")));
@@ -177,6 +182,13 @@ public class RollCallFragmentTest {
   }
 
   @Test
+  public void scanButtonIsDisplayedWhenOpenedTest() {
+    openRollCall();
+    setupViewModel();
+    rollCallScanButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)));
+  }
+
+  @Test
   public void managementButtonCloseRollCallWhenOpened() {
     openRollCall();
     setupViewModel();
@@ -194,9 +206,25 @@ public class RollCallFragmentTest {
   }
 
   @Test
+  public void scanButtonOPenScanningTest() {
+    openRollCall();
+    setupViewModel();
+
+    rollCallScanButton().perform(click());
+    fragmentContainer().check(matches(withChild(withId(cameraPermissionId()))));
+  }
+
+  @Test
   public void statusClosedTest() {
     closeRollCall();
     rollCallStatusText().check(matches(withText("Closed")));
+  }
+
+  @Test
+  public void scanButtonIsNotDisplayedWhenClosedTest() {
+    closeRollCall();
+    setupViewModel();
+    rollCallScanButton().check(matches(withEffectiveVisibility(Visibility.GONE)));
   }
 
   @Test


### PR DESCRIPTION
This PR adds a Scan button to the RollCall Fragment, it allows the organizer to go back to the scanning fragment when the roll call is opened.

I also refactored the RollCall Fragment to fix some codesmells, use data binding and have better naming.