### PR TITLE
Fix networking issues

### DIFF
--- a/fe1-web/src/App.tsx
+++ b/fe1-web/src/App.tsx
@@ -1,18 +1,18 @@
 import 'react-native-gesture-handler';
 
 import { ActionSheetProvider } from '@expo/react-native-action-sheet';
-import { NavigationContainer, useNavigationContainerRef } from '@react-navigation/native';
+import { NavigationContainer } from '@react-navigation/native';
 import { registerRootComponent } from 'expo';
 import React from 'react';
 import { Platform, StatusBar } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { ToastProvider } from 'react-native-toast-notifications';
+import Toast, { ToastProvider } from 'react-native-toast-notifications';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 
 import FeatureContext from 'core/contexts/FeatureContext';
 import { configureKeyPair } from 'core/keypair';
-import AppNavigation from 'core/navigation/AppNavigation';
+import AppNavigation, { navigationRef } from 'core/navigation/AppNavigation';
 import { configureNetwork } from 'core/network';
 import { persist, store } from 'core/redux';
 import { Color } from 'core/styles';
@@ -39,8 +39,6 @@ persist.persist();
  * The Platform.OS is to put the statusBar in IOS in black, otherwise it is not readable
  */
 function App() {
-  const navigationRef = useNavigationContainerRef();
-
   return (
     <Provider store={store}>
       <PersistGate loading={null} persistor={persist}>
@@ -57,6 +55,11 @@ function App() {
                   warningColor={Color.warning}
                   dangerColor={Color.error}>
                   <AppNavigation screens={navigationOpts.screens} />
+                  <Toast
+                    ref={(ref) => {
+                      globalThis.toast = ref;
+                    }}
+                  />
                 </ToastProvider>
               </SafeAreaProvider>
             </ActionSheetProvider>

--- a/fe1-web/src/__mocks__/websocket/index.ts
+++ b/fe1-web/src/__mocks__/websocket/index.ts
@@ -18,6 +18,9 @@ export class w3cwebsocket {
 
   constructor(url: string) {
     this.url = url;
+
+    // mock connection establishment
+    setTimeout(this.mockOnOpen.bind(this), 100);
   }
 
   public mockOnOpen() {

--- a/fe1-web/src/__mocks__/websocket/index.ts
+++ b/fe1-web/src/__mocks__/websocket/index.ts
@@ -1,5 +1,31 @@
 import { jest } from '@jest/globals';
-import { ICloseEvent, IMessageEvent, w3cwebsocket as W3CWebSocket } from 'websocket';
+import { w3cwebsocket as W3CWebSocket } from 'websocket';
+
+type NetworkMessage = string;
+type NetworkMessageHandler = (ws: w3cwebsocket, message: NetworkMessage) => void;
+
+let networkMessageHandlers: NetworkMessageHandler[] = [];
+
+export const addNetworkMessageHandler = (handler: NetworkMessageHandler) =>
+  networkMessageHandlers.push(handler);
+
+export const removeNetworkMessageHandler = (handler: NetworkMessageHandler) => {
+  networkMessageHandlers = networkMessageHandlers.filter((h) => h !== handler);
+};
+
+export const clearNetworkMessageHandlers = () => {
+  networkMessageHandlers = [];
+};
+
+let areNewConnectionsPossible = true;
+
+export const allowNewConnections = () => {
+  areNewConnectionsPossible = true;
+};
+
+export const disallowNewConnections = () => {
+  areNewConnectionsPossible = false;
+};
 
 // the name of the mock must match exactly
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -20,30 +46,54 @@ export class w3cwebsocket {
     this.url = url;
 
     // mock connection establishment
-    setTimeout(this.mockOnOpen.bind(this), 100);
+    setTimeout(() => {
+      if (areNewConnectionsPossible) {
+        this.mockOnOpen();
+      } else {
+        this.mockConnectionError(new Error('Could not reach destination'));
+      }
+    }, 100);
   }
 
   public mockOnOpen() {
+    this.readyState = 1;
     this.onopen();
   }
 
-  public mockOnMessage(message: IMessageEvent) {
-    this.onmessage(message);
+  public mockReceive(message: string) {
+    this.onmessage({ data: message });
   }
 
-  public mockOnClose(event: ICloseEvent) {
-    this.onclose(event);
-  }
-
-  public mockOnError(error: Error) {
-    this.onerror(error);
-  }
-
-  public close = jest.fn(() => {
+  public mockConnectionClose(wasClean: boolean, code?: number, reason?: string) {
     this.readyState = 3;
+    this.onclose({ code: code || 0, reason: reason || 'No reason provided', wasClean });
+  }
+
+  public mockConnectionError(error: Error) {
+    this.readyState = 3;
+    this.onerror(error);
+    this.onclose({ code: -1, reason: error.message, wasClean: false });
+  }
+
+  public close: W3CWebSocket['close'] = jest.fn((code?: number, reason?: string) => {
+    this.readyState = 2;
+
+    setTimeout(() => {
+      this.readyState = 3;
+
+      // https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close_event
+      this.onclose({
+        /* A unsigned short containing the close code sent by the server. */
+        code: code || 0,
+        reason: reason || 'Client closed the connection',
+        wasClean: true,
+      });
+    }, 100);
   });
 
-  public send = jest.fn();
+  public send: W3CWebSocket['send'] = jest.fn((message: NetworkMessage) => {
+    networkMessageHandlers.forEach((h) => h(this, message));
+  });
 }
 
 export type MockedW3CWebSocket = w3cwebsocket;

--- a/fe1-web/src/__tests__/utils/websocket.ts
+++ b/fe1-web/src/__tests__/utils/websocket.ts
@@ -1,0 +1,27 @@
+import {
+  w3cwebsocket,
+  // @ts-ignore
+  addNetworkMessageHandler as addHandler,
+  // @ts-ignore
+  removeNetworkMessageHandler as removeHandler,
+  // @ts-ignore
+  clearNetworkMessageHandlers as clearHandlers,
+  // @ts-ignore
+  allowNewConnections as allowNewC,
+  // @ts-ignore
+  disallowNewConnections as disallowNewC,
+} from 'websocket';
+
+export type MockWebsocket = w3cwebsocket & { mockReceive: (message: NetworkMessage) => void };
+
+export type NetworkMessage = string;
+export type NetworkMessageHandler = (ws: MockWebsocket, message: NetworkMessage) => void;
+
+export const addNetworkMessageHandler = addHandler as (handler: NetworkMessageHandler) => void;
+export const removeNetworkMessageHandler = removeHandler as (
+  handler: NetworkMessageHandler,
+) => void;
+export const clearNetworkMessageHandlers = clearHandlers as () => void;
+
+export const allowNewConnections = allowNewC as () => void;
+export const disallowNewConnections = disallowNewC as () => void;

--- a/fe1-web/src/__tests__/utils/websocket.ts
+++ b/fe1-web/src/__tests__/utils/websocket.ts
@@ -12,7 +12,10 @@ import {
   disallowNewConnections as disallowNewC,
 } from 'websocket';
 
-export type MockWebsocket = w3cwebsocket & { mockReceive: (message: NetworkMessage) => void };
+export type MockWebsocket = w3cwebsocket & {
+  mockReceive: (message: NetworkMessage) => void;
+  mockConnectionClose: (wasClean: boolean, code?: number, reason?: string) => void;
+};
 
 export type NetworkMessage = string;
 export type NetworkMessageHandler = (ws: MockWebsocket, message: NetworkMessage) => void;

--- a/fe1-web/src/core/navigation/AppNavigation.tsx
+++ b/fe1-web/src/core/navigation/AppNavigation.tsx
@@ -1,3 +1,4 @@
+import { createNavigationContainerRef } from '@react-navigation/core';
 import { createStackNavigator } from '@react-navigation/stack';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -8,6 +9,9 @@ import STRINGS from 'resources/strings';
 
 import { AppParamList } from './typing/AppParamList';
 import { NavigationScreen } from './typing/Screen';
+
+// allows react-navigation to be used outside of react components
+export const navigationRef = createNavigationContainerRef<AppParamList>();
 
 /**
  * Define the App stack navigation

--- a/fe1-web/src/core/network/NetworkConnection.ts
+++ b/fe1-web/src/core/network/NetworkConnection.ts
@@ -67,9 +67,14 @@ export class NetworkConnection {
   private onInitialOpenCallback?: () => void;
 
   /**
+   * The timeout set when initially opening a connection
+   */
+  private readonly initalOpenTimeout: ReturnType<typeof setTimeout>;
+
+  /**
    * Function called when the connection closes for good
    */
-  private readonly onConnectionDeadCallback?: () => void;
+  private readonly onConnectionDeathCallback?: () => void;
 
   /**
    * Boolean indicating whether this connection is open or there is still hope
@@ -90,14 +95,27 @@ export class NetworkConnection {
     address: string,
     handler?: JsonRpcHandler,
     onInitialOpenCallback?: () => void,
-    onConnectionDeadCallback?: () => void,
+    onInitialOpenTimeout?: () => void,
+    onConnectionDeathCallback?: () => void,
   ) {
     this.address = address;
     this.onRpcHandler = handler !== undefined ? handler : defaultRpcHandler;
     this.onInitialOpenCallback = onInitialOpenCallback;
-    this.onConnectionDeadCallback = onConnectionDeadCallback;
+    this.onConnectionDeathCallback = onConnectionDeathCallback;
     this.alive = true;
     this.closeIntent = false;
+
+    this.initalOpenTimeout = setTimeout(() => {
+      // if the initial timeout expires, we deem this connection
+      // dead. this signals the rest of the class to ignore
+      // any further data that is received
+      this.alive = false;
+      this.disconnect();
+
+      if (onInitialOpenTimeout) {
+        onInitialOpenTimeout();
+      }
+    }, WEBSOCKET_CONNECTION_FAILURE_TIMEOUT_MS);
 
     this.ws = this.establishConnection(address);
   }
@@ -117,25 +135,21 @@ export class NetworkConnection {
    * Creates a new NetworkConnection instance
    * @param address The address to connect to
    * @param handler The json rpc message handler
-   * @param onConnectionDeadCallback A function called when the connection closes for good because of an error
+   * @param onConnectionDeathCallback A function called when the connection closes for good because of an error
    * @returns A promise with the network connection if a connection can be established
    */
   static create(
     address: string,
     handler: JsonRpcHandler,
-    onConnectionDeadCallback: () => void,
+    onConnectionDeathCallback: () => void,
   ): Promise<NetworkConnection> {
     return new Promise((resolve, reject) => {
-      setTimeout(
-        () => reject(new NetworkError(`Connecting to ${address} timed out.`)),
-        WEBSOCKET_CONNECTION_FAILURE_TIMEOUT_MS,
-      );
-
       const nc: NetworkConnection = new NetworkConnection(
         address,
         handler,
         () => resolve(nc),
-        onConnectionDeadCallback,
+        () => reject(new NetworkError(`Connecting to ${address} timed out.`)),
+        onConnectionDeathCallback,
       );
     });
   }
@@ -156,12 +170,15 @@ export class NetworkConnection {
     // 0 = CONNECTING, 1 = OPEN, 2 = CLOSING, 3 = CLOSED
     if (this.ws.readyState > 1) {
       return new Promise((resolve, reject) => {
-        setTimeout(
+        const connectionTimeout = setTimeout(
           () => reject(new NetworkError(`Re-connecting to ${this.address} timed out.`)),
           WEBSOCKET_CONNECTION_FAILURE_TIMEOUT_MS,
         );
 
-        this.onInitialOpenCallback = resolve;
+        this.onInitialOpenCallback = () => {
+          resolve();
+          clearTimeout(connectionTimeout);
+        };
         this.ws = this.establishConnection(this.address);
       });
     }
@@ -173,7 +190,14 @@ export class NetworkConnection {
    * Function called when the websocket connection opens / is established
    */
   private onOpen(): void {
+    // only execute function if the connection is still alive
+    // (it could be that due to a timeout this connection is already deemed dead)
+    // if (!this.alive) {
+    //   return;
+    // }
+
     console.info(`Initiating web socket : ${this.address}`);
+    clearTimeout(this.initalOpenTimeout);
 
     // reset failed connection attempts
     this.failedConnectionAttempts = 0;
@@ -222,9 +246,17 @@ export class NetworkConnection {
    * Function called when the connection has been closed, either on purpose or because of an error
    */
   private onClose(): void {
+    // only execute function if the connection is still alive
+    // (it could be that due to a timeout this connection is already deemed dead)
+    if (!this.alive) {
+      return;
+    }
+
     console.info(`Closed websocket connection : ${this.address}`);
 
+    // check if we actually wanted to close this connection
     if (this.closeIntent) {
+      this.alive = false;
       return;
     }
 
@@ -243,10 +275,10 @@ export class NetworkConnection {
     console.error(`Connection with ${this.address} broke for good`);
     this.alive = false;
 
-    if (this.onConnectionDeadCallback) {
+    if (this.onConnectionDeathCallback) {
       // do not try to re-establish the connection, this connection seems
       // to be broken for now and the near future
-      this.onConnectionDeadCallback();
+      this.onConnectionDeathCallback();
     }
   }
 
@@ -254,6 +286,12 @@ export class NetworkConnection {
    * Function called when the websocket connection fails because of an error
    */
   private onError(event: Error): void {
+    // only execute function if the connection is still alive
+    // (it could be that due to a timeout this connection is already deemed dead)
+    if (!this.alive) {
+      return;
+    }
+
     console.error(`WebSocket error observed on '${this.address}' : `, event);
   }
 

--- a/fe1-web/src/core/network/NetworkConnection.ts
+++ b/fe1-web/src/core/network/NetworkConnection.ts
@@ -224,26 +224,30 @@ export class NetworkConnection {
   private onClose(): void {
     console.info(`Closed websocket connection : ${this.address}`);
 
-    // it was not our intention to close the connection. try to re-connect
-    if (!this.closeIntent) {
-      this.failedConnectionAttempts += 1;
-      console.error(`Trying to re-establish a connection at address : ${this.address}`);
-
-      // only retry a certain number of times and add a wait before retrying
-      if (this.failedConnectionAttempts <= WEBSOCKET_CONNECTION_MAX_ATTEMPTS) {
-        setTimeout(() => {
-          this.reconnectIfNecessary();
-        }, WEBSOCKET_CONNECTION_FAILURE_TIMEOUT_MS);
-
-        // check if callback is set
-      } else if (this.onConnectionDeadCallback) {
-        // do not try to re-establish the connection, this connection seems
-        // to be broken for now and the near future
-        console.error(`Connection with ${this.address} broke for good`);
-        this.alive = false;
-        this.onConnectionDeadCallback();
-      }
+    if (this.closeIntent) {
+      return;
     }
+    
+    // it was not our intention to close the connection. try to re-connect
+    this.failedConnectionAttempts += 1;
+    console.error(`Trying to re-establish a connection at address : ${this.address}`);
+
+    // only retry a certain number of times and add a wait before retrying
+    if (this.failedConnectionAttempts <= WEBSOCKET_CONNECTION_MAX_ATTEMPTS) {
+      setTimeout(() => {
+        this.reconnectIfNecessary();
+      }, WEBSOCKET_CONNECTION_FAILURE_TIMEOUT_MS);
+      return;
+    }
+    
+    if (this.onConnectionDeadCallback) {
+      // do not try to re-establish the connection, this connection seems
+      // to be broken for now and the near future
+      console.error(`Connection with ${this.address} broke for good`);
+      this.alive = false;
+      this.onConnectionDeadCallback();
+    }
+    
   }
 
   /**

--- a/fe1-web/src/core/network/NetworkConnection.ts
+++ b/fe1-web/src/core/network/NetworkConnection.ts
@@ -227,7 +227,7 @@ export class NetworkConnection {
     if (this.closeIntent) {
       return;
     }
-    
+
     // it was not our intention to close the connection. try to re-connect
     this.failedConnectionAttempts += 1;
     console.error(`Trying to re-establish a connection at address : ${this.address}`);
@@ -239,15 +239,15 @@ export class NetworkConnection {
       }, WEBSOCKET_CONNECTION_FAILURE_TIMEOUT_MS);
       return;
     }
-    
+
+    console.error(`Connection with ${this.address} broke for good`);
+    this.alive = false;
+
     if (this.onConnectionDeadCallback) {
       // do not try to re-establish the connection, this connection seems
       // to be broken for now and the near future
-      console.error(`Connection with ${this.address} broke for good`);
-      this.alive = false;
       this.onConnectionDeadCallback();
     }
-    
   }
 
   /**

--- a/fe1-web/src/core/network/NetworkConnection.ts
+++ b/fe1-web/src/core/network/NetworkConnection.ts
@@ -69,7 +69,7 @@ export class NetworkConnection {
   /**
    * Function called when the connection closes for good
    */
-  private onConnectionDeadCallback?: () => void;
+  private readonly onConnectionDeadCallback?: () => void;
 
   /**
    * Boolean indicating whether this connection is open or there is still hope

--- a/fe1-web/src/core/network/NetworkManager.ts
+++ b/fe1-web/src/core/network/NetworkManager.ts
@@ -88,13 +88,13 @@ class NetworkManager {
     this.connectionDeathHandlers = [];
   }
 
-  private reconnectIfNecessary() {
+  private async reconnectIfNecessary() {
     // the sending strategy will fail if we have no connection
     if (this.connections.length > 0) {
       console.info('Reconnecting to all disconnected websockets..');
-      for (const connection of this.connections) {
-        connection.reconnectIfNecessary();
-      }
+      await Promise.all(this.connections.map((connection) => connection.reconnectIfNecessary()));
+      console.info('Done. Execute re-connection handlers..');
+
       for (const handler of this.reconnectionHandlers) {
         handler();
       }

--- a/fe1-web/src/core/network/NetworkManager.ts
+++ b/fe1-web/src/core/network/NetworkManager.ts
@@ -42,26 +42,28 @@ class NetworkManager {
     AppState.addEventListener('change', this.onAppStateChange.bind(this));
   }
 
-  private onNetworkChange(state: NetInfoState): void {
+  private onNetworkChange(state: NetInfoState): Promise<void> {
     const isOnline = state.isConnected || false;
     if (!this.isOnline && isOnline) {
       // if we were disconnected before and are now reconnected to the network
       // then try to reconnect all connections
-      this.reconnectIfNecessary();
+      return this.reconnectIfNecessary();
     }
 
     this.isOnline = isOnline;
+    return Promise.resolve();
   }
 
-  private onAppStateChange(status: AppStateStatus) {
+  private onAppStateChange(status: AppStateStatus): Promise<void> {
     const isFocused = status === 'active';
     if (!this.isFocused && isFocused) {
       // if we were backgrounded and become active again, the websocket
       // connections are very likely to be broken
-      this.reconnectIfNecessary();
+      return this.reconnectIfNecessary();
     }
 
     this.isFocused = isFocused;
+    return Promise.resolve();
   }
 
   public addReconnectionHandler(handler: ReconnectionHandler) {

--- a/fe1-web/src/core/network/NetworkManager.ts
+++ b/fe1-web/src/core/network/NetworkManager.ts
@@ -105,7 +105,7 @@ class NetworkManager {
     return this.connections.find((nc: NetworkConnection) => nc.address === address);
   }
 
-  private onConnectionDead(address: string) {
+  private onConnectionDeath(address: string) {
     this.disconnectFrom(address);
     this.connectionDeathHandlers.forEach((handler) => handler(address));
   }
@@ -130,7 +130,7 @@ class NetworkManager {
     const connection: NetworkConnection = await NetworkConnection.create(
       href,
       this.rpcHandler,
-      () => this.onConnectionDead(href),
+      () => this.onConnectionDeath(href),
     );
     this.connections.push(connection);
     return connection;

--- a/fe1-web/src/core/network/__tests__/JsonRpcApi.test.ts
+++ b/fe1-web/src/core/network/__tests__/JsonRpcApi.test.ts
@@ -69,6 +69,7 @@ beforeAll(() => {
   // this cannot be initialized before as it requires the mock registries to be set up
   mockResponseMessage = Message.fromData(mockMessageData, mockKeyPair, mockChannel, []);
   mockResponse = {
+    jsonrpc: '2.0',
     id: 0,
     result: [mockResponseMessage],
   };

--- a/fe1-web/src/core/network/__tests__/NetworkConnection.test.ts
+++ b/fe1-web/src/core/network/__tests__/NetworkConnection.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect } from '@jest/globals';
+
+import { mockAddress, mockChannel } from '__tests__/utils';
+import {
+  addNetworkMessageHandler,
+  allowNewConnections,
+  clearNetworkMessageHandlers,
+  disallowNewConnections,
+  MockWebsocket,
+} from '__tests__/utils/websocket';
+
+import {
+  ExtendedJsonRpcRequest,
+  ExtendedJsonRpcResponse,
+  JsonRpcMethod,
+  JsonRpcRequest,
+  JsonRpcResponse,
+  Subscribe,
+} from '../jsonrpc';
+import { AUTO_ASSIGN_ID } from '../JsonRpcApi';
+import { NetworkConnection } from '../NetworkConnection';
+
+// mock network connections
+jest.mock('websocket');
+
+// websocket ready states
+const CONNECTING = 0;
+const OPEN = 1;
+
+const mockRequest = new JsonRpcRequest({
+  method: JsonRpcMethod.SUBSCRIBE,
+  params: new Subscribe({
+    channel: mockChannel,
+  }),
+  id: AUTO_ASSIGN_ID,
+});
+
+beforeEach(() => {
+  // for some reason having 'allowNewConnections();' in here 'breaks' the tests..?
+  clearNetworkMessageHandlers();
+});
+
+// define a function that allows us retrieving the websocket from a
+// connection object
+
+const getWebsocket = (connection: NetworkConnection): MockWebsocket =>
+  // @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/dot-notation
+  connection['ws'];
+
+describe('NetworkConnection', () => {
+  describe('constructor', () => {
+    beforeAll(() => {
+      allowNewConnections();
+    });
+
+    it('is possible to construct new instances', async () => {
+      const connection = await new Promise<NetworkConnection>((resolve) => {
+        const c: NetworkConnection = new NetworkConnection(mockAddress, undefined, () =>
+          resolve(c),
+        );
+
+        expect(getWebsocket(c).readyState).toEqual(CONNECTING);
+        expect(c).toBeInstanceOf(NetworkConnection);
+        expect(c.address).toEqual(mockAddress);
+      });
+
+      const ws = getWebsocket(connection);
+
+      expect(ws.readyState).toEqual(OPEN);
+    });
+  });
+
+  describe('create', () => {
+    it('resolves to a connection if it is possible to connect', async () => {
+      allowNewConnections();
+      const connection = await NetworkConnection.create(mockAddress, jest.fn(), jest.fn());
+
+      expect(connection).toBeInstanceOf(NetworkConnection);
+      expect(connection.address).toEqual(mockAddress);
+      expect(getWebsocket(connection).readyState).toEqual(OPEN);
+    });
+
+    /**
+     * This test might log some errors depending on the timeout for the initial connection
+     * and the time configured for the mocked websockets
+     */
+    it('rejects of it is not possible to create the connection within the timeout', async () => {
+      disallowNewConnections();
+
+      await expect(
+        NetworkConnection.create(mockAddress, jest.fn(), jest.fn()),
+      ).rejects.toBeInstanceOf(Error);
+    });
+  });
+
+  describe('reconnectIfNecessary', () => {
+    beforeAll(() => {
+      allowNewConnections();
+    });
+
+    it('does nothing if the socket is still open', async () => {
+      const connection = await NetworkConnection.create(mockAddress, jest.fn(), jest.fn());
+
+      const ws = getWebsocket(connection);
+      await expect(connection.reconnectIfNecessary()).resolves.not.toThrow();
+
+      // should still be the same websocket object
+      expect(getWebsocket(connection)).toBe(ws);
+    });
+    it('re-connects if the socket has been closed', async () => {
+      // This simulates the situation where the readyState of the websocket has been updated
+      // because it is no longer open but onClose was not called. Yes, this should in theory never
+      // happen.
+      const connection = await NetworkConnection.create(mockAddress, jest.fn(), jest.fn());
+
+      const ws = getWebsocket(connection);
+      ws.readyState = 3;
+      await expect(connection.reconnectIfNecessary()).resolves.not.toThrow();
+
+      const ws2 = getWebsocket(connection);
+
+      // the websocket connection should have been replaced
+      expect(ws2).not.toBe(ws);
+      expect(ws2.readyState).toEqual(OPEN);
+    });
+  });
+
+  describe('setRpcHandler', () => {
+    beforeAll(() => {
+      allowNewConnections();
+    });
+
+    it('allows setting a new rpc handler', async () => {
+      const connection = await NetworkConnection.create(mockAddress, jest.fn(), jest.fn());
+
+      const newHandler = jest.fn();
+      connection.setRpcHandler(newHandler);
+
+      const ws = getWebsocket(connection);
+
+      ws.mockReceive(JSON.stringify(mockRequest));
+
+      expect(newHandler).toHaveBeenCalledWith(
+        new ExtendedJsonRpcRequest({ receivedFrom: mockAddress }, mockRequest),
+      );
+    });
+  });
+
+  describe('sendPayload', () => {
+    beforeAll(() => {
+      allowNewConnections();
+    });
+
+    it('allows sending a payload', async () => {
+      const connection = await NetworkConnection.create(mockAddress, jest.fn(), jest.fn());
+
+      addNetworkMessageHandler((ws, msg) => {
+        const message = JSON.parse(msg);
+        const id = message.id as number;
+
+        const mockResponse = new JsonRpcResponse({
+          id,
+          result: 0,
+        });
+
+        ws.mockReceive(JSON.stringify(mockResponse));
+      });
+
+      const promise = connection.sendPayload(mockRequest);
+
+      await expect(promise).resolves.toBeInstanceOf(ExtendedJsonRpcResponse);
+      await expect(promise).resolves.toHaveProperty('response.result', 0);
+    });
+
+    it('waits until the websocket connection is ready / open', async () => {
+      const connection = await NetworkConnection.create(mockAddress, jest.fn(), jest.fn());
+
+      const networkMessageHandler = jest.fn<void, [MockWebsocket, string]>((ws, msg) => {
+        const message = JSON.parse(msg);
+        const id = message.id as number;
+
+        const mockResponse = new JsonRpcResponse({
+          id,
+          result: 0,
+        });
+
+        ws.mockReceive(JSON.stringify(mockResponse));
+      });
+
+      addNetworkMessageHandler(networkMessageHandler);
+
+      // make connection think the socket is still connecting
+      getWebsocket(connection).readyState = 0;
+
+      const promise = connection.sendPayload(mockRequest);
+
+      // check if message has already been sent
+      expect(networkMessageHandler).toHaveBeenCalledTimes(0);
+
+      // wait 100 ms
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // now mock connection establishment
+      getWebsocket(connection).readyState = 1;
+
+      // now the promise should resolve
+      await expect(promise).resolves.toBeInstanceOf(ExtendedJsonRpcResponse);
+      await expect(promise).resolves.toHaveProperty('response.result', 0);
+    });
+
+    // not (yet) tested because the timeout is larger than the timeout for the tests..
+    // it('rejects after a timeout', () => {});
+  });
+});

--- a/fe1-web/src/core/network/__tests__/NetworkManager.test.ts
+++ b/fe1-web/src/core/network/__tests__/NetworkManager.test.ts
@@ -117,7 +117,7 @@ describe('NetworkManager', () => {
     expect(sendingStrategy).toHaveBeenCalledWith(mockJsonRpcPayload, [connection]);
   });
 
-  it('is possible to add a reconnection handlers', () => {
+  it('is possible to add a reconnection handler', () => {
     const handler = jest.fn();
     const handler2 = jest.fn();
 
@@ -137,7 +137,7 @@ describe('NetworkManager', () => {
     expect(networkManager['reconnectionHandlers']).toEqual([]);
   });
 
-  it('is possible to remove all reconnection handler', () => {
+  it('is possible to remove all reconnection handlers', () => {
     const handler = jest.fn();
     const handler2 = jest.fn();
 
@@ -162,6 +162,56 @@ describe('NetworkManager', () => {
 
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler2).toHaveBeenCalledTimes(1);
+  });
+
+  it('is possible to add a connection death handler', () => {
+    const handler = jest.fn();
+    const handler2 = jest.fn();
+
+    networkManager.addConnectionDeathHandler(handler);
+    expect(networkManager['connectionDeathHandlers']).toEqual([handler]);
+
+    networkManager.addConnectionDeathHandler(handler2);
+    expect(networkManager['connectionDeathHandlers']).toEqual([handler, handler2]);
+  });
+
+  it('is possible to remove a connection death handler', () => {
+    const handler = jest.fn();
+
+    networkManager.addConnectionDeathHandler(handler);
+    networkManager.removeConnectionDeathHandler(handler);
+
+    expect(networkManager['connectionDeathHandlers']).toEqual([]);
+  });
+
+  it('is possible to remove all connection death handlers', () => {
+    const handler = jest.fn();
+    const handler2 = jest.fn();
+
+    networkManager.addConnectionDeathHandler(handler);
+    networkManager.addConnectionDeathHandler(handler2);
+    networkManager.removeAllConnectionDeathHandlers();
+
+    expect(networkManager['connectionDeathHandlers']).toEqual([]);
+  });
+
+  it('correctly calls the connection death handlers', async () => {
+    // have to add some connection, otherwise no reconnection happens
+    await networkManager.connect(mockAddress);
+
+    const handler = jest.fn();
+    const handler2 = jest.fn();
+
+    networkManager.addConnectionDeathHandler(handler);
+    networkManager.addConnectionDeathHandler(handler2);
+
+    networkManager['onConnectionDeath'](mockAddress);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(mockAddress);
+
+    expect(handler2).toHaveBeenCalledTimes(1);
+    expect(handler2).toHaveBeenCalledWith(mockAddress);
   });
 
   it('triggers reconnect() after being reconnected to the network', async () => {

--- a/fe1-web/src/core/network/__tests__/NetworkManager.test.ts
+++ b/fe1-web/src/core/network/__tests__/NetworkManager.test.ts
@@ -22,6 +22,7 @@ const { getMockNetworkManager } = NetworkManagerMock;
 afterEach(() => {
   networkManager.disconnectFromAll();
   networkManager.removeAllReconnectionHandler();
+  networkManager.removeAllConnectionDeathHandlers();
 });
 
 describe('NetworkManager', () => {
@@ -158,7 +159,7 @@ describe('NetworkManager', () => {
     networkManager.addReconnectionHandler(handler);
     networkManager.addReconnectionHandler(handler2);
 
-    networkManager['reconnectIfNecessary']();
+    await networkManager['reconnectIfNecessary']();
 
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler2).toHaveBeenCalledTimes(1);
@@ -226,7 +227,7 @@ describe('NetworkManager', () => {
     networkManager.addReconnectionHandler(handler);
 
     // mock reconnection
-    networkManager['onNetworkChange']({ isConnected: true } as NetInfoState);
+    await networkManager['onNetworkChange']({ isConnected: true } as NetInfoState);
 
     // make sure the handler has been called
     expect(handler).toHaveBeenCalledTimes(1);
@@ -244,7 +245,7 @@ describe('NetworkManager', () => {
     networkManager.addReconnectionHandler(handler);
 
     // mock becoming active again
-    networkManager['onAppStateChange']('active');
+    await networkManager['onAppStateChange']('active');
 
     // make sure the handler has been called
     expect(handler).toHaveBeenCalledTimes(1);

--- a/fe1-web/src/core/network/__tests__/NetworkManager.test.ts
+++ b/fe1-web/src/core/network/__tests__/NetworkManager.test.ts
@@ -35,8 +35,8 @@ describe('NetworkManager', () => {
     expect(instance2).toBe(instance3);
   });
 
-  it('can connect to address', () => {
-    const connection = networkManager.connect(mockAddress);
+  it('can connect to address', async () => {
+    const connection = await networkManager.connect(mockAddress);
 
     // check whether the address of the connection has been set
     expect(connection.address).toEqual(mockAddress);
@@ -44,31 +44,31 @@ describe('NetworkManager', () => {
     expect(networkManager['connections']).toEqual([connection]);
   });
 
-  it('does not create two connections to the same address', () => {
-    const connection1 = networkManager.connect(mockAddress);
-    const connection2 = networkManager.connect(mockAddress);
+  it('does not create two connections to the same address', async () => {
+    const connection1 = await networkManager.connect(mockAddress);
+    const connection2 = await networkManager.connect(mockAddress);
 
     expect(connection1).toBe(connection2);
     expect(networkManager['connections']).toEqual([connection1]);
   });
 
-  it('can connect to multiple addresses', () => {
-    const connection1 = networkManager.connect(mockAddress);
-    const connection2 = networkManager.connect('wss://some-other-address.com:8000/');
+  it('can connect to multiple addresses', async () => {
+    const connection1 = await networkManager.connect(mockAddress);
+    const connection2 = await networkManager.connect('wss://some-other-address.com:8000/');
 
     // check whether the connections have been added
     expect(networkManager['connections']).toEqual([connection1, connection2]);
   });
 
-  it('can disconnect a given connection', () => {
-    const connection = networkManager.connect(mockAddress);
+  it('can disconnect a given connection', async () => {
+    const connection = await networkManager.connect(mockAddress);
     networkManager.disconnect(connection);
 
     expect(networkManager['connections']).toEqual([]);
   });
 
-  it('can disconnect from a given address', () => {
-    const connection = networkManager.connect(mockAddress);
+  it('can disconnect from a given address', async () => {
+    const connection = await networkManager.connect(mockAddress);
 
     expect(networkManager['connections']).toEqual([connection]);
 
@@ -77,10 +77,10 @@ describe('NetworkManager', () => {
     expect(networkManager['connections']).toEqual([]);
   });
 
-  it('can disconnect from all connections', () => {
-    const connection1 = networkManager.connect(mockAddress);
-    const connection2 = networkManager.connect('wss://some-other-address.com:8000/');
-    const connection3 = networkManager.connect('wss://another-address.com:8000/');
+  it('can disconnect from all connections', async () => {
+    const connection1 = await networkManager.connect(mockAddress);
+    const connection2 = await networkManager.connect('wss://some-other-address.com:8000/');
+    const connection3 = await networkManager.connect('wss://another-address.com:8000/');
 
     expect(networkManager['connections']).toEqual([connection1, connection2, connection3]);
 
@@ -89,10 +89,10 @@ describe('NetworkManager', () => {
     expect(networkManager['connections']).toEqual([]);
   });
 
-  it('sets the RPC handler correctly', () => {
-    const connection1 = networkManager.connect(mockAddress);
-    const connection2 = networkManager.connect('wss://some-other-address.com:8000/');
-    const connection3 = networkManager.connect('wss://another-address.com:8000/');
+  it('sets the RPC handler correctly', async () => {
+    const connection1 = await networkManager.connect(mockAddress);
+    const connection2 = await networkManager.connect('wss://some-other-address.com:8000/');
+    const connection3 = await networkManager.connect('wss://another-address.com:8000/');
 
     const rpcHandler = jest.fn();
 
@@ -107,11 +107,11 @@ describe('NetworkManager', () => {
     expect(connection3['onRpcHandler']).toBe(rpcHandler);
   });
 
-  it('can sends data using the sending strategy', () => {
+  it('can sends data using the sending strategy', async () => {
     const sendingStrategy = jest.fn();
     const mockNetworkManager: NetworkManagerType = getMockNetworkManager(sendingStrategy);
 
-    const connection = mockNetworkManager.connect(mockAddress);
+    const connection = await mockNetworkManager.connect(mockAddress);
     mockNetworkManager.sendPayload(mockJsonRpcPayload);
 
     expect(sendingStrategy).toHaveBeenCalledWith(mockJsonRpcPayload, [connection]);
@@ -148,9 +148,9 @@ describe('NetworkManager', () => {
     expect(networkManager['reconnectionHandlers']).toEqual([]);
   });
 
-  it('correctly calls the reconnection handlers', () => {
+  it('correctly calls the reconnection handlers', async () => {
     // have to add some connection, otherwise no reconnection happens
-    networkManager.connect(mockAddress);
+    await networkManager.connect(mockAddress);
 
     const handler = jest.fn();
     const handler2 = jest.fn();
@@ -164,9 +164,9 @@ describe('NetworkManager', () => {
     expect(handler2).toHaveBeenCalledTimes(1);
   });
 
-  it('triggers reconnect() after being reconnected to the network', () => {
+  it('triggers reconnect() after being reconnected to the network', async () => {
     // have to add some connection, otherwise no reconnection happens
-    networkManager.connect(mockAddress);
+    await networkManager.connect(mockAddress);
 
     // mock disconnection
     networkManager['onNetworkChange']({ isConnected: false } as NetInfoState);
@@ -182,9 +182,9 @@ describe('NetworkManager', () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
-  it('triggers reconnect() after becoming active again', () => {
+  it('triggers reconnect() after becoming active again', async () => {
     // have to add some connection, otherwise no reconnection happens
-    networkManager.connect(mockAddress);
+    await networkManager.connect(mockAddress);
 
     // mock backgrounding
     networkManager['onAppStateChange']('background');

--- a/fe1-web/src/core/network/jsonrpc/JsonRpcResponse.ts
+++ b/fe1-web/src/core/network/jsonrpc/JsonRpcResponse.ts
@@ -12,6 +12,8 @@ interface ErrorObject {
 }
 
 export class JsonRpcResponse {
+  public readonly jsonrpc: string;
+
   public readonly result?: number | Message[];
 
   public readonly error?: ErrorObject;
@@ -42,6 +44,8 @@ export class JsonRpcResponse {
     } else {
       throw new ProtocolError("Unexpected json-rpc answer : both 'error' and 'result' are absent");
     }
+
+    this.jsonrpc = '2.0';
   }
 
   public static fromJson(jsonString: string): JsonRpcResponse {

--- a/fe1-web/src/features/home/screens/ConnectConfirm.tsx
+++ b/fe1-web/src/features/home/screens/ConnectConfirm.tsx
@@ -46,7 +46,7 @@ const ConnectConfirm = () => {
 
   const onButtonConfirm = async () => {
     try {
-      const connection = getNetworkManager().connect(serverUrl);
+      const connection = await getNetworkManager().connect(serverUrl);
 
       const laoChannel = getLaoChannel(laoId);
       if (!laoChannel) {
@@ -67,7 +67,7 @@ const ConnectConfirm = () => {
         screen: STRINGS.navigation_lao_home,
       });
     } catch (err) {
-      console.error(`Failed to establish lao connection: ${err}`);
+      console.error(`Failed to establish lao connection`, err);
       toast.show(`Failed to establish lao connection: ${err}`, {
         type: 'danger',
         placement: 'top',

--- a/fe1-web/src/features/home/screens/ConnectOpenScan.tsx
+++ b/fe1-web/src/features/home/screens/ConnectOpenScan.tsx
@@ -70,7 +70,7 @@ const ConnectOpenScan = () => {
     });
   }, [navigation]);
 
-  const handleScan = (data: string | null) => {
+  const handleScan = async (data: string | null) => {
     if (!data) {
       return;
     }
@@ -101,7 +101,9 @@ const ConnectOpenScan = () => {
       );
 
       // connect to the lao
-      const connections = connectToLao.servers.map((server) => getNetworkManager().connect(server));
+      const connections = await Promise.all(
+        connectToLao.servers.map((server) => getNetworkManager().connect(server)),
+      );
       if (connections.length === 0) {
         return;
       }

--- a/fe1-web/src/features/home/screens/ConnectOpenScan.tsx
+++ b/fe1-web/src/features/home/screens/ConnectOpenScan.tsx
@@ -1,7 +1,7 @@
 import { CompositeScreenProps, useNavigation } from '@react-navigation/core';
 import { StackScreenProps } from '@react-navigation/stack';
-import React, { useEffect, useState } from 'react';
-import { StyleSheet, View, ViewStyle } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import { StyleSheet, Text, View, ViewStyle } from 'react-native';
 import { useToast } from 'react-native-toast-notifications';
 import { useDispatch } from 'react-redux';
 
@@ -11,7 +11,8 @@ import QrCodeScanner, { QrCodeScannerUIElementContainer } from 'core/components/
 import { AppParamList } from 'core/navigation/typing/AppParamList';
 import { ConnectParamList } from 'core/navigation/typing/ConnectParamList';
 import { getNetworkManager, subscribeToChannel } from 'core/network';
-import { Color, Icon, Spacing } from 'core/styles';
+import { Channel } from 'core/objects';
+import { Color, Icon, Spacing, Typography } from 'core/styles';
 import { FOUR_SECONDS } from 'resources/const';
 import STRINGS from 'resources/strings';
 
@@ -52,6 +53,8 @@ const ConnectOpenScan = () => {
 
   // this is needed as otherwise the camera may stay turned on
   const [showScanner, setShowScanner] = useState(false);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const isProcessingScan = useRef(false);
 
   // re-enable scanner on focus events
   useEffect(() => {
@@ -70,15 +73,21 @@ const ConnectOpenScan = () => {
     });
   }, [navigation]);
 
-  const handleScan = async (data: string | null) => {
-    if (!data) {
-      return;
-    }
+  /**
+   * Checks if the passed connection data is valid
+   * @param data A stringified ConnectToLao object
+   */
+  const validateConnectionData = (
+    data: string,
+  ): { connectToLao: ConnectToLao; laoChannel: Channel } | false => {
+    const obj = JSON.parse(data);
 
     try {
-      const obj = JSON.parse(data);
-
       const connectToLao = ConnectToLao.fromJson(obj);
+
+      if (connectToLao.servers.length === 0) {
+        throw new Error('The scanned QR code did not contain any server address');
+      }
 
       // if we are already connected to a LAO, then only allow new connections
       // to servers for the same LAO id
@@ -91,24 +100,12 @@ const ConnectOpenScan = () => {
             duration: FOUR_SECONDS,
           },
         );
-        return;
-      }
 
-      setShowScanner(false);
-
-      console.info(
-        `Trying to connect to lao with id '${connectToLao.lao}' on '${connectToLao.servers}'.`,
-      );
-
-      // connect to the lao
-      const connections = await Promise.all(
-        connectToLao.servers.map((server) => getNetworkManager().connect(server)),
-      );
-      if (connections.length === 0) {
-        return;
+        return false;
       }
 
       const laoChannel = getLaoChannel(connectToLao.lao);
+
       if (!laoChannel) {
         // invalid lao id
         toast.show(STRINGS.connect_scanning_fail, {
@@ -116,27 +113,88 @@ const ConnectOpenScan = () => {
           placement: 'top',
           duration: FOUR_SECONDS,
         });
-        return;
+
+        return false;
       }
 
-      const lao = getLaoById(connectToLao.lao);
+      return { connectToLao, laoChannel };
+    } catch (e) {
+      console.error(e);
 
-      let promise: Promise<void>;
+      toast.show(`The scanned QR code is invalid`, {
+        type: 'warning',
+        placement: 'top',
+        duration: FOUR_SECONDS,
+      });
 
-      if (lao) {
-        // subscribe to all previously subscribed to channels on the new connectionss
-        promise = resubscribeToLao(lao, dispatch, connections);
-      } else {
-        // subscribe to the lao channel on the new connections
-        promise = subscribeToChannel(connectToLao.lao, dispatch, laoChannel, connections);
-      }
+      return false;
+    }
+  };
 
-      promise.then(() => {
-        navigation.navigate(STRINGS.navigation_app_lao, {
-          screen: STRINGS.navigation_lao_home,
-        });
+  const connectToLaoAndSubscribe = async (connectToLao: ConnectToLao, laoChannel: Channel) => {
+    // connect to the lao
+    const connections = await Promise.all(
+      connectToLao.servers.map((server) => getNetworkManager().connect(server)),
+    );
+    if (connections.length !== connectToLao.servers.length) {
+      throw new Error(
+        `networkManager.connect() should either return a connection or throw an error.
+        ${connectToLao.servers.length} addresses were passed and ${connections.length} were received`,
+      );
+    }
+
+    const lao = getLaoById(connectToLao.lao);
+
+    if (lao) {
+      // subscribe to all previously subscribed to channels on the new connectionss
+      return resubscribeToLao(lao, dispatch, connections);
+    }
+
+    // subscribe to the lao channel on the new connections
+    return subscribeToChannel(connectToLao.lao, dispatch, laoChannel, connections);
+  };
+
+  const handleScan = async (data: string | null) => {
+    if (!data || isProcessingScan.current) {
+      return;
+    }
+
+    const validatedConnectionData = validateConnectionData(data);
+    if (!validatedConnectionData) {
+      return;
+    }
+
+    const { connectToLao, laoChannel } = validatedConnectionData;
+
+    try {
+      // prevent the function from being executed twice
+      // it is okay to only call this here (after the above checks) since
+      // javascript is single threaded and will not stop executing this function
+      // in the middle
+      isProcessingScan.current = true;
+      // update (and possibly disable) the UI while the scanned data is being processed
+      setIsConnecting(true);
+
+      console.info(
+        `Trying to connect to lao with id '${connectToLao.lao}' on '${connectToLao.servers}'.`,
+      );
+
+      await connectToLaoAndSubscribe(connectToLao, laoChannel);
+
+      isProcessingScan.current = false;
+      setIsConnecting(false);
+
+      navigation.navigate(STRINGS.navigation_app_lao, {
+        screen: STRINGS.navigation_lao_home,
       });
     } catch (error) {
+      // close already established connections
+      getNetworkManager().disconnectFromAll();
+
+      // allow scanning of new codes
+      isProcessingScan.current = false;
+      setIsConnecting(false);
+
       toast.show(STRINGS.connect_scanning_fail, {
         type: 'danger',
         placement: 'top',
@@ -144,6 +202,14 @@ const ConnectOpenScan = () => {
       });
     }
   };
+
+  if (isConnecting) {
+    return (
+      <QrCodeScanner showCamera={showScanner} handleScan={handleScan}>
+        <Text style={Typography.base}>{STRINGS.navigation_connect_processing}</Text>
+      </QrCodeScanner>
+    );
+  }
 
   return (
     <QrCodeScanner showCamera={showScanner} handleScan={handleScan}>

--- a/fe1-web/src/features/home/screens/Launch.tsx
+++ b/fe1-web/src/features/home/screens/Launch.tsx
@@ -45,25 +45,29 @@ const Launch = () => {
   const connectToTestLao = HomeHooks.useConnectToTestLao();
   const requestCreateLao = HomeHooks.useRequestCreateLao();
 
-  const onButtonLaunchPress = (laoName: string) => {
+  const onButtonLaunchPress = async (laoName: string) => {
     if (!laoName) {
       return;
     }
 
-    getNetworkManager().connect(inputAddress);
+    try {
+      // establish connection
+      await getNetworkManager().connect(inputAddress);
 
-    requestCreateLao(laoName)
-      .then((channel: Channel) => {
-        const laoId = getLaoIdFromChannel(channel);
+      // create lao
+      const channel: Channel = await requestCreateLao(laoName);
+      const laoId = getLaoIdFromChannel(channel);
 
-        subscribeToChannel(laoId, dispatch, channel).then(() => {
-          // navigate to the newly created LAO
-          navigation.navigate(STRINGS.navigation_app_lao, {
-            screen: STRINGS.navigation_lao_home,
-          });
-        });
-      })
-      .catch((reason) => console.debug(`Failed to establish lao connection: ${reason}`));
+      // subscribe to the just created lao channel
+      await subscribeToChannel(laoId, dispatch, channel);
+
+      // navigate to the newly created LAO
+      navigation.navigate(STRINGS.navigation_app_lao, {
+        screen: STRINGS.navigation_lao_home,
+      });
+    } catch (e) {
+      console.error(`Failed to establish lao connection`, e);
+    }
   };
 
   const onTestClearStorage = () => dispatch({ type: 'CLEAR_STORAGE', value: {} });

--- a/fe1-web/src/features/lao/components/LaoItem.tsx
+++ b/fe1-web/src/features/lao/components/LaoItem.tsx
@@ -48,7 +48,7 @@ const LaoItem = ({ lao, isFirstItem, isLastItem }: IPropTypes) => {
   const reconnectToLao = async () => {
     try {
       // connect to toe lao
-      const connections = connectToLao(lao);
+      const connections = await connectToLao(lao);
       // and subscribe to all previously subscribed to channels on the new connections
       await resubscribeToLao(lao, dispatch, connections);
 

--- a/fe1-web/src/features/lao/functions/TestConnection.ts
+++ b/fe1-web/src/features/lao/functions/TestConnection.ts
@@ -8,8 +8,8 @@ import { dispatch } from 'core/redux';
 import { Lao } from '../objects';
 import { setCurrentLao } from '../reducer';
 
-export const openLaoTestConnection = () => {
-  const nc = getNetworkManager().connect('ws://127.0.0.1:9000/organizer/client');
+export const openLaoTestConnection = async () => {
+  const nc = await getNetworkManager().connect('ws://127.0.0.1:9000/organizer/client');
   nc.setRpcHandler(() => {
     console.info('Using custom test rpc handler: does nothing');
   });

--- a/fe1-web/src/features/lao/functions/network.ts
+++ b/fe1-web/src/features/lao/functions/network.ts
@@ -10,8 +10,8 @@ import { Lao, LaoState } from '../objects/Lao';
  * @param lao The lao to connect to
  * @returns The list of new network connections
  */
-export const connectToLao = (lao: Lao): NetworkConnection[] =>
-  lao.server_addresses.map((address) => getNetworkManager().connect(address));
+export const connectToLao = (lao: Lao): Promise<NetworkConnection[]> =>
+  Promise.all(lao.server_addresses.map((address) => getNetworkManager().connect(address)));
 
 /**
  * Resubscribes to a known lao

--- a/fe1-web/src/features/lao/network/LaoGreetWatcher.ts
+++ b/fe1-web/src/features/lao/network/LaoGreetWatcher.ts
@@ -65,6 +65,10 @@ export const storeBackendAndConnectToPeers = async (
     // this only applies to peers which are not implemented at the moment
     // anyway. In the future we might need to show the user an indication
     // of the fact that it was not possible to connect to (all) peers
+    console.warn(
+      `Tried connecting to peers ${greetLaoMsg.peers.join(', ')} but some connection failed.
+      This case is currently ignored and should be handled properly.`,
+    );
   }
 };
 

--- a/fe1-web/src/features/lao/network/__tests__/LaoGreetWatcher.test.ts
+++ b/fe1-web/src/features/lao/network/__tests__/LaoGreetWatcher.test.ts
@@ -66,7 +66,7 @@ jest.mock('core/redux', () => {
 });
 
 describe('handleLaoGreet', () => {
-  it('should add the server and mark the greeting message as handled', () => {
+  it('should add the server and mark the greeting message as handled', async () => {
     const greetLaoMsg = new GreetLao({
       object: ObjectType.LAO,
       action: ActionType.GREET,
@@ -83,7 +83,7 @@ describe('handleLaoGreet', () => {
       t,
     );
 
-    storeBackendAndConnectToPeers(msg.message_id, greetLaoMsg, msg.sender);
+    await storeBackendAndConnectToPeers(msg.message_id, greetLaoMsg, msg.sender);
     expect(dispatch).toHaveBeenCalledTimes(2);
     // the key of the server should have been stored
     expect(dispatch).toHaveBeenCalledWith(

--- a/fe1-web/src/resources/strings.ts
+++ b/fe1-web/src/resources/strings.ts
@@ -109,6 +109,7 @@ namespace STRINGS {
   export const lao_properties_add_additional_connection = 'Add connection';
   export const lao_properties_disconnect = 'Disconnect';
   export const lao_no_current = 'You are currently not connected to any LAO';
+  export const lao_error_disconnect = 'The connection to the LAO broke unexpectedly';
 
   /* --- Home Strings --- */
 

--- a/fe1-web/src/resources/strings.ts
+++ b/fe1-web/src/resources/strings.ts
@@ -44,6 +44,7 @@ namespace STRINGS {
 
   /* --- ConnectionNavigation Strings --- */
   export const navigation_connect_scan = 'Scanning';
+  export const navigation_connect_processing = 'Processing scanned QR code';
   export const navigation_connect_launch = 'Launch';
   export const navigation_connect_launch_title = 'Launch a new LAO';
   export const navigation_connect_confirm = 'Confirm';

--- a/fe1-web/types/index.d.ts
+++ b/fe1-web/types/index.d.ts
@@ -1,0 +1,12 @@
+/* eslint-disable no-var */
+/* eslint-disable vars-on-top */
+
+type ToastType = import('react-native-toast-notifications').ToastType;
+
+declare global {
+  var toast: ToastType | undefined | null;
+}
+
+declare let toast: ToastType;
+
+export {};


### PR DESCRIPTION
This PR should fix issues #1217 and #1224.

It does so by making the whole network stack more stable and improves the handling of requests that cannot be sent. (Re-try sending them even if the connection has been re-established)

What is left to do is writing tests (for NetworkConnection.ts, no tests exist so far 🙃) As this will probably take some time, it might be worth discussing to what extend I should try to model the network :)

As a side effect of this PR, both the navigation and the toasts can now be accessed globally, i.e. also outside of react components. This allows to trigger a toast and navigate to home when a connection breaks.