### PR TITLE
Rename useAssertCurrentLaoId

### DIFF
--- a/fe1-web/src/features/digital-cash/__tests__/utils.ts
+++ b/fe1-web/src/features/digital-cash/__tests__/utils.ts
@@ -17,7 +17,7 @@ export const mockRollCallToken = new RollCallToken({
 
 export const mockDigitalCashContextValue = (isOrganizer: boolean) => ({
   [DIGITAL_CASH_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => true,
     useIsLaoOrganizer: () => isOrganizer,
     useRollCallById: () => mockRollCall,

--- a/fe1-web/src/features/digital-cash/hooks/DigitalCashHooks.ts
+++ b/fe1-web/src/features/digital-cash/hooks/DigitalCashHooks.ts
@@ -25,7 +25,7 @@ export namespace DigitalCashHooks {
   /**
    * Gets the current lao id, throws an error if there is none
    */
-  export const useAssertCurrentLaoId = () => useDigitalCashContext().useAssertCurrentLaoId();
+  export const useCurrentLaoId = () => useDigitalCashContext().useCurrentLaoId();
 
   /**
    * Returns true if currently connected to a lao, false if in offline mode

--- a/fe1-web/src/features/digital-cash/index.ts
+++ b/fe1-web/src/features/digital-cash/index.ts
@@ -33,7 +33,7 @@ export function compose(
     },
     context: {
       useRollCallById: configuration.useRollCallById,
-      useAssertCurrentLaoId: configuration.useAssertCurrentLaoId,
+      useCurrentLaoId: configuration.useCurrentLaoId,
       useConnectedToLao: configuration.useConnectedToLao,
       useIsLaoOrganizer: configuration.useIsLaoOrganizer,
       useRollCallTokensByLaoId: configuration.useRollCallTokensByLaoId,

--- a/fe1-web/src/features/digital-cash/interface/Configuration.ts
+++ b/fe1-web/src/features/digital-cash/interface/Configuration.ts
@@ -35,7 +35,7 @@ export interface DigitalCashCompositionConfiguration {
    * Returns the currently active lao id. Should be used inside react components.
    * Throws an error if there is no currently active lao
    */
-  useAssertCurrentLaoId: () => Hash;
+  useCurrentLaoId: () => Hash;
 
   /**
    * Returns true if currently connected to a lao, false if in offline mode
@@ -102,7 +102,7 @@ export interface DigitalCashCompositionConfiguration {
 export type DigitalCashReactContext = Pick<
   DigitalCashCompositionConfiguration,
   /* lao */
-  | 'useAssertCurrentLaoId'
+  | 'useCurrentLaoId'
   | 'useIsLaoOrganizer'
   | 'useConnectedToLao'
 

--- a/fe1-web/src/features/digital-cash/screens/DigitalCashWallet.tsx
+++ b/fe1-web/src/features/digital-cash/screens/DigitalCashWallet.tsx
@@ -28,7 +28,7 @@ type NavigationProps = CompositeScreenProps<
 
 const DigitalCashWallet = () => {
   const navigation = useNavigation<NavigationProps['navigation']>();
-  const laoId = DigitalCashHooks.useAssertCurrentLaoId();
+  const laoId = DigitalCashHooks.useCurrentLaoId();
 
   const balances = useSelector(useMemo(() => makeBalancesSelector(laoId), [laoId]));
   const isOrganizer = DigitalCashHooks.useIsLaoOrganizer(laoId);

--- a/fe1-web/src/features/digital-cash/screens/SendReceive/SendReceive.tsx
+++ b/fe1-web/src/features/digital-cash/screens/SendReceive/SendReceive.tsx
@@ -43,7 +43,7 @@ const styles = StyleSheet.create({
 const SendReceive = () => {
   const navigation = useNavigation<NavigationProps['navigation']>();
   const route = useRoute<NavigationProps['route']>();
-  const laoId = DigitalCashHooks.useAssertCurrentLaoId();
+  const laoId = DigitalCashHooks.useCurrentLaoId();
   const isConnected = DigitalCashHooks.useConnectedToLao();
 
   const { rollCallId, isCoinbase, scannedPoPToken } = route.params;
@@ -254,7 +254,7 @@ export const SendReceiveHeaderRight = () => {
   const [modalVisible, setModalVisible] = useState(false);
 
   const route = useRoute<NavigationProps['route']>();
-  const laoId = DigitalCashHooks.useAssertCurrentLaoId();
+  const laoId = DigitalCashHooks.useCurrentLaoId();
 
   const { rollCallId, isCoinbase } = route.params;
 

--- a/fe1-web/src/features/events/components/EventLists.tsx
+++ b/fe1-web/src/features/events/components/EventLists.tsx
@@ -31,7 +31,7 @@ type NavigationProps = CompositeScreenProps<
  * to 'past', 'present' and 'future' events.
  */
 const EventLists = () => {
-  const laoId = EventHooks.useAssertCurrentLaoId();
+  const laoId = EventHooks.useCurrentLaoId();
   const navigation = useNavigation<NavigationProps['navigation']>();
 
   const eventListSelector = useMemo(() => makeEventListSelector(laoId.valueOf()), [laoId]);

--- a/fe1-web/src/features/events/components/__tests__/CreateEventButton.test.tsx
+++ b/fe1-web/src/features/events/components/__tests__/CreateEventButton.test.tsx
@@ -31,7 +31,7 @@ const mockStore = configureStore({
 
 const contextValue = {
   [EVENT_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     eventTypes: [ElectionEventType, MeetingEventType, RollCallEventType],
     useIsLaoOrganizer: () => false,
   } as EventReactContext,

--- a/fe1-web/src/features/events/components/__tests__/EventLists.test.tsx
+++ b/fe1-web/src/features/events/components/__tests__/EventLists.test.tsx
@@ -48,12 +48,12 @@ const mockStore = configureStore({
 
 const getContextValue = (isOrganizer: boolean) => ({
   [EVENT_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     eventTypes: [ElectionEventType, MeetingEventType, RollCallEventType],
     useIsLaoOrganizer: () => isOrganizer,
   } as EventReactContext,
   [EVOTING_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => true,
     useCurrentLao: () => mockLao,
     addEvent,
@@ -62,17 +62,17 @@ const getContextValue = (isOrganizer: boolean) => ({
     useLaoOrganizerBackendPublicKey: () => mockKeyPair.publicKey,
   } as EvotingReactContext,
   [MEETING_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
   } as MeetingReactContext,
   [ROLLCALL_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => true,
     generateToken,
     hasSeed: () => getWalletState(mockStore.getState()).seed !== undefined,
     makeEventByTypeSelector,
   } as RollCallReactContext,
   [WALLET_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useCurrentLao: () => mockLao,
     useConnectedToLao: () => true,
     useRollCallsByLaoId: () => ({}),

--- a/fe1-web/src/features/events/hooks/EventHooks.ts
+++ b/fe1-web/src/features/events/hooks/EventHooks.ts
@@ -17,7 +17,7 @@ export namespace EventHooks {
   /**
    * Gets the current lao id or throws an error of there is none
    */
-  export const useAssertCurrentLaoId = () => useEventsContext().useAssertCurrentLaoId();
+  export const useCurrentLaoId = () => useEventsContext().useCurrentLaoId();
 
   /**
    * Gets whether the current user is organizer of the current lao

--- a/fe1-web/src/features/events/index.ts
+++ b/fe1-web/src/features/events/index.ts
@@ -34,7 +34,7 @@ export function compose(config: EventCompositionConfiguration): EventComposition
   return {
     identifier: EVENT_FEATURE_IDENTIFIER,
     context: {
-      useAssertCurrentLaoId: config.useAssertCurrentLaoId,
+      useCurrentLaoId: config.useCurrentLaoId,
       useIsLaoOrganizer: config.useIsLaoOrganizer,
       eventTypes: config.eventTypes,
     },

--- a/fe1-web/src/features/events/interface/Configuration.ts
+++ b/fe1-web/src/features/events/interface/Configuration.ts
@@ -84,7 +84,7 @@ export interface EventCompositionConfiguration {
    * Returns the currently active lao id or throws an error if there is none.
    * Should be used inside react components
    */
-  useAssertCurrentLaoId: () => Hash;
+  useCurrentLaoId: () => Hash;
 
   /**
    * Gets whether the current user is organizer of the current lao
@@ -121,7 +121,7 @@ interface EventType {
 export type EventReactContext = Pick<
   EventCompositionConfiguration,
   /* lao */
-  | 'useAssertCurrentLaoId'
+  | 'useCurrentLaoId'
   | 'useIsLaoOrganizer'
   /* other */
   | 'eventTypes'

--- a/fe1-web/src/features/events/screens/UpcomingEvents.tsx
+++ b/fe1-web/src/features/events/screens/UpcomingEvents.tsx
@@ -13,7 +13,7 @@ import { EventState } from '../objects';
 import { makeEventListSelector } from '../reducer';
 
 const UpcomingEvents = () => {
-  const laoId = EventHooks.useAssertCurrentLaoId();
+  const laoId = EventHooks.useCurrentLaoId();
   const eventListSelector = useMemo(() => makeEventListSelector(laoId.valueOf()), [laoId]);
   const events = useSelector(eventListSelector);
 

--- a/fe1-web/src/features/events/screens/__tests__/UpcomingEvents.test.tsx
+++ b/fe1-web/src/features/events/screens/__tests__/UpcomingEvents.test.tsx
@@ -50,12 +50,12 @@ const FUTURE = 1800000000;
 
 const getContextValue = (isOrganizer: boolean) => ({
   [EVENT_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     eventTypes: [ElectionEventType, MeetingEventType, RollCallEventType],
     useIsLaoOrganizer: () => isOrganizer,
   } as EventReactContext,
   [EVOTING_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => true,
     useCurrentLao: () => mockLao,
     addEvent,
@@ -64,17 +64,17 @@ const getContextValue = (isOrganizer: boolean) => ({
     useLaoOrganizerBackendPublicKey: () => mockKeyPair.publicKey,
   } as EvotingReactContext,
   [MEETING_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
   } as MeetingReactContext,
   [ROLLCALL_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => true,
     generateToken,
     hasSeed: () => getWalletState(mockStore.getState()).seed !== undefined,
     makeEventByTypeSelector,
   } as RollCallReactContext,
   [WALLET_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useCurrentLao: () => mockLao,
     useConnectedToLao: () => true,
     useRollCallsByLaoId: () => ({}),

--- a/fe1-web/src/features/evoting/hooks/EvotingHooks.ts
+++ b/fe1-web/src/features/evoting/hooks/EvotingHooks.ts
@@ -17,7 +17,7 @@ export namespace EvotingHooks {
    * Gets the current lao id
    * @returns The current lao id
    */
-  export const useAssertCurrentLaoId = () => useEvotingContext().useAssertCurrentLaoId();
+  export const useCurrentLaoId = () => useEvotingContext().useCurrentLaoId();
 
   /**
    * Returns true if currently connected to a lao, false if in offline mode

--- a/fe1-web/src/features/evoting/hooks/__tests__/EvotingHooks.test.tsx
+++ b/fe1-web/src/features/evoting/hooks/__tests__/EvotingHooks.test.tsx
@@ -20,7 +20,7 @@ const onConfirmEventCreation = jest.fn();
 const contextValue = {
   [EVOTING_FEATURE_IDENTIFIER]: {
     useCurrentLao: () => mockLao,
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => false,
     addEvent: () => mockReduxAction,
     updateEvent: () => mockReduxAction,
@@ -43,9 +43,9 @@ describe('EvotingHooks', () => {
     });
   });
 
-  describe('useAssertCurrentLaoId', () => {
+  describe('useCurrentLaoId', () => {
     it('should return the current lao id', () => {
-      const { result } = renderHook(() => EvotingHooks.useAssertCurrentLaoId(), { wrapper });
+      const { result } = renderHook(() => EvotingHooks.useCurrentLaoId(), { wrapper });
       expect(result.current).toEqual(mockLaoIdHash);
     });
   });

--- a/fe1-web/src/features/evoting/index.ts
+++ b/fe1-web/src/features/evoting/index.ts
@@ -13,7 +13,7 @@ import { CreateElectionScreen, ViewSingleElectionScreen } from './screens';
 export const configure = (config: EvotingConfiguration): EvotingInterface => {
   const {
     useCurrentLao,
-    useAssertCurrentLaoId,
+    useCurrentLaoId,
     useConnectedToLao,
     useLaoOrganizerBackendPublicKey,
     getEventById,
@@ -31,7 +31,7 @@ export const configure = (config: EvotingConfiguration): EvotingInterface => {
     context: {
       /* lao */
       useCurrentLao,
-      useAssertCurrentLaoId,
+      useCurrentLaoId,
       useConnectedToLao,
       useLaoOrganizerBackendPublicKey,
       /* event */

--- a/fe1-web/src/features/evoting/interface/Configuration.ts
+++ b/fe1-web/src/features/evoting/interface/Configuration.ts
@@ -39,7 +39,7 @@ export interface EvotingConfiguration {
    * Should be used inside react components
    * @returns The current lao id
    */
-  useAssertCurrentLaoId: () => Hash;
+  useCurrentLaoId: () => Hash;
 
   /**
    * Returns true if currently connected to a lao, false if in offline mode
@@ -95,7 +95,7 @@ export type EvotingReactContext = Pick<
   EvotingConfiguration,
   /* lao */
   | 'useCurrentLao'
-  | 'useAssertCurrentLaoId'
+  | 'useCurrentLaoId'
   | 'useConnectedToLao'
   | 'useLaoOrganizerBackendPublicKey'
   /* events */

--- a/fe1-web/src/features/evoting/screens/__tests__/CreateElection.test.tsx
+++ b/fe1-web/src/features/evoting/screens/__tests__/CreateElection.test.tsx
@@ -17,10 +17,9 @@ import CreateElection from '../CreateElection';
 const contextValue = {
   [EVOTING_FEATURE_IDENTIFIER]: {
     getCurrentLao: () => mockLao,
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => true,
     useCurrentLao: () => mockLao,
-    useCurrentLaoId: () => mockLaoIdHash,
     addEvent: () => mockReduxAction,
     updateEvent: () => mockReduxAction,
     getEventFromId: () => undefined,

--- a/fe1-web/src/features/evoting/screens/__tests__/ViewSingleElection.test.tsx
+++ b/fe1-web/src/features/evoting/screens/__tests__/ViewSingleElection.test.tsx
@@ -58,7 +58,7 @@ mockStore.dispatch(addElection(mockElectionNotStarted.toState()));
 const contextValue = {
   [EVOTING_FEATURE_IDENTIFIER]: {
     useCurrentLao: () => mockLao,
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => true,
     useLaoOrganizerBackendPublicKey: () => mockKeyPair.publicKey,
     addEvent: () => mockReduxAction,

--- a/fe1-web/src/features/home/hooks/HomeHooks.ts
+++ b/fe1-web/src/features/home/hooks/HomeHooks.ts
@@ -57,10 +57,10 @@ export namespace HomeHooks {
   export const useGetLaoChannel = () => useHomeContext().getLaoChannel;
 
   /**
-   * Gets the current lao id
-   * @returns The current lao id
+   * A hook returning if currently connected to a lao
+   * Returns undefined if there is no current lao
    */
-  export const useCurrentLaoId = () => useHomeContext().useCurrentLaoId();
+  export const useConnectedToLao = () => useHomeContext().useConnectedToLao();
 
   /**
    * Gets the disconnect from lao function

--- a/fe1-web/src/features/home/hooks/__tests__/HomeHooks.test.tsx
+++ b/fe1-web/src/features/home/hooks/__tests__/HomeHooks.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { combineReducers } from 'redux';
 
-import { mockLao, mockLaoIdHash } from '__tests__/utils';
+import { mockLao } from '__tests__/utils';
 import FeatureContext from 'core/contexts/FeatureContext';
 import { HOME_FEATURE_IDENTIFIER, HomeFeature, HomeReactContext } from 'features/home/interface';
 import { LaoHooks } from 'features/lao/hooks';
@@ -38,7 +38,7 @@ const contextValue = {
     LaoList,
     homeNavigationScreens,
     getLaoChannel,
-    useCurrentLaoId: LaoHooks.useCurrentLaoId,
+    useConnectedToLao: () => false,
     hasSeed,
     useDisconnectFromLao: () => () => {},
     getLaoById: () => mockLao,
@@ -100,10 +100,10 @@ describe('Home hooks', () => {
     });
   });
 
-  describe('useCurrentLaoId', () => {
-    it('should return the the current lao id', () => {
-      const { result } = renderHook(() => HomeHooks.useCurrentLaoId(), { wrapper });
-      expect(result.current).toEqual(mockLaoIdHash);
+  describe('useConnectedToLao', () => {
+    it('should return whether the app is currently connected to a lao', () => {
+      const { result } = renderHook(() => HomeHooks.useConnectedToLao(), { wrapper });
+      expect(result.current).toBeFalse();
     });
   });
 

--- a/fe1-web/src/features/home/index.ts
+++ b/fe1-web/src/features/home/index.ts
@@ -18,7 +18,7 @@ export function compose(config: HomeCompositionConfiguration): HomeInterface {
       LaoList: config.LaoList,
       homeNavigationScreens: config.homeNavigationScreens,
       getLaoChannel: config.getLaoChannel,
-      useCurrentLaoId: config.useCurrentLaoId,
+      useConnectedToLao: config.useConnectedToLao,
       useDisconnectFromLao: config.useDisconnectFromLao,
       getLaoById: config.getLaoById,
       resubscribeToLao: config.resubscribeToLao,

--- a/fe1-web/src/features/home/interface/Configuration.ts
+++ b/fe1-web/src/features/home/interface/Configuration.ts
@@ -28,10 +28,10 @@ export interface HomeCompositionConfiguration {
   getLaoById(laoId: string): HomeFeature.Lao | undefined;
 
   /**
-   * A hook returning the current lao id
-   * @returns The current lao id
+   * A hook returning if currently connected to a lao
+   * Returns undefined if there is no current lao
    */
-  useCurrentLaoId: () => Hash | undefined;
+  useConnectedToLao: () => boolean | undefined;
 
   /* functions */
 
@@ -102,7 +102,7 @@ export type HomeReactContext = Pick<
   | 'homeNavigationScreens'
   | 'getLaoChannel'
   | 'resubscribeToLao'
-  | 'useCurrentLaoId'
+  | 'useConnectedToLao'
   | 'useDisconnectFromLao'
   | 'getLaoById'
 >;

--- a/fe1-web/src/features/home/navigation/__tests__/ConnectNavigation.test.tsx
+++ b/fe1-web/src/features/home/navigation/__tests__/ConnectNavigation.test.tsx
@@ -8,7 +8,6 @@ import MockNavigator from '__tests__/components/MockNavigator';
 import { mockChannel, mockLao, mockReduxAction } from '__tests__/utils';
 import FeatureContext from 'core/contexts/FeatureContext';
 import { HOME_FEATURE_IDENTIFIER, HomeReactContext } from 'features/home/interface';
-import { LaoHooks } from 'features/lao/hooks';
 import { laoReducer, setCurrentLao } from 'features/lao/reducer';
 
 import ConnectNavigation from '../ConnectNavigation';
@@ -16,7 +15,7 @@ import ConnectNavigation from '../ConnectNavigation';
 const contextValue = {
   [HOME_FEATURE_IDENTIFIER]: {
     addLaoServerAddress: () => mockReduxAction,
-    useCurrentLaoId: LaoHooks.useCurrentLaoId,
+    useConnectedToLao: () => true,
     getLaoChannel: () => mockChannel,
     requestCreateLao: () => Promise.resolve(mockChannel),
     connectToTestLao: () => {},

--- a/fe1-web/src/features/home/navigation/__tests__/HomeNavigation.test.tsx
+++ b/fe1-web/src/features/home/navigation/__tests__/HomeNavigation.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import MockNavigator from '__tests__/components/MockNavigator';
-import { mockChannel, mockLao, mockLaoIdHash, mockReduxAction } from '__tests__/utils';
+import { mockChannel, mockLao, mockReduxAction } from '__tests__/utils';
 import FeatureContext from 'core/contexts/FeatureContext';
 import { HomeFeature, HomeReactContext, HOME_FEATURE_IDENTIFIER } from 'features/home/interface';
 import { Home } from 'features/home/screens';
@@ -24,7 +24,7 @@ const contextValue = {
       { id: 'home2' as HomeFeature.HomeScreen['id'], Component: Home },
     ],
     getLaoChannel: () => mockChannel,
-    useCurrentLaoId: () => mockLaoIdHash,
+    useConnectedToLao: () => true,
     useDisconnectFromLao: () => () => {},
     getLaoById: () => mockLao,
     resubscribeToLao: () => Promise.resolve(),

--- a/fe1-web/src/features/home/screens/ConnectScan.tsx
+++ b/fe1-web/src/features/home/screens/ConnectScan.tsx
@@ -46,7 +46,6 @@ const ConnectScan = () => {
 
   const toast = useToast();
 
-  const laoId = HomeHooks.useCurrentLaoId();
   const getLaoChannel = HomeHooks.useGetLaoChannel();
   const getLaoById = HomeHooks.useGetLaoById();
   const resubscribeToLao = HomeHooks.useResubscribeToLao();
@@ -87,21 +86,6 @@ const ConnectScan = () => {
 
       if (connectToLao.servers.length === 0) {
         throw new Error('The scanned QR code did not contain any server address');
-      }
-
-      // if we are already connected to a LAO, then only allow new connections
-      // to servers for the same LAO id
-      if (laoId && connectToLao.lao !== laoId.valueOf()) {
-        toast.show(
-          `The scanned QR code is for a different LAO than the one currently connected to`,
-          {
-            type: 'warning',
-            placement: 'top',
-            duration: FOUR_SECONDS,
-          },
-        );
-
-        return false;
       }
 
       const laoChannel = getLaoChannel(connectToLao.lao);

--- a/fe1-web/src/features/home/screens/Home.tsx
+++ b/fe1-web/src/features/home/screens/Home.tsx
@@ -30,20 +30,20 @@ const Home: FunctionComponent<unknown> = () => {
   const laos = HomeHooks.useLaoList();
   const LaoList = HomeHooks.useLaoListComponent();
 
-  const laoId = HomeHooks.useCurrentLaoId();
+  const isConnected = HomeHooks.useConnectedToLao();
   const disconnectFromLao = HomeHooks.useDisonnectFromLao();
 
   useEffect(() => {
     // Return the function to unsubscribe from the event so it gets removed on unmount
     return navigation.addListener('focus', () => {
       // The screen is now focused, check if we are connected to a lao
-      if (laoId) {
+      if (isConnected) {
         // if we enter this screen and connected to a lao
         // disconnect from this lao
         disconnectFromLao();
       }
     });
-  }, [navigation, laoId, disconnectFromLao]);
+  }, [navigation, isConnected, disconnectFromLao]);
 
   const toolbarItems = useMemo<ToolbarItem[]>(
     () => [

--- a/fe1-web/src/features/home/screens/__tests__/ConnectConfirm.test.tsx
+++ b/fe1-web/src/features/home/screens/__tests__/ConnectConfirm.test.tsx
@@ -18,7 +18,6 @@ import FeatureContext from 'core/contexts/FeatureContext';
 import { subscribeToChannel } from 'core/network';
 import { HOME_FEATURE_IDENTIFIER, HomeReactContext } from 'features/home/interface';
 import { getLaoChannel, resubscribeToLao } from 'features/lao/functions';
-import { LaoHooks } from 'features/lao/hooks';
 import { laoReducer, setCurrentLao } from 'features/lao/reducer';
 
 import ConnectConfirm from '../ConnectConfirm';
@@ -26,7 +25,7 @@ import ConnectConfirm from '../ConnectConfirm';
 const contextValue = {
   [HOME_FEATURE_IDENTIFIER]: {
     addLaoServerAddress: () => mockReduxAction,
-    useCurrentLaoId: LaoHooks.useCurrentLaoId,
+    useConnectedToLao: () => true,
     getLaoChannel: () => mockChannel,
     requestCreateLao: () => Promise.resolve(mockChannel),
     connectToTestLao: () => {},

--- a/fe1-web/src/features/home/screens/__tests__/ConnectOpenScan.test.tsx
+++ b/fe1-web/src/features/home/screens/__tests__/ConnectOpenScan.test.tsx
@@ -21,7 +21,6 @@ import { subscribeToChannel } from 'core/network';
 import { HOME_FEATURE_IDENTIFIER, HomeReactContext } from 'features/home/interface';
 import { ConnectToLao } from 'features/home/objects';
 import { getLaoChannel, resubscribeToLao } from 'features/lao/functions';
-import { LaoHooks } from 'features/lao/hooks';
 import { laoReducer, setCurrentLao } from 'features/lao/reducer';
 
 import ConnectScan from '../ConnectScan';
@@ -72,7 +71,7 @@ beforeEach(jest.clearAllMocks);
 const contextValue = {
   [HOME_FEATURE_IDENTIFIER]: {
     addLaoServerAddress: () => mockReduxAction,
-    useCurrentLaoId: LaoHooks.useCurrentLaoId,
+    useConnectedToLao: () => true,
     getLaoChannel: () => mockChannel,
     LaoList: () => null,
     connectToTestLao: () => {},

--- a/fe1-web/src/features/home/screens/__tests__/Home.test.tsx
+++ b/fe1-web/src/features/home/screens/__tests__/Home.test.tsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import { combineReducers } from 'redux';
 
 import MockNavigator from '__tests__/components/MockNavigator';
-import { mockChannel, mockLao, mockLaoIdHash, mockReduxAction } from '__tests__/utils';
+import { mockChannel, mockLao, mockReduxAction } from '__tests__/utils';
 import FeatureContext from 'core/contexts/FeatureContext';
 import { HOME_FEATURE_IDENTIFIER, HomeReactContext } from 'features/home/interface';
 import { LaoList } from 'features/lao/components';
@@ -22,7 +22,7 @@ const contextValueEmpyList = {
     LaoList: () => null,
     homeNavigationScreens: [],
     getLaoChannel: () => mockChannel,
-    useCurrentLaoId: () => mockLaoIdHash,
+    useConnectedToLao: () => true,
     useDisconnectFromLao: () => () => {},
     getLaoById: () => mockLao,
     resubscribeToLao: () => Promise.resolve(),
@@ -39,7 +39,7 @@ const contextValue = {
     LaoList,
     homeNavigationScreens: [],
     getLaoChannel: () => mockChannel,
-    useCurrentLaoId: () => mockLaoIdHash,
+    useConnectedToLao: () => true,
     hasSeed: () => true,
     useDisconnectFromLao: () => () => {},
     getLaoById: () => mockLao,

--- a/fe1-web/src/features/home/screens/__tests__/Launch.test.tsx
+++ b/fe1-web/src/features/home/screens/__tests__/Launch.test.tsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import { combineReducers } from 'redux';
 
 import MockNavigator from '__tests__/components/MockNavigator';
-import { mockChannel, mockLao, mockLaoIdHash, mockReduxAction } from '__tests__/utils';
+import { mockChannel, mockLao, mockReduxAction } from '__tests__/utils';
 import FeatureContext from 'core/contexts/FeatureContext';
 import { HOME_FEATURE_IDENTIFIER, HomeReactContext } from 'features/home/interface';
 
@@ -20,7 +20,7 @@ const contextValue = {
     LaoList: () => null,
     homeNavigationScreens: [],
     getLaoChannel: () => mockChannel,
-    useCurrentLaoId: () => mockLaoIdHash,
+    useConnectedToLao: () => true,
     useDisconnectFromLao: () => () => {},
     getLaoById: () => mockLao,
     resubscribeToLao: () => Promise.resolve(),

--- a/fe1-web/src/features/index.ts
+++ b/fe1-web/src/features/index.ts
@@ -144,7 +144,7 @@ export function configureFeatures() {
     addLaoServerAddress: laoConfiguration.actionCreators.addLaoServerAddress,
     /* hooks */
     useLaoList: laoConfiguration.hooks.useLaoList,
-    useCurrentLaoId: laoConfiguration.hooks.useCurrentLaoId,
+    useConnectedToLao: laoConfiguration.hooks.useConnectedToLao,
     useDisconnectFromLao: laoConfiguration.hooks.useDisconnectFromLao,
     /* components */
     LaoList: laoConfiguration.components.LaoList,

--- a/fe1-web/src/features/index.ts
+++ b/fe1-web/src/features/index.ts
@@ -35,7 +35,7 @@ export function configureFeatures() {
     useLaoOrganizerBackendPublicKey: laoConfiguration.hooks.useLaoOrganizerBackendPublicKey,
     /* lao: hooks */
     useCurrentLao: laoConfiguration.hooks.useCurrentLao,
-    useAssertCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
     useConnectedToLao: laoConfiguration.hooks.useConnectedToLao,
     /* EVENTS FEATURE */
     /* events: action creators */
@@ -53,7 +53,7 @@ export function configureFeatures() {
     updateEvent: eventConfiguration.actionCreators.updateEvent,
     getEventById: eventConfiguration.functions.getEventById,
     getLaoById: laoConfiguration.functions.getLaoById,
-    useAssertCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
     useConnectedToLao: laoConfiguration.hooks.useConnectedToLao,
   });
 
@@ -65,7 +65,7 @@ export function configureFeatures() {
     makeEventByTypeSelector: eventConfiguration.functions.makeEventByTypeSelector,
     getLaoById: laoConfiguration.functions.getLaoById,
     setLaoLastRollCall: laoConfiguration.actionCreators.setLaoLastRollCall,
-    useAssertCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
     useConnectedToLao: laoConfiguration.hooks.useConnectedToLao,
     generateToken: walletConfiguration.functions.generateToken,
     hasSeed: walletConfiguration.functions.hasSeed,
@@ -75,7 +75,7 @@ export function configureFeatures() {
     keyPairRegistry,
     messageRegistry,
     getCurrentLao: laoConfiguration.functions.getCurrentLao,
-    useAssertCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
     useCurrentLao: laoConfiguration.hooks.useCurrentLao,
     useConnectedToLao: laoConfiguration.hooks.useConnectedToLao,
     getEventById: eventConfiguration.functions.getEventById,
@@ -91,7 +91,7 @@ export function configureFeatures() {
     keyPairRegistry: keyPairRegistry,
     getCurrentLao: laoConfiguration.functions.getCurrentLao,
     getCurrentLaoId: laoConfiguration.functions.getCurrentLaoId,
-    useAssertCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
     useConnectedToLao: laoConfiguration.hooks.useConnectedToLao,
     useIsLaoOrganizer: laoConfiguration.hooks.useIsLaoOrganizer,
     getLaoOrganizer: laoConfiguration.functions.getLaoOrganizer,
@@ -116,7 +116,7 @@ export function configureFeatures() {
   const witnessConfiguration = witness.configure({
     enabled: false,
     messageRegistry,
-    useAssertCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
     useConnectedToLao: laoConfiguration.hooks.useConnectedToLao,
     getCurrentLao: laoConfiguration.functions.getCurrentLao,
     getCurrentLaoId: laoConfiguration.functions.getCurrentLaoId,
@@ -128,7 +128,7 @@ export function configureFeatures() {
 
   // compose features
   const notificationComposition = notification.compose({
-    useAssertCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
     notificationTypes: [
       ...witnessConfiguration.notificationTypes,
     ] as NotificationCompositionConfiguration['notificationTypes'],
@@ -159,7 +159,7 @@ export function configureFeatures() {
       ...evotingConfiguration.eventTypes,
     ],
     useIsLaoOrganizer: laoConfiguration.hooks.useIsLaoOrganizer,
-    useAssertCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
   });
 
   const laoComposition = lao.compose({

--- a/fe1-web/src/features/index.ts
+++ b/fe1-web/src/features/index.ts
@@ -35,7 +35,7 @@ export function configureFeatures() {
     useLaoOrganizerBackendPublicKey: laoConfiguration.hooks.useLaoOrganizerBackendPublicKey,
     /* lao: hooks */
     useCurrentLao: laoConfiguration.hooks.useCurrentLao,
-    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useCurrentLaoId,
     useConnectedToLao: laoConfiguration.hooks.useConnectedToLao,
     /* EVENTS FEATURE */
     /* events: action creators */
@@ -53,7 +53,7 @@ export function configureFeatures() {
     updateEvent: eventConfiguration.actionCreators.updateEvent,
     getEventById: eventConfiguration.functions.getEventById,
     getLaoById: laoConfiguration.functions.getLaoById,
-    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useCurrentLaoId,
     useConnectedToLao: laoConfiguration.hooks.useConnectedToLao,
   });
 
@@ -65,7 +65,7 @@ export function configureFeatures() {
     makeEventByTypeSelector: eventConfiguration.functions.makeEventByTypeSelector,
     getLaoById: laoConfiguration.functions.getLaoById,
     setLaoLastRollCall: laoConfiguration.actionCreators.setLaoLastRollCall,
-    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useCurrentLaoId,
     useConnectedToLao: laoConfiguration.hooks.useConnectedToLao,
     generateToken: walletConfiguration.functions.generateToken,
     hasSeed: walletConfiguration.functions.hasSeed,
@@ -75,7 +75,7 @@ export function configureFeatures() {
     keyPairRegistry,
     messageRegistry,
     getCurrentLao: laoConfiguration.functions.getCurrentLao,
-    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useCurrentLaoId,
     useCurrentLao: laoConfiguration.hooks.useCurrentLao,
     useConnectedToLao: laoConfiguration.hooks.useConnectedToLao,
     getEventById: eventConfiguration.functions.getEventById,
@@ -91,7 +91,7 @@ export function configureFeatures() {
     keyPairRegistry: keyPairRegistry,
     getCurrentLao: laoConfiguration.functions.getCurrentLao,
     getCurrentLaoId: laoConfiguration.functions.getCurrentLaoId,
-    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useCurrentLaoId,
     useConnectedToLao: laoConfiguration.hooks.useConnectedToLao,
     useIsLaoOrganizer: laoConfiguration.hooks.useIsLaoOrganizer,
     getLaoOrganizer: laoConfiguration.functions.getLaoOrganizer,
@@ -116,7 +116,7 @@ export function configureFeatures() {
   const witnessConfiguration = witness.configure({
     enabled: false,
     messageRegistry,
-    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useCurrentLaoId,
     useConnectedToLao: laoConfiguration.hooks.useConnectedToLao,
     getCurrentLao: laoConfiguration.functions.getCurrentLao,
     getCurrentLaoId: laoConfiguration.functions.getCurrentLaoId,
@@ -128,7 +128,7 @@ export function configureFeatures() {
 
   // compose features
   const notificationComposition = notification.compose({
-    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useCurrentLaoId,
     notificationTypes: [
       ...witnessConfiguration.notificationTypes,
     ] as NotificationCompositionConfiguration['notificationTypes'],
@@ -159,7 +159,7 @@ export function configureFeatures() {
       ...evotingConfiguration.eventTypes,
     ],
     useIsLaoOrganizer: laoConfiguration.hooks.useIsLaoOrganizer,
-    useCurrentLaoId: laoConfiguration.hooks.useAssertCurrentLaoId,
+    useCurrentLaoId: laoConfiguration.hooks.useCurrentLaoId,
   });
 
   const laoComposition = lao.compose({

--- a/fe1-web/src/features/lao/hooks/LaoHooks.ts
+++ b/fe1-web/src/features/lao/hooks/LaoHooks.ts
@@ -112,12 +112,6 @@ export namespace LaoHooks {
   };
 
   /**
-   * Returns the current lao id or undefined if there is none
-   * @returns The current lao id
-   */
-  export const useCurrentLaoId = () => useSelector(selectCurrentLaoId);
-
-  /**
    * Returns true if currently connected to a lao, false if in offline mode
    * and undefined if there is no current lao
    */
@@ -127,8 +121,8 @@ export namespace LaoHooks {
    * Returns the current lao id or throws an NoCurrentLaoError if there is none
    * @returns The current lao id
    */
-  export const useAssertCurrentLaoId = () => {
-    const laoId = useCurrentLaoId();
+  export const useCurrentLaoId = () => {
+    const laoId = useSelector(selectCurrentLaoId);
 
     if (!laoId) {
       throw new NoCurrentLaoError('Violation of the assertion of the existence of a current lao');

--- a/fe1-web/src/features/lao/hooks/__tests__/LaoHooks.test.tsx
+++ b/fe1-web/src/features/lao/hooks/__tests__/LaoHooks.test.tsx
@@ -9,6 +9,7 @@ import { mockKeyPair, mockLao, mockLaoId, mockPopToken } from '__tests__/utils';
 import FeatureContext from 'core/contexts/FeatureContext';
 import { keyPairReducer, setKeyPair } from 'core/keypair';
 import { encodeLaoConnectionForQRCode } from 'features/home/functions';
+import { NoCurrentLaoError } from 'features/lao/errors/NoCurrentLaoError';
 import { LAO_FEATURE_IDENTIFIER, LaoFeature, LaoReactContext } from 'features/lao/interface';
 import { laoReducer, setCurrentLao } from 'features/lao/reducer';
 
@@ -69,11 +70,11 @@ describe('LaoHooks', () => {
       expect(result.current?.valueOf()).toEqual(mockLaoId);
     });
 
-    it('should return the undefined if there is no current lao', () => {
+    it('should throw if there is no current lao', () => {
       const { result } = renderHook(() => LaoHooks.useCurrentLaoId(), {
         wrapper: wrapper(emptyMockStore),
       });
-      expect(result.current).toEqual(undefined);
+      expect(result.error).toBeInstanceOf(NoCurrentLaoError);
     });
   });
 

--- a/fe1-web/src/features/lao/index.ts
+++ b/fe1-web/src/features/lao/index.ts
@@ -42,7 +42,6 @@ export const configure = (config: LaoConfiguration): LaoConfigurationInterface =
       useLaoMap: hooks.LaoHooks.useLaoMap,
       useCurrentLao: hooks.LaoHooks.useCurrentLao,
       useCurrentLaoId: hooks.LaoHooks.useCurrentLaoId,
-      useAssertCurrentLaoId: hooks.LaoHooks.useAssertCurrentLaoId,
       useConnectedToLao: hooks.LaoHooks.useConnectedToLao,
       useLaoOrganizerBackendPublicKey: hooks.LaoHooks.useLaoOrganizerBackendPublicKey,
       useDisconnectFromLao: hooks.LaoHooks.useDisconnectFromLao,

--- a/fe1-web/src/features/lao/interface/Configuration.ts
+++ b/fe1-web/src/features/lao/interface/Configuration.ts
@@ -110,15 +110,9 @@ export interface LaoConfigurationInterface extends FeatureInterface {
 
     /**
      * Gets the current lao id
-     * @returns The current lao id or undefined if there is none
-     */
-    useCurrentLaoId: () => Hash | undefined;
-
-    /**
-     * Gets the current lao id
      * @returns The current lao id or throws an exeception if there is none
      */
-    useAssertCurrentLaoId: () => Hash;
+    useCurrentLaoId: () => Hash;
 
     /**
      * Returns true if currently connected to a lao, false if in offline mode

--- a/fe1-web/src/features/meeting/hooks/MeetingHooks.ts
+++ b/fe1-web/src/features/meeting/hooks/MeetingHooks.ts
@@ -18,7 +18,7 @@ export namespace MeetingHooks {
    * Returns the currently active lao id or throws an error if there is none.
    * Should be used inside react components
    */
-  export const useAssertCurrentLaoId = () => useMeetingContext().useAssertCurrentLaoId();
+  export const useCurrentLaoId = () => useMeetingContext().useCurrentLaoId();
 
   /**
    * Returns true if currently connected to a lao, false if in offline mode

--- a/fe1-web/src/features/meeting/hooks/__tests__/MeetingHooks.test.tsx
+++ b/fe1-web/src/features/meeting/hooks/__tests__/MeetingHooks.test.tsx
@@ -10,7 +10,7 @@ import { MeetingHooks } from '../index';
 
 const contextValue = {
   [MEETING_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => false,
   } as MeetingReactContext,
 };
@@ -20,9 +20,9 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 );
 
 describe('Meeting hooks', () => {
-  describe('useAssertCurrentLaoId', () => {
+  describe('useuseCurrentLaoIdAssertCurrentLaoId', () => {
     it('should return the current lao id', () => {
-      const { result } = renderHook(() => MeetingHooks.useAssertCurrentLaoId(), { wrapper });
+      const { result } = renderHook(() => MeetingHooks.useCurrentLaoId(), { wrapper });
       expect(result.current).toEqual(mockLaoIdHash);
     });
   });

--- a/fe1-web/src/features/meeting/index.ts
+++ b/fe1-web/src/features/meeting/index.ts
@@ -17,7 +17,7 @@ export const configure = (configuration: MeetingConfiguration): MeetingInterface
     eventTypes: [MeetingEventType],
     laoEventScreens: [CreateMeetingScreen, ViewSingleMeetingScreen],
     context: {
-      useAssertCurrentLaoId: configuration.useAssertCurrentLaoId,
+      useCurrentLaoId: configuration.useCurrentLaoId,
       useConnectedToLao: configuration.useConnectedToLao,
     },
     reducers: {

--- a/fe1-web/src/features/meeting/interface/Configuration.ts
+++ b/fe1-web/src/features/meeting/interface/Configuration.ts
@@ -26,7 +26,7 @@ export interface MeetingConfiguration {
    * Returns the currently active lao id. Should be used inside react components
    * @returns The current lao id
    */
-  useAssertCurrentLaoId: () => Hash;
+  useCurrentLaoId: () => Hash;
 
   /**
    * Returns true if currently connected to a lao, false if in offline mode
@@ -67,7 +67,7 @@ export interface MeetingConfiguration {
  */
 export type MeetingReactContext = Pick<
   MeetingConfiguration,
-  'useAssertCurrentLaoId' | 'useConnectedToLao'
+  'useCurrentLaoId' | 'useConnectedToLao'
 >;
 
 /**

--- a/fe1-web/src/features/meeting/screens/CreateMeeting.tsx
+++ b/fe1-web/src/features/meeting/screens/CreateMeeting.tsx
@@ -39,7 +39,7 @@ type NavigationProps = CompositeScreenProps<
 const CreateMeeting = () => {
   const navigation = useNavigation<NavigationProps['navigation']>();
   const toast = useToast();
-  const laoId = MeetingHooks.useAssertCurrentLaoId();
+  const laoId = MeetingHooks.useCurrentLaoId();
   const isConnected = MeetingHooks.useConnectedToLao();
 
   const [meetingName, setMeetingName] = useState('');

--- a/fe1-web/src/features/meeting/screens/__tests__/CreateMeeting.test.tsx
+++ b/fe1-web/src/features/meeting/screens/__tests__/CreateMeeting.test.tsx
@@ -10,7 +10,7 @@ import CreateMeeting from '../CreateMeeting';
 
 const contextValue = {
   [MEETING_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => true,
   } as MeetingReactContext,
 };

--- a/fe1-web/src/features/meeting/screens/__tests__/ViewSingleMeeting.test.tsx
+++ b/fe1-web/src/features/meeting/screens/__tests__/ViewSingleMeeting.test.tsx
@@ -33,7 +33,7 @@ mockStore.dispatch(addMeeting(mockMeeting.toState()));
 
 const contextValue = {
   [MEETING_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
   } as MeetingReactContext,
 };
 

--- a/fe1-web/src/features/notification/components/NotificationBadge.tsx
+++ b/fe1-web/src/features/notification/components/NotificationBadge.tsx
@@ -20,7 +20,7 @@ const NotificationBadgeStyles = StyleSheet.create({
 });
 
 const NotificationBadge = () => {
-  const laoId = NotificationHooks.useAssertCurrentLaoId();
+  const laoId = NotificationHooks.useCurrentLaoId();
   const selectUnreadNotificationCount = useMemo(
     () => makeUnreadNotificationCountSelector(laoId.valueOf()),
     [laoId],

--- a/fe1-web/src/features/notification/components/__tests__/NotificationBadge.test.tsx
+++ b/fe1-web/src/features/notification/components/__tests__/NotificationBadge.test.tsx
@@ -17,7 +17,7 @@ import NotificationBadge from '../NotificationBadge';
 
 const contextValue = {
   [NOTIFICATION_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     notificationTypes: [WitnessNotificationType],
   } as NotificationReactContext,
 };

--- a/fe1-web/src/features/notification/hooks/NotificationHooks.ts
+++ b/fe1-web/src/features/notification/hooks/NotificationHooks.ts
@@ -23,7 +23,7 @@ export namespace NotificationHooks {
    * A hook returning the current lao id
    * @returns The current lao id
    */
-  export const useAssertCurrentLaoId = () => useNotificationContext().useAssertCurrentLaoId();
+  export const useCurrentLaoId = () => useNotificationContext().useCurrentLaoId();
 
   /**
    * Gets the list of notification types with e.g. the component that should be used to

--- a/fe1-web/src/features/notification/hooks/__tests__/NotificationHooks.test.tsx
+++ b/fe1-web/src/features/notification/hooks/__tests__/NotificationHooks.test.tsx
@@ -18,7 +18,7 @@ import { NotificationHooks } from '../NotificationHooks';
 
 const contextValue = {
   [NOTIFICATION_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     notificationTypes: [WitnessNotificationType],
   } as NotificationReactContext,
 };

--- a/fe1-web/src/features/notification/index.ts
+++ b/fe1-web/src/features/notification/index.ts
@@ -38,7 +38,7 @@ export const compose = (
 ): NotificationCompositionInterface => ({
   identifier: NOTIFICATION_FEATURE_IDENTIFIER,
   context: {
-    useAssertCurrentLaoId: configuration.useAssertCurrentLaoId,
+    useCurrentLaoId: configuration.useCurrentLaoId,
     notificationTypes: configuration.notificationTypes,
   },
 });

--- a/fe1-web/src/features/notification/interface/Configuration.ts
+++ b/fe1-web/src/features/notification/interface/Configuration.ts
@@ -35,7 +35,7 @@ export interface NotificationCompositionConfiguration {
    * A hook returning the current lao id
    * @returns The current lao id
    */
-  useAssertCurrentLaoId: () => Hash;
+  useCurrentLaoId: () => Hash;
 
   notificationTypes: {
     /**
@@ -72,7 +72,7 @@ export interface NotificationCompositionConfiguration {
  */
 export type NotificationReactContext = Pick<
   NotificationCompositionConfiguration,
-  'useAssertCurrentLaoId' | 'notificationTypes'
+  'useCurrentLaoId' | 'notificationTypes'
 >;
 
 export interface NotificationCompositionInterface extends FeatureInterface {

--- a/fe1-web/src/features/notification/screens/NotificationScreen.tsx
+++ b/fe1-web/src/features/notification/screens/NotificationScreen.tsx
@@ -22,7 +22,7 @@ import {
  * The notification screen component displaying the list of read and unread notifications
  */
 const NotificationScreen = () => {
-  const laoId = NotificationHooks.useAssertCurrentLaoId();
+  const laoId = NotificationHooks.useCurrentLaoId();
 
   const selectUnreadNotifications = useMemo(
     () => makeUnreadNotificationsSelector(laoId.valueOf()),
@@ -62,7 +62,7 @@ export const NotificationScreenRightHeader = () => {
   const showActionSheet = useActionSheet();
   const notificationTypes = NotificationHooks.useNotificationTypes();
 
-  const laoId = NotificationHooks.useAssertCurrentLaoId();
+  const laoId = NotificationHooks.useCurrentLaoId();
 
   const selectUnreadNotifications = useMemo(
     () => makeUnreadNotificationsSelector(laoId.valueOf()),

--- a/fe1-web/src/features/notification/screens/SingleNotificationScreen.tsx
+++ b/fe1-web/src/features/notification/screens/SingleNotificationScreen.tsx
@@ -21,7 +21,7 @@ const SingleNotificationScreen = () => {
   const navigation = useNavigation<NavigationProps['navigation']>();
   const { notificationId } = route.params;
 
-  const laoId = NotificationHooks.useAssertCurrentLaoId();
+  const laoId = NotificationHooks.useCurrentLaoId();
 
   const notificationSelector = useMemo(
     () => makeNotificationSelector(laoId.valueOf(), notificationId),

--- a/fe1-web/src/features/notification/screens/__tests__/NotificationScreen.test.tsx
+++ b/fe1-web/src/features/notification/screens/__tests__/NotificationScreen.test.tsx
@@ -23,7 +23,7 @@ import NotificationScreen, { NotificationScreenRightHeader } from '../Notificati
 
 const contextValue = {
   [NOTIFICATION_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     notificationTypes: [WitnessNotificationType],
   } as NotificationReactContext,
 };

--- a/fe1-web/src/features/notification/screens/__tests__/SingleNotificationScreen.test.tsx
+++ b/fe1-web/src/features/notification/screens/__tests__/SingleNotificationScreen.test.tsx
@@ -18,7 +18,7 @@ import SingleNotificationScreen from '../SingleNotificationScreen';
 
 const contextValue = {
   [NOTIFICATION_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     notificationTypes: [WitnessNotificationType],
   } as NotificationReactContext,
 };

--- a/fe1-web/src/features/rollCall/hooks/RollCallHooks.ts
+++ b/fe1-web/src/features/rollCall/hooks/RollCallHooks.ts
@@ -27,7 +27,7 @@ export namespace RollCallHooks {
   /**
    * Gets the current lao id or throws an exception if there is none
    */
-  export const useAssertCurrentLaoId = () => useRollCallContext().useAssertCurrentLaoId();
+  export const useCurrentLaoId = () => useRollCallContext().useCurrentLaoId();
 
   /**
    * Returns true if currently connected to a lao, false if in offline mode

--- a/fe1-web/src/features/rollCall/hooks/__tests__/RollCallHooks.test.tsx
+++ b/fe1-web/src/features/rollCall/hooks/__tests__/RollCallHooks.test.tsx
@@ -57,7 +57,7 @@ const mockHasSeed = jest.fn();
 
 const contextValue = {
   [ROLLCALL_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => false,
     makeEventByTypeSelector,
     generateToken: mockGenerateToken,
@@ -102,9 +102,9 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 );
 
 describe('RollCallHooks', () => {
-  describe('useAssertCurrentLaoId', () => {
+  describe('useCurrentLaoId', () => {
     it('should return the current lao id', () => {
-      const { result } = renderHook(() => RollCallHooks.useAssertCurrentLaoId(), { wrapper });
+      const { result } = renderHook(() => RollCallHooks.useCurrentLaoId(), { wrapper });
       expect(result.current).toEqual(mockLaoIdHash);
     });
   });

--- a/fe1-web/src/features/rollCall/index.ts
+++ b/fe1-web/src/features/rollCall/index.ts
@@ -27,7 +27,7 @@ export function configure(configuration: RollCallConfiguration): RollCallInterfa
       useRollCallAttendeesById: RollCallHooks.useAttendeesByRollCallId,
     },
     context: {
-      useAssertCurrentLaoId: configuration.useAssertCurrentLaoId,
+      useCurrentLaoId: configuration.useCurrentLaoId,
       useConnectedToLao: configuration.useConnectedToLao,
       makeEventByTypeSelector: configuration.makeEventByTypeSelector,
       generateToken: configuration.generateToken,

--- a/fe1-web/src/features/rollCall/interface/Configuration.ts
+++ b/fe1-web/src/features/rollCall/interface/Configuration.ts
@@ -28,7 +28,7 @@ export interface RollCallConfiguration {
    * Should be used inside react components
    * @returns The current lao id
    */
-  useAssertCurrentLaoId: () => Hash;
+  useCurrentLaoId: () => Hash;
 
   /**
    * Returns true if currently connected to a lao, false if in offline mode
@@ -101,11 +101,7 @@ export interface RollCallConfiguration {
  */
 export type RollCallReactContext = Pick<
   RollCallConfiguration,
-  | 'useAssertCurrentLaoId'
-  | 'useConnectedToLao'
-  | 'makeEventByTypeSelector'
-  | 'generateToken'
-  | 'hasSeed'
+  'useCurrentLaoId' | 'useConnectedToLao' | 'makeEventByTypeSelector' | 'generateToken' | 'hasSeed'
 >;
 
 /**

--- a/fe1-web/src/features/rollCall/screens/CreateRollCall.tsx
+++ b/fe1-web/src/features/rollCall/screens/CreateRollCall.tsx
@@ -42,7 +42,7 @@ const CreateRollCall = () => {
   const navigation = useNavigation<NavigationProps['navigation']>();
   const toast = useToast();
 
-  const laoId = RollCallHooks.useAssertCurrentLaoId();
+  const laoId = RollCallHooks.useCurrentLaoId();
   const isConnected = RollCallHooks.useConnectedToLao();
 
   const [proposedStartTime, setProposedStartTime] = useState(Timestamp.EpochNow());

--- a/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
@@ -55,7 +55,7 @@ const RollCallOpened = () => {
   const [inputModalIsVisible, setInputModalIsVisible] = useState(false);
   const toast = useToast();
 
-  const laoId = RollCallHooks.useAssertCurrentLaoId();
+  const laoId = RollCallHooks.useCurrentLaoId();
   const generateToken = RollCallHooks.useGenerateToken();
 
   const rollCallSelector = useMemo(() => makeRollCallSelector(rollCallId), [rollCallId]);

--- a/fe1-web/src/features/rollCall/screens/ViewSingleRollCall.tsx
+++ b/fe1-web/src/features/rollCall/screens/ViewSingleRollCall.tsx
@@ -37,7 +37,7 @@ const ViewSingleRollCall = () => {
   } = route.params;
 
   const selectRollCall = useMemo(() => makeRollCallSelector(rollCallId), [rollCallId]);
-  const laoId = RollCallHooks.useAssertCurrentLaoId();
+  const laoId = RollCallHooks.useCurrentLaoId();
   const isConnected = RollCallHooks.useConnectedToLao();
   const rollCall = useSelector(selectRollCall);
 

--- a/fe1-web/src/features/rollCall/screens/__tests__/CreateRollCall.test.tsx
+++ b/fe1-web/src/features/rollCall/screens/__tests__/CreateRollCall.test.tsx
@@ -11,7 +11,7 @@ import CreateRollCall from '../CreateRollCall';
 
 const contextValue = {
   [ROLLCALL_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => true,
     makeEventByTypeSelector,
     generateToken: jest.fn(),

--- a/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
+++ b/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
@@ -84,7 +84,7 @@ const mockGenerateToken = jest.fn(() => Promise.resolve(mockPopToken));
 
 const contextValue = {
   [ROLLCALL_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => true,
     makeEventByTypeSelector: makeEventByTypeSelector,
     generateToken: mockGenerateToken,

--- a/fe1-web/src/features/rollCall/screens/__tests__/ViewSingleRollCall.test.tsx
+++ b/fe1-web/src/features/rollCall/screens/__tests__/ViewSingleRollCall.test.tsx
@@ -72,7 +72,7 @@ mockStore.dispatch(addRollCall(mockRollCallState));
 
 const contextValue = {
   [ROLLCALL_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => true,
     makeEventByTypeSelector,
     generateToken,

--- a/fe1-web/src/features/wallet/components/__tests__/RollCallWalletItems.test.tsx
+++ b/fe1-web/src/features/wallet/components/__tests__/RollCallWalletItems.test.tsx
@@ -15,7 +15,7 @@ import RollCallWalletItems from '../RollCallWalletItems';
 
 const contextValue = (useRollCallsByLaoId: Record<string, WalletFeature.RollCall>) => ({
   [WALLET_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useCurrentLao: () => mockLao,
     useConnectedToLao: () => true,
     useLaoIds: () => [],

--- a/fe1-web/src/features/wallet/hooks/WalletHooks.ts
+++ b/fe1-web/src/features/wallet/hooks/WalletHooks.ts
@@ -22,7 +22,7 @@ export namespace WalletHooks {
   /**
    * Gets the current lao id, throws error if there is none
    */
-  export const useAssertCurrentLaoId = () => useWalletContext().useAssertCurrentLaoId();
+  export const useCurrentLaoId = () => useWalletContext().useCurrentLaoId();
 
   /**
    * Gets the current lao, throws error if there is none

--- a/fe1-web/src/features/wallet/hooks/__tests__/WalletHooks.test.tsx
+++ b/fe1-web/src/features/wallet/hooks/__tests__/WalletHooks.test.tsx
@@ -34,7 +34,7 @@ const walletNavigationScreens: WalletFeature.WalletScreen[] = [];
 
 const contextValue = {
   [WALLET_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useCurrentLao: () => mockLao,
     useConnectedToLao: () => false,
     getEventById,
@@ -71,9 +71,9 @@ describe('WalletHooks', () => {
     });
   });
 
-  describe('useAssertCurrentLaoId', () => {
+  describe('useCurrentLaoId', () => {
     it('should return the current lao id', () => {
-      const { result } = renderHook(() => WalletHooks.useAssertCurrentLaoId(), { wrapper });
+      const { result } = renderHook(() => WalletHooks.useCurrentLaoId(), { wrapper });
       expect(result.current).toEqual(mockLaoIdHash);
     });
   });

--- a/fe1-web/src/features/wallet/index.ts
+++ b/fe1-web/src/features/wallet/index.ts
@@ -38,7 +38,7 @@ export function compose(configuration: WalletCompositionConfiguration): WalletCo
     context: {
       useRollCallTokensByLaoId: configuration.useRollCallTokensByLaoId,
       useRollCallsByLaoId: configuration.useRollCallsByLaoId,
-      useAssertCurrentLaoId: configuration.useAssertCurrentLaoId,
+      useCurrentLaoId: configuration.useCurrentLaoId,
       useCurrentLao: configuration.useCurrentLao,
       useConnectedToLao: configuration.useConnectedToLao,
       walletItemGenerators: configuration.walletItemGenerators,

--- a/fe1-web/src/features/wallet/interface/Configuration.ts
+++ b/fe1-web/src/features/wallet/interface/Configuration.ts
@@ -53,7 +53,7 @@ export interface WalletCompositionConfiguration {
    * Returns the currently active lao id, throws error if there is none.
    * Should be used inside react components
    */
-  useAssertCurrentLaoId: () => Hash | undefined;
+  useCurrentLaoId: () => Hash;
 
   /**
    * Returns the currently active lao, throws error if there is none.
@@ -111,7 +111,7 @@ export type WalletReactContext = Pick<
   | 'walletItemGenerators'
   | 'walletNavigationScreens'
   /* lao */
-  | 'useAssertCurrentLaoId'
+  | 'useCurrentLaoId'
   | 'useCurrentLao'
   | 'useConnectedToLao'
   /* events */

--- a/fe1-web/src/features/wallet/navigation/WalletNavigation.tsx
+++ b/fe1-web/src/features/wallet/navigation/WalletNavigation.tsx
@@ -31,6 +31,7 @@ export default function WalletNavigation() {
         options={{
           headerTitle: STRINGS.navigation_wallet_home_title,
           headerLeft: () => null,
+          headerRight: () => null,
         }}
       />
       <Stack.Screen

--- a/fe1-web/src/features/wallet/screens/__tests__/WalletHome.test.tsx
+++ b/fe1-web/src/features/wallet/screens/__tests__/WalletHome.test.tsx
@@ -68,7 +68,7 @@ const mockRollCallToken: RollCallToken = {
 
 const contextValue = (rollCallTokens: RollCallToken[]) => ({
   [WALLET_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useCurrentLao: () => mockLao,
     useConnectedToLao: () => true,
     getEventById,
@@ -80,7 +80,7 @@ const contextValue = (rollCallTokens: RollCallToken[]) => ({
     walletNavigationScreens: [],
   } as WalletReactContext,
   [ROLLCALL_FEATURE_IDENTIFIER]: {
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => true,
     generateToken,
     hasSeed,

--- a/fe1-web/src/features/witness/components/WitnessNotification.tsx
+++ b/fe1-web/src/features/witness/components/WitnessNotification.tsx
@@ -25,7 +25,7 @@ const WitnessNotification = ({ notification, navigateToNotificationScreen }: IPr
   const discardNotifications = WitnessHooks.useDiscardNotifications();
   const markNotificationAsRead = WitnessHooks.useMarkNotificationAsRead();
   const isEnabled = WitnessHooks.useIsEnabled();
-  const laoId = WitnessHooks.useAssertCurrentLaoId();
+  const laoId = WitnessHooks.useCurrentLaoId();
   const isConnected = WitnessHooks.useConnectedToLao();
 
   // if the notification state somehow gets out of sync, remove the corresponding notification

--- a/fe1-web/src/features/witness/components/__tests__/WitnessNotification.test.tsx
+++ b/fe1-web/src/features/witness/components/__tests__/WitnessNotification.test.tsx
@@ -80,7 +80,7 @@ mockStore.dispatch(addNotification(mockNotification));
 const contextValue = {
   [WITNESS_FEATURE_IDENTIFIER]: {
     enabled: true,
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => true,
     addNotification: (notification) => mockStore.dispatch(addNotification(notification)),
     discardNotifications: (args) => mockStore.dispatch(discardNotifications(args)),

--- a/fe1-web/src/features/witness/hooks/WitnessHooks.ts
+++ b/fe1-web/src/features/witness/hooks/WitnessHooks.ts
@@ -19,7 +19,7 @@ export namespace WitnessHooks {
   /**
    * A hook returning the current lao id or throws an error of there is none
    */
-  export const useAssertCurrentLaoId = () => useWitnessContext().useAssertCurrentLaoId();
+  export const useCurrentLaoId = () => useWitnessContext().useCurrentLaoId();
 
   /**
    * Returns true if currently connected to a lao, false if in offline mode

--- a/fe1-web/src/features/witness/hooks/__tests__/WitnessHooks.test.tsx
+++ b/fe1-web/src/features/witness/hooks/__tests__/WitnessHooks.test.tsx
@@ -15,7 +15,7 @@ const markNotificationAsRead = jest.fn();
 const contextValue = {
   [WITNESS_FEATURE_IDENTIFIER]: {
     enabled: true,
-    useAssertCurrentLaoId: () => mockLaoIdHash,
+    useCurrentLaoId: () => mockLaoIdHash,
     useConnectedToLao: () => true,
     addNotification,
     discardNotifications,
@@ -30,9 +30,9 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 );
 
 describe('WitnessHooks', () => {
-  describe('useAssertCurrentLaoId', () => {
+  describe('useCurrentLaoId', () => {
     it('should return the correct value', () => {
-      const { result } = renderHook(() => WitnessHooks.useAssertCurrentLaoId(), {
+      const { result } = renderHook(() => WitnessHooks.useCurrentLaoId(), {
         wrapper,
       });
       expect(result.current).toEqual(mockLaoIdHash);

--- a/fe1-web/src/features/witness/index.ts
+++ b/fe1-web/src/features/witness/index.ts
@@ -19,7 +19,7 @@ export function configure(configuration: WitnessConfiguration): WitnessInterface
 
     context: {
       enabled: configuration.enabled,
-      useAssertCurrentLaoId: configuration.useAssertCurrentLaoId,
+      useCurrentLaoId: configuration.useCurrentLaoId,
       useConnectedToLao: configuration.useConnectedToLao,
       addNotification: configuration.addNotification,
       discardNotifications: configuration.discardNotifications,

--- a/fe1-web/src/features/witness/interface/Configuration.ts
+++ b/fe1-web/src/features/witness/interface/Configuration.ts
@@ -29,7 +29,7 @@ export interface WitnessConfiguration {
    * Returns the currently active lao id or throws an error if there is none.
    * Should be used inside react components
    */
-  useAssertCurrentLaoId: () => Hash;
+  useCurrentLaoId: () => Hash;
 
   /**
    * Returns true if currently connected to a lao, false if in offline mode
@@ -73,7 +73,7 @@ export interface WitnessConfiguration {
 export type WitnessReactContext = Pick<
   WitnessConfiguration,
   | 'enabled'
-  | 'useAssertCurrentLaoId'
+  | 'useCurrentLaoId'
   | 'useConnectedToLao'
   | 'addNotification'
   | 'markNotificationAsRead'


### PR DESCRIPTION
This PR removes all occurrences of the old "useCurrentLaoId", renames "useAssertCurrentLaoId" to "useCurrentLaoId".