### PR TITLE
Make election answers labels clickable

### DIFF
--- a/fe1-web/src/features/evoting/components/ElectionOpened.tsx
+++ b/fe1-web/src/features/evoting/components/ElectionOpened.tsx
@@ -146,7 +146,10 @@ const ElectionOpened = ({ election }: IPropTypes) => {
               </ListItem.Content>
             }
             onPress={() =>
-              setIsQuestionOpen({ ...isQuestionOpen, [question.id]: !isQuestionOpen[question.id] })
+              setIsQuestionOpen({
+                ...isQuestionOpen,
+                [question.id]: !isQuestionOpen[question.id],
+              })
             }
             isExpanded={!!isQuestionOpen[question.id]}>
             {question.ballot_options.map((ballotOption, ballotOptionIndex) => {
@@ -159,19 +162,25 @@ const ElectionOpened = ({ election }: IPropTypes) => {
                 listStyle.push(List.hiddenItem);
               }
 
+              const onPress = () => {
+                setSelectedBallots({
+                  ...selectedBallots,
+                  [questionIndex]: ballotOptionIndex,
+                });
+              };
+
               return (
-                <ListItem key={ballotOption} containerStyle={listStyle} style={listStyle}>
+                <ListItem
+                  key={ballotOption}
+                  containerStyle={listStyle}
+                  style={listStyle}
+                  onPress={onPress}>
                   <View style={List.icon}>
                     <ListItem.CheckBox
                       testID={`questions_${questionIndex}_ballots_option_${ballotOptionIndex}_checkbox`}
                       size={Icon.size}
                       checked={selectedBallots[questionIndex] === ballotOptionIndex}
-                      onPress={() =>
-                        setSelectedBallots({
-                          ...selectedBallots,
-                          [questionIndex]: ballotOptionIndex,
-                        })
-                      }
+                      onPress={onPress}
                     />
                   </View>
                   <ListItem.Content>
@@ -233,7 +242,12 @@ export const ElectionOpenedRightHeader = (props: RightHeaderIPropTypes) => {
     <PoPTouchableOpacity
       testID="election_opened_option_selector"
       onPress={() =>
-        showActionSheet([{ displayName: STRINGS.election_end, action: onTerminateElection }])
+        showActionSheet([
+          {
+            displayName: STRINGS.election_end,
+            action: onTerminateElection,
+          },
+        ])
       }>
       <PoPIcon name="options" color={Color.inactive} size={Icon.size} />
     </PoPTouchableOpacity>

--- a/fe1-web/src/features/evoting/screens/__tests__/__snapshots__/ViewSingleElection.test.tsx.snap
+++ b/fe1-web/src/features/evoting/screens/__tests__/__snapshots__/ViewSingleElection.test.tsx.snap
@@ -8186,6 +8186,18 @@ exports[`ViewSingleElection renders correctly non organizers opened election 1`]
                               testID="RNE__ListItem__Accordion__Children"
                             >
                               <View
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 style={
                                   Array [
                                     Object {
@@ -8394,6 +8406,18 @@ exports[`ViewSingleElection renders correctly non organizers opened election 1`]
                                 </View>
                               </View>
                               <View
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 style={
                                   Array [
                                     Object {
@@ -8818,6 +8842,18 @@ exports[`ViewSingleElection renders correctly non organizers opened election 1`]
                               testID="RNE__ListItem__Accordion__Children"
                             >
                               <View
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 style={
                                   Array [
                                     Object {
@@ -9026,6 +9062,18 @@ exports[`ViewSingleElection renders correctly non organizers opened election 1`]
                                 </View>
                               </View>
                               <View
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 style={
                                   Array [
                                     Object {
@@ -14986,6 +15034,18 @@ exports[`ViewSingleElection renders correctly organizers opened election 1`] = `
                               testID="RNE__ListItem__Accordion__Children"
                             >
                               <View
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 style={
                                   Array [
                                     Object {
@@ -15171,6 +15231,18 @@ exports[`ViewSingleElection renders correctly organizers opened election 1`] = `
                                 </View>
                               </View>
                               <View
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 style={
                                   Array [
                                     Object {
@@ -15572,6 +15644,18 @@ exports[`ViewSingleElection renders correctly organizers opened election 1`] = `
                               testID="RNE__ListItem__Accordion__Children"
                             >
                               <View
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 style={
                                   Array [
                                     Object {
@@ -15757,6 +15841,18 @@ exports[`ViewSingleElection renders correctly organizers opened election 1`] = `
                                 </View>
                               </View>
                               <View
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 style={
                                   Array [
                                     Object {


### PR DESCRIPTION
Fixes issue #1219. Label of answers are now clickable instead of having to click on the checkbox specifically.