### PR TITLE
Fix disappearing qr code icon if lao title is too long

### DIFF
--- a/fe2-android/app/src/main/res/layout/lao_detail_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/lao_detail_fragment.xml
@@ -33,10 +33,10 @@
         android:layout_width="@dimen/channel_qr_code_size"
         android:layout_height="@dimen/channel_qr_code_size"
         android:contentDescription="@string/qr_code_image_description"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"/>
 
       <ImageView
         android:id="@+id/qr_icon_close"

--- a/fe2-android/app/src/main/res/layout/lao_detail_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/lao_detail_fragment.xml
@@ -62,8 +62,10 @@
         <TextView
           android:id="@+id/lao_detail_title"
           style="@style/title_style"
+          android:maxWidth="@dimen/title_max_width"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
+          android:singleLine="false"
           android:text="@{view_model.getCurrentLaoName}"
           app:layout_constraintEnd_toEndOf="parent"
           app:layout_constraintStart_toStartOf="parent"

--- a/fe2-android/app/src/main/res/values/dimens.xml
+++ b/fe2-android/app/src/main/res/values/dimens.xml
@@ -117,6 +117,7 @@
   <dimen name="qr_close_icon_side">30dp</dimen>
   <dimen name="qr_layout_margin">40dp</dimen>
   <dimen name="qr_layout_elevation">8dp</dimen>
+  <dimen name="title_max_width">250dp</dimen>
 
   <!-- Lao list dimensions -->
   <dimen name="rv_margin_top">20dp</dimen>


### PR DESCRIPTION
This fixes #1229. The fix is quite ugly it defines a max width for the title. Value was chosen by trial and error on different screen sizes. For tiny phones, it might still be a problem though. 
I've looked for a better alternative online and found some people complaining about the same kind of problem. None of the other proposed solution worked/were satisfactory.