### PR TITLE
Refactor the RollCallHandler functions

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/MessageHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/MessageHandler.scala
@@ -8,6 +8,7 @@ import ch.epfl.pop.pubsub.AskPatternConstants
 import ch.epfl.pop.pubsub.graph.{ErrorCodes, GraphMessage, PipelineError}
 import ch.epfl.pop.storage.DbActor
 import ch.epfl.pop.storage.DbActor.DbActorReadLaoDataAck
+import com.sun.org.apache.xalan.internal.xsltc.compiler.util.ErrorMsg
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, Future}
@@ -19,11 +20,17 @@ trait MessageHandler extends AskPatternConstants {
     */
   def dbActor: AskableActorRef = DbActor.getInstance
 
-  def checkParameters(rpcRequest: JsonRpcRequest, error: String): Future[GraphMessage] = {
+  def checkParameters(rpcRequest: JsonRpcRequest, errorMsg: String): Future[GraphMessage] = {
     rpcRequest.getParamsMessage match {
       case Some(_) => Future(Left(rpcRequest))
-      case _       => Future(Right(PipelineError(ErrorCodes.SERVER_ERROR.id, error, rpcRequest.id)))
+      case _       => Future(Right(PipelineError(ErrorCodes.SERVER_ERROR.id, errorMsg, rpcRequest.id)))
+    }
+  }
 
+  def checkLaoChannel(rpcRequest: JsonRpcRequest, errorMsg: String): Future[GraphMessage] = {
+    rpcRequest.getParamsChannel.decodeChannelLaoId match {
+      case Some(_) => Future(Left(rpcRequest))
+      case _       => Future(Right(PipelineError(ErrorCodes.SERVER_ERROR.id, errorMsg, rpcRequest.id)))
     }
   }
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/MessageHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/MessageHandler.scala
@@ -19,6 +19,14 @@ trait MessageHandler extends AskPatternConstants {
     */
   def dbActor: AskableActorRef = DbActor.getInstance
 
+  def checkParameters(rpcRequest: JsonRpcRequest, error: String): Future[GraphMessage] = {
+    rpcRequest.getParamsMessage match {
+      case Some(_) => Future(Left(rpcRequest))
+      case _       => Future(Right(PipelineError(ErrorCodes.SERVER_ERROR.id, error, rpcRequest.id)))
+
+    }
+  }
+
   /** Asks the database to store the message contained in <rpcMessage> (or the provided message)
     *
     * @param rpcRequest

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandler.scala
@@ -19,8 +19,11 @@ object RollCallHandler extends MessageHandler {
   final lazy val handlerInstance = new RollCallHandler(super.dbActor)
 
   def handleCreateRollCall(rpcMessage: JsonRpcRequest): GraphMessage = handlerInstance.handleCreateRollCall(rpcMessage)
+
   def handleOpenRollCall(rpcMessage: JsonRpcRequest): GraphMessage = handlerInstance.handleOpenRollCall(rpcMessage)
+
   def handleReopenRollCall(rpcMessage: JsonRpcRequest): GraphMessage = handlerInstance.handleReopenRollCall(rpcMessage)
+
   def handleCloseRollCall(rpcMessage: JsonRpcRequest): GraphMessage = handlerInstance.handleCloseRollCall(rpcMessage)
 }
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandler.scala
@@ -39,142 +39,114 @@ class RollCallHandler(dbRef: => AskableActorRef) extends MessageHandler {
   private val serverUnexpectedAnswer: String = "The server is doing something unexpected"
 
   def handleCreateRollCall(rpcRequest: JsonRpcRequest): GraphMessage = {
-    rpcRequest.getParamsMessage match {
-      case Some(message: Message) =>
-        val data: CreateRollCall = message.decodedData.get.asInstanceOf[CreateRollCall]
-        // we are using the rollcall id instead of the message_id at rollcall creation
-        val rollCallChannel: Channel = Channel(s"${Channel.ROOT_CHANNEL_PREFIX}${data.id}")
-        val laoId: Hash = rpcRequest.extractLaoId
-        val ask =
-          for {
-            _ <- dbActor ? DbActor.ChannelExists(rollCallChannel) transformWith {
-              case Success(_) => Future {
-                  throw DbActorNAckException(ErrorCodes.INVALID_ACTION.id, "rollCall already exists in db")
-                }
-              case _ => Future {}
-            }
-            // we create a new channel to write uniquely the RollCall, this ensures then if the RollCall already exists or not
-            // otherwise, we never write in this channel
-            _ <- dbActor ? DbActor.CreateChannel(rollCallChannel, ObjectType.ROLL_CALL)
-            _ <- dbAskWritePropagate(rpcRequest)
-            _ <- dbActor ? DbActor.WriteRollCallData(laoId, message)
-          } yield ()
-
-        Await.ready(ask, duration).value match {
-          case Some(Success(_))                        => Left(rpcRequest)
-          case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleCreateRollCall failed : ${ex.message}", rpcRequest.getId))
-          case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleCreateRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
-        }
-      case _ =>
-        Right(
-          PipelineError(ErrorCodes.SERVER_ERROR.id, serverUnexpectedAnswer, rpcRequest.getId)
-        )
-    }
-  }
-
-  def handleOpenRollCall(rpcRequest: JsonRpcRequest): GraphMessage = {
-    rpcRequest.getParamsMessage match {
-      case Some(message: Message) =>
-        val channel: Channel = rpcRequest.getParamsChannel
-        val laoId: Hash = rpcRequest.extractLaoId
-        val ask =
-          for {
-            // check if the roll call already exists to open it
-            _ <- dbActor ? DbActor.ChannelExists(channel) transformWith {
-              case Success(_) => Future {}
-              case _ => Future {
-                  throw DbActorNAckException(ErrorCodes.INVALID_ACTION.id, "rollCall does not exist in db")
-                }
-            }
-            _ <- dbAskWritePropagate(rpcRequest)
-            // creates a RollCallData
-            _ <- dbActor ? DbActor.WriteRollCallData(laoId, message)
-          } yield ()
-
-        Await.ready(ask, duration).value match {
-          case Some(Success(_))                        => Left(rpcRequest)
-          case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleOpenRollCall failed : ${ex.message}", rpcRequest.getId))
-          case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleOpenRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
-        }
-      case _ =>
-        Right(
-          PipelineError(ErrorCodes.SERVER_ERROR.id, serverUnexpectedAnswer, rpcRequest.getId)
-        )
-    }
-  }
-
-  def handleReopenRollCall(rpcRequest: JsonRpcRequest): GraphMessage = {
-    rpcRequest.getParamsMessage match {
-      case Some(message: Message) =>
-        val laoId: Hash = rpcRequest.extractLaoId
-        val ask = for {
+      val ask =
+        for {
+          _ <- checkParameters(rpcRequest, serverUnexpectedAnswer)
+          message: Message = rpcRequest.getParamsMessage.get
+          data: CreateRollCall = message.decodedData.get.asInstanceOf[CreateRollCall]
+          // we are using the rollcall id instead of the message_id at rollcall creation
+          rollCallChannel: Channel = Channel(s"${Channel.ROOT_CHANNEL_PREFIX}${data.id}")
+          laoId: Hash = rpcRequest.extractLaoId
+          //do not see how to NOT use the transformWith function except if create other function, i.e. the inverse of CHannelExists
+          _ <- dbActor ? DbActor.ChannelExists(rollCallChannel) transformWith {
+            case Success(_) => Future {
+                throw DbActorNAckException(ErrorCodes.INVALID_ACTION.id, "rollCall already exists in db")
+              }
+            case _ => Future {}
+          }
+          // we create a new channel to write uniquely the RollCall, this ensures then if the RollCall already exists or not
+          // otherwise, we never write in this channel
+          _ <- dbActor ? DbActor.CreateChannel(rollCallChannel, ObjectType.ROLL_CALL)
           _ <- dbAskWritePropagate(rpcRequest)
           _ <- dbActor ? DbActor.WriteRollCallData(laoId, message)
         } yield ()
 
-        Await.ready(ask, duration).value match {
-          case Some(Success(_))                        => Left(rpcRequest)
-          case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleReOpenRollCall failed : ${ex.message}", rpcRequest.getId))
-          case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleRepenRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
-        }
-      case _ =>
-        Right(
-          PipelineError(ErrorCodes.SERVER_ERROR.id, serverUnexpectedAnswer, rpcRequest.getId)
-        )
-    }
+      Await.ready(ask, duration).value match {
+        case Some(Success(_))                        => Left(rpcRequest)
+        case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleCreateRollCall failed : ${ex.message}", rpcRequest.getId))
+        case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleCreateRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
+      }
+  }
+
+  def handleOpenRollCall(rpcRequest: JsonRpcRequest): GraphMessage = {
+      val ask =
+        for {
+          _ <- checkParameters(rpcRequest, serverUnexpectedAnswer) //if it fails, throw an error
+          message: Message = rpcRequest.getParamsMessage.get // this line is not executed if the first fails
+          channel: Channel = rpcRequest.getParamsChannel
+          laoId: Hash = rpcRequest.extractLaoId
+          // check if the roll call already exists to open it
+          //no need for the transform with, message of error thrown by the CHannelExists
+          _ <- dbActor ? DbActor.ChannelExists(channel)
+          _ <- dbAskWritePropagate(rpcRequest)
+          // creates a RollCallData
+          _ <- dbActor ? DbActor.WriteRollCallData(laoId, message)
+        } yield ()
+
+      Await.ready(ask, duration).value match {
+        case Some(Success(_))                        => Left(rpcRequest)
+        case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleOpenRollCall failed : ${ex.message}", rpcRequest.getId))
+        case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleOpenRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
+      }
+  }
+
+  def handleReopenRollCall(rpcRequest: JsonRpcRequest): GraphMessage = {
+      val ask = for {
+        _ <- checkParameters(rpcRequest, serverUnexpectedAnswer)
+        message: Message = rpcRequest.getParamsMessage.get
+        laoId: Hash = rpcRequest.extractLaoId
+        _ <- dbAskWritePropagate(rpcRequest)
+        _ <- dbActor ? DbActor.WriteRollCallData(laoId, message)
+      } yield ()
+
+      Await.ready(ask, duration).value match {
+        case Some(Success(_))                        => Left(rpcRequest)
+        case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleReOpenRollCall failed : ${ex.message}", rpcRequest.getId))
+        case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleRepenRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
+      }
   }
 
   def handleCloseRollCall(rpcRequest: JsonRpcRequest): GraphMessage = {
-    val ask: Future[GraphMessage] = dbAskWritePropagate(rpcRequest)
-    Await.result(ask, duration) match {
-      case Left(_) =>
-        rpcRequest.getParamsMessage match {
-          case Some(message: Message) =>
-            val data: CloseRollCall = message.decodedData.get.asInstanceOf[CloseRollCall]
+    val laoChannel: Option[Hash] = rpcRequest.getParamsChannel.decodeChannelLaoId
+    laoChannel match {
+      case None => Right(PipelineError(
+          ErrorCodes.SERVER_ERROR.id,
+          s"There is an issue with the data of the LAO",
+          rpcRequest.id
+        ))
+      case Some(_) =>
+        val combined = for {
+          _ <- dbAskWritePropagate(rpcRequest)
+          _ <- checkParameters(rpcRequest, s"Unable to handle lao message $rpcRequest. Not a Publish/Broadcast message")
+          message: Message = rpcRequest.getParamsMessage.get
+          _ <- dbActor ? DbActor.WriteLaoData(rpcRequest.getParamsChannel, message, None)
+          _ <- dbActor ? DbActor.WriteRollCallData(laoChannel.get, message)
+        } yield ()
 
-            // creates a channel for each attendee (of name /root/lao_id/social/PublicKeyAttendee), returns a GraphMessage
-            def createAttendeeChannels(attendees: List[PublicKey]): GraphMessage = {
-              val listAttendeeChannels: List[(Channel, ObjectType.ObjectType)] = data.attendees.map {
-                attendee => (generateSocialChannel(rpcRequest.getParamsChannel, attendee), ObjectType.CHIRP)
-              }
-
-              val askCreateChannels = dbActor ? DbActor.CreateChannelsFromList(listAttendeeChannels)
-
-              Await.ready(askCreateChannels, duration).value match {
-                case Some(Success(_))                        => Left(rpcRequest)
-                case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleCloseRollCall failed : ${ex.message}", rpcRequest.getId))
-                case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleCloseRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
-              }
-            }
-            val laoChannel: Option[Hash] = rpcRequest.getParamsChannel.decodeChannelLaoId
-            laoChannel match {
-              case None => Right(PipelineError(
-                  ErrorCodes.SERVER_ERROR.id,
-                  s"There is an issue with the data of the LAO",
-                  rpcRequest.id
-                ))
-              case Some(_) =>
-                val combined = for {
-                  _ <- dbActor ? DbActor.WriteLaoData(rpcRequest.getParamsChannel, message, None)
-                  _ <- dbActor ? DbActor.WriteRollCallData(laoChannel.get, message)
-                } yield ()
-
-                Await.ready(combined, duration).value match {
-                  case Some(Success(_))                        => createAttendeeChannels(data.attendees)
-                  case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleCloseRollCall failed : ${ex.message}", rpcRequest.getId))
-                  case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleCloseRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
-                }
-            }
-          case _ => Right(PipelineError(
-              ErrorCodes.SERVER_ERROR.id,
-              s"Unable to handle lao message $rpcRequest. Not a Publish/Broadcast message",
-              rpcRequest.id
-            ))
+        Await.ready(combined, duration).value match {
+          case Some(Success(_))                        => createAttendeeChannels(rpcRequest)
+          case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleCloseRollCall failed : ${ex.message}", rpcRequest.getId))
+          case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleCloseRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
         }
-      case error @ Right(_) => error
-      case _                => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, unknownAnswer, rpcRequest.id))
     }
   }
 
   private def generateSocialChannel(channel: Channel, pk: PublicKey): Channel = Channel(s"$channel${Channel.SOCIAL_CHANNEL_PREFIX}${pk.base64Data}")
+
+  // creates a channel for each attendee (of name /root/lao_id/social/PublicKeyAttendee), returns a GraphMessage
+  private def createAttendeeChannels(rpcRequest: JsonRpcRequest): GraphMessage = {
+    val message: Message = rpcRequest.getParamsMessage.get
+    val data: CloseRollCall = message.decodedData.get.asInstanceOf[CloseRollCall]
+    val listAttendeeChannels: List[(Channel, ObjectType.ObjectType)] = data.attendees.map {
+      attendee => (generateSocialChannel(rpcRequest.getParamsChannel, attendee), ObjectType.CHIRP)
+    }
+
+    val askCreateChannels = dbActor ? DbActor.CreateChannelsFromList(listAttendeeChannels)
+
+    Await.ready(askCreateChannels, duration).value match {
+      case Some(Success(_))                        => Left(rpcRequest)
+      case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleCloseRollCall failed : ${ex.message}", rpcRequest.getId))
+      case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleCloseRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
+    }
+  }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/storage/DbActor.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/storage/DbActor.scala
@@ -460,12 +460,12 @@ object DbActor {
   final case class ChannelExists(channel: Channel) extends Event
 
   /** Request to check if channel <channel> is missing in the db
-   *
-   * @param channel
-   *   targeted channel
-   * @note
-   *   db answers with a simple boolean
-   */
+    *
+    * @param channel
+    *   targeted channel
+    * @note
+    *   db answers with a simple boolean
+    */
   final case class ChannelMissing(channel: Channel) extends Event
 
   /** Request to append witness <signature> to a stored message with message_id <messageId>

--- a/be2-scala/src/main/scala/ch/epfl/pop/storage/DbActor.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/storage/DbActor.scala
@@ -317,6 +317,14 @@ final case class DbActor(
         sender() ! Status.Failure(DbActorNAckException(ErrorCodes.INVALID_ACTION.id, s"channel '$channel' does not exist in db"))
       }
 
+    case ChannelMissing(channel) =>
+      log.info(s"Actor $self (db) received an ChannelMissing request for channel '$channel'")
+      if (checkChannelExistence(channel)) {
+        sender() ! Status.Failure(DbActorNAckException(ErrorCodes.INVALID_ACTION.id, s"channel '$channel' already exists in db"))
+      } else {
+        sender() ! DbActorAck()
+      }
+
     case AddWitnessSignature(channel, messageId, signature) =>
       log.info(s"Actor $self (db) received an AddWitnessSignature request for message_id '$messageId'")
       Try(addWitnessSignature(channel, messageId, signature)) match {
@@ -450,6 +458,15 @@ object DbActor {
     *   db answers with a simple boolean
     */
   final case class ChannelExists(channel: Channel) extends Event
+
+  /** Request to check if channel <channel> is missing in the db
+   *
+   * @param channel
+   *   targeted channel
+   * @note
+   *   db answers with a simple boolean
+   */
+  final case class ChannelMissing(channel: Channel) extends Event
 
   /** Request to append witness <signature> to a stored message with message_id <messageId>
     *

--- a/be2-scala/src/main/scala/ch/epfl/pop/storage/DbActor.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/storage/DbActor.scala
@@ -317,8 +317,8 @@ final case class DbActor(
         sender() ! Status.Failure(DbActorNAckException(ErrorCodes.INVALID_ACTION.id, s"channel '$channel' does not exist in db"))
       }
 
-    case ChannelMissing(channel) =>
-      log.info(s"Actor $self (db) received an ChannelMissing request for channel '$channel'")
+    case AssertChannelMissing(channel) =>
+      log.info(s"Actor $self (db) received an AssertChannelMissing request for channel '$channel'")
       if (checkChannelExistence(channel)) {
         sender() ! Status.Failure(DbActorNAckException(ErrorCodes.INVALID_ACTION.id, s"channel '$channel' already exists in db"))
       } else {
@@ -466,7 +466,7 @@ object DbActor {
     * @note
     *   db answers with a simple boolean
     */
-  final case class ChannelMissing(channel: Channel) extends Event
+  final case class AssertChannelMissing(channel: Channel) extends Event
 
   /** Request to append witness <signature> to a stored message with message_id <messageId>
     *

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandlerTest.scala
@@ -10,7 +10,7 @@ import ch.epfl.pop.storage.DbActor
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
 import org.scalatest.matchers.should.Matchers
-import util.examples.data.{CreateRollCallMessages, OpenRollCallMessages}
+import util.examples.data.{CloseRollCallMessages, CreateRollCallMessages, OpenRollCallMessages, ReopenRollCallMessages}
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -99,7 +99,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     system.stop(mockedDB.actorRef)
   }
 
-  test("CreateRollCall should succeed if the roll call doesn't already exist in the database") {
+  test("CreateRollCall should succeed if the rollcall call doesn't already exist in the database") {
     val mockedDB = mockDbRollCallNotCreated
     val rc = new RollCallHandler(mockedDB)
     val request = CreateRollCallMessages.createRollCall
@@ -107,7 +107,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     system.stop(mockedDB.actorRef)
   }
 
-  test("CreateRollCall should fail if the roll call already exists in database") {
+  test("CreateRollCall should fail if the rollcall call already exists in database") {
     val mockedDB = mockDbRollCallAlreadyCreated
     val rc = new RollCallHandler(mockedDB)
     val request = CreateRollCallMessages.createRollCall
@@ -115,7 +115,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     system.stop(mockedDB.actorRef)
   }
 
-  test("OpenRollCall should fail if the roll does not exist in database") {
+  test("OpenRollCall should fail if the rollcall does not exist in database") {
     val mockedDB = mockDbRollCallNotCreated
     val rc = new RollCallHandler(mockedDB)
     val request = OpenRollCallMessages.openRollCall
@@ -123,7 +123,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     system.stop(mockedDB.actorRef)
   }
 
-  test("OpenRollCall should succeed if the roll is already created") {
+  test("OpenRollCall should succeed if the rollcall is already created") {
     val mockedDB = mockDbRollCallAlreadyCreated
     val rc = new RollCallHandler(mockedDB)
     val request = OpenRollCallMessages.openRollCall
@@ -136,6 +136,38 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     val rc = new RollCallHandler(mockedDB)
     val request = OpenRollCallMessages.openRollCall
     rc.handleOpenRollCall(request) shouldBe an[Right[PipelineError, _]]
+    system.stop(mockedDB.actorRef)
+  }
+
+  test("ReopenRollcall should succeed if the rollcall is already created") {
+    val mockedDB = mockDbRollCallAlreadyCreated
+    val rc = new RollCallHandler(mockedDB)
+    val request = ReopenRollCallMessages.reopenRollCall
+    rc.handleReopenRollCall(request) should matchPattern { case Left(_) => }
+    system.stop(mockedDB.actorRef)
+  }
+
+  test("ReopenRollcall should fail if the database fails storing the message") {
+    val mockedDB = mockDbWithNack
+    val rc = new RollCallHandler(mockedDB)
+    val request = ReopenRollCallMessages.reopenRollCall
+    rc.handleReopenRollCall(request) shouldBe an[Right[PipelineError, _]]
+    system.stop(mockedDB.actorRef)
+  }
+
+  test("CloseRollcall should succeed if the rollcall is already created") {
+    val mockedDB = mockDbRollCallAlreadyCreated
+    val rc = new RollCallHandler(mockedDB)
+    val request = CloseRollCallMessages.closeRollCall
+    rc.handleCloseRollCall(request) should matchPattern { case Left(_) => }
+    system.stop(mockedDB.actorRef)
+  }
+
+  test("CloseRollcall should fail if the database fails storing the message") {
+    val mockedDB = mockDbWithNack
+    val rc = new RollCallHandler(mockedDB)
+    val request = CloseRollCallMessages.closeRollCall
+    rc.handleCloseRollCall(request) shouldBe an[Right[PipelineError, _]]
     system.stop(mockedDB.actorRef)
   }
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandlerTest.scala
@@ -28,7 +28,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         // You can modify the following match case to include more args, names...
-        case m @ (DbActor.WriteAndPropagate(_, _) | DbActor.ChannelExists(_) | DbActor.CreateChannel(_, _) | DbActor.ChannelMissing(_)) =>
+        case m @ (DbActor.WriteAndPropagate(_, _) | DbActor.ChannelExists(_) | DbActor.CreateChannel(_, _) | DbActor.ChannelMissing(_) | DbActor.WriteRollCallData(_, _) | DbActor.WriteLaoData(_, _, _)) =>
           system.log.info(s"Received - message $m")
           system.log.info("Responding with a Nack")
           sender() ! Status.Failure(DbActorNAckException(1, "error"))
@@ -74,7 +74,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
           system.log.info(s"Received a message")
           system.log.info("Responding with a Ack")
           sender() ! DbActor.DbActorAck()
-        case DbActor.WriteRollCallData(_, _) =>
+        case DbActor.WriteRollCallData(_, _) | DbActor.WriteLaoData(_, _, _) =>
           system.log.info(s"Received a message")
           system.log.info("Responding with a Ack")
           sender() ! DbActor.DbActorAck()
@@ -152,14 +152,6 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     val rc = new RollCallHandler(mockedDB)
     val request = ReopenRollCallMessages.reopenRollCall
     rc.handleReopenRollCall(request) shouldBe an[Right[PipelineError, _]]
-    system.stop(mockedDB.actorRef)
-  }
-
-  test("CloseRollcall should succeed if the rollcall is already created") {
-    val mockedDB = mockDbRollCallAlreadyCreated
-    val rc = new RollCallHandler(mockedDB)
-    val request = CloseRollCallMessages.closeRollCall
-    rc.handleCloseRollCall(request) should matchPattern { case Left(_) => }
     system.stop(mockedDB.actorRef)
   }
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandlerTest.scala
@@ -28,7 +28,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         // You can modify the following match case to include more args, names...
-        case m @ (DbActor.WriteAndPropagate(_, _) | DbActor.ChannelExists(_) | DbActor.CreateChannel(_, _) | DbActor.ChannelMissing(_) | DbActor.WriteRollCallData(_, _) | DbActor.WriteLaoData(_, _, _)) =>
+        case m @ (DbActor.WriteAndPropagate(_, _) | DbActor.ChannelExists(_) | DbActor.CreateChannel(_, _) | DbActor.AssertChannelMissing(_) | DbActor.WriteRollCallData(_, _) | DbActor.WriteLaoData(_, _, _)) =>
           system.log.info(s"Received - message $m")
           system.log.info("Responding with a Nack")
           sender() ! Status.Failure(DbActorNAckException(1, "error"))
@@ -55,7 +55,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
           system.log.info(s"Received a create rollcall message")
           system.log.info("Responding with a no")
           sender() ! Status.Failure(DbActorNAckException(1, "error"))
-        case DbActor.ChannelMissing(_) =>
+        case DbActor.AssertChannelMissing(_) =>
           system.log.info(s"Received a message")
           system.log.info("Responding with a Ack")
           sender() ! DbActor.DbActorAck()
@@ -78,7 +78,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
           system.log.info(s"Received a message")
           system.log.info("Responding with a Ack")
           sender() ! DbActor.DbActorAck()
-        case DbActor.ChannelMissing(_) =>
+        case DbActor.AssertChannelMissing(_) =>
           system.log.info(s"Received a message")
           system.log.info("Responding with a no")
           sender() ! Status.Failure(DbActorNAckException(1, "error"))
@@ -99,7 +99,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     system.stop(mockedDB.actorRef)
   }
 
-  test("CreateRollCall should succeed if the rollcall call doesn't already exist in the database") {
+  test("CreateRollCall should succeed if the rollcall doesn't already exist in the database") {
     val mockedDB = mockDbRollCallNotCreated
     val rc = new RollCallHandler(mockedDB)
     val request = CreateRollCallMessages.createRollCall
@@ -107,7 +107,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     system.stop(mockedDB.actorRef)
   }
 
-  test("CreateRollCall should fail if the rollcall call already exists in database") {
+  test("CreateRollCall should fail if the rollcall already exists in database") {
     val mockedDB = mockDbRollCallAlreadyCreated
     val rc = new RollCallHandler(mockedDB)
     val request = CreateRollCallMessages.createRollCall

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandlerTest.scala
@@ -28,7 +28,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         // You can modify the following match case to include more args, names...
-        case m @ (DbActor.WriteAndPropagate(_, _) | DbActor.ChannelExists(_) | DbActor.CreateChannel(_, _)) =>
+        case m @ (DbActor.WriteAndPropagate(_, _) | DbActor.ChannelExists(_) | DbActor.CreateChannel(_, _) | DbActor.ChannelMissing(_)) =>
           system.log.info(s"Received - message $m")
           system.log.info("Responding with a Nack")
           sender() ! Status.Failure(DbActorNAckException(1, "error"))
@@ -55,6 +55,10 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
           system.log.info(s"Received a create rollcall message")
           system.log.info("Responding with a no")
           sender() ! Status.Failure(DbActorNAckException(1, "error"))
+        case DbActor.ChannelMissing(_) =>
+          system.log.info(s"Received a message")
+          system.log.info("Responding with a Ack")
+          sender() ! DbActor.DbActorAck()
         case x =>
           system.log.info(s"Received - error $x")
       }
@@ -74,6 +78,10 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
           system.log.info(s"Received a message")
           system.log.info("Responding with a Ack")
           sender() ! DbActor.DbActorAck()
+        case DbActor.ChannelMissing(_) =>
+          system.log.info(s"Received a message")
+          system.log.info("Responding with a no")
+          sender() ! Status.Failure(DbActorNAckException(1, "error"))
         case x =>
           system.log.info(s"Received - error $x")
       }

--- a/be2-scala/src/test/scala/util/examples/data/RollCallMessages.scala
+++ b/be2-scala/src/test/scala/util/examples/data/RollCallMessages.scala
@@ -46,9 +46,9 @@ object ReopenRollCallMessages extends RollCallMessagesTrait {
 
   override val CHANNEL: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + "reopen_roll_call_channel")
 
-  final val reopenRollCall: JsonRpcRequest = getJsonRPCRequestFromFile("reopen_call_close.json")()
+  final val reopenRollCall: JsonRpcRequest = getJsonRPCRequestFromFile("roll_call_reopen.json")()
 
-  // TODO: Generate other Close RollCall messages
+  // TODO: Generate other Reopen RollCall messages
 }
 
 object RollCallCustomBuilders {

--- a/be2-scala/src/test/scala/util/examples/data/RollCallMessages.scala
+++ b/be2-scala/src/test/scala/util/examples/data/RollCallMessages.scala
@@ -35,7 +35,7 @@ object CloseRollCallMessages extends RollCallMessagesTrait {
 
   override val CHANNEL: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + "close_roll_call_channel")
 
-  final val openRollCall: JsonRpcRequest = getJsonRPCRequestFromFile("roll_call_close.json")()
+  final val closeRollCall: JsonRpcRequest = getJsonRPCRequestFromFile("roll_call_close.json")()
 
   // TODO: Generate other Close RollCall messages
 }
@@ -46,7 +46,7 @@ object ReopenRollCallMessages extends RollCallMessagesTrait {
 
   override val CHANNEL: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + "reopen_roll_call_channel")
 
-  final val openRollCall: JsonRpcRequest = getJsonRPCRequestFromFile("reopen_call_close.json")()
+  final val reopenRollCall: JsonRpcRequest = getJsonRPCRequestFromFile("reopen_call_close.json")()
 
   // TODO: Generate other Close RollCall messages
 }

--- a/be2-scala/src/test/scala/util/examples/data/builders/HighLevelMessageGenerator.scala
+++ b/be2-scala/src/test/scala/util/examples/data/builders/HighLevelMessageGenerator.scala
@@ -122,6 +122,11 @@ object HighLevelMessageGenerator {
           params = new ParamsWithMessage(Channel.ROOT_CHANNEL, message.withDecodedData(messageData).toMessage)
           JsonRpcRequest(RpcValidator.JSON_RPC_VERSION, methodType, params, id)
 
+        case (ObjectType.ROLL_CALL, ActionType.REOPEN) =>
+          messageData = OpenRollCall.buildFromJson(payload)
+          params = new ParamsWithMessage(Channel.ROOT_CHANNEL, message.withDecodedData(messageData).toMessage)
+          JsonRpcRequest(RpcValidator.JSON_RPC_VERSION, methodType, params, id)
+
         case (ObjectType.ROLL_CALL, ActionType.CLOSE) =>
           messageData = CloseRollCall.buildFromJson(payload)
           params = new ParamsWithMessage(Channel.ROOT_CHANNEL, message.withDecodedData(messageData).toMessage)


### PR DESCRIPTION
I have tried to refactor as we discussed during the meeting: 

- I created a function `checkParameters` in `MessageHandler` file, so that we avoid having several matching cases (that is the simpler way I found). Also, this function can be used in every handler file. 
- Concerning the ChannelExists function, I did not find a simple way to avoid using the `transformWith` function. Any suggestion could be useful 
- In line 80 of `RollCallHandler` file, I avoided the `transformWith` function, because I thought it was not really useful, since we already get a error message from the function `ChannelExists` itself. 
- Concerning the `CloseRollCall` function, I rearranged the function by redefining the function `createAttendeeChannels`  and putting it outside as a private function. 
