### PR TITLE
Do not select tab when switching opens an activity

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/detail/LaoDetailActivity.java
@@ -78,10 +78,10 @@ public class LaoDetailActivity extends NavigationActivity<LaoTab> {
       if (fragment instanceof LaoDetailFragment) {
         startActivity(HomeActivity.newIntent(this));
       } else {
-        if (viewModel.getCurrentTab().getValue() == LaoTab.EVENTS){
-            // On reselection the navigation is supposed to do nothing to prevent loops, so we
-            // manually change the fragment
-            openEventsTab();
+        if (viewModel.getCurrentTab().getValue() == LaoTab.EVENTS) {
+          // On reselection the navigation is supposed to do nothing to prevent loops, so we
+          // manually change the fragment
+          openEventsTab();
         } else {
           viewModel.setCurrentTab(LaoTab.EVENTS);
         }
@@ -109,23 +109,23 @@ public class LaoDetailActivity extends NavigationActivity<LaoTab> {
     switch (tab) {
       case EVENTS:
         openEventsTab();
-        break;
+        return true;
       case IDENTITY:
         openIdentityTab();
-        break;
+        return true;
       case WITNESSING:
         openWitnessTab();
-        break;
+        return true;
       case DIGITAL_CASH:
         openDigitalCashTab();
-        break;
+        return false;
       case SOCIAL:
         openSocialMediaTab();
-        break;
+        return false;
       default:
         Log.w(TAG, "Unhandled tab type : " + tab);
+        return false;
     }
-    return true;
   }
 
   @Override


### PR DESCRIPTION
This tiny PR tries to fix the issue of the navigation bar that desynchronizes from the actual opened tab.

It removes the fact that the social media and digital cash activities are selected when pressing their respective button.

That way, going back to the Lao activity keeps the last selected tab, which is the one opened.