### PR TITLE
Workaround for react-camera issue

### DIFF
--- a/fe1-web/src/core/components/QrCodeScanner.tsx
+++ b/fe1-web/src/core/components/QrCodeScanner.tsx
@@ -50,6 +50,11 @@ const styles = StyleSheet.create({
   },
 });
 
+/**
+ * Attention: react-camera currently has the problem that the onBarCodeScanned property is only set initially, i.e
+ * the function cannot be changed later meaning if we pass a function that references other variables, they will
+ * only have their proper values if they are mutated which in general should be avoided.
+ */
 const QrCodeScanner = ({ showCamera, children, handleScan }: IPropTypes) => {
   const [permission, requestPermission] = Camera.useCameraPermissions();
   const [cameraType, setCameraType] = useState<CameraType>(CameraType.back);

--- a/fe1-web/src/core/components/QrCodeScanner.tsx
+++ b/fe1-web/src/core/components/QrCodeScanner.tsx
@@ -54,6 +54,7 @@ const styles = StyleSheet.create({
  * Attention: react-camera currently has the problem that the onBarCodeScanned property is only set initially, i.e
  * the function cannot be changed later meaning if we pass a function that references other variables, they will
  * only have their proper values if they are mutated which in general should be avoided.
+ * (2022-12-05, Tyratox) Issue to track this: https://github.com/dedis/popstellar/issues/1306
  */
 const QrCodeScanner = ({ showCamera, children, handleScan }: IPropTypes) => {
   const [permission, requestPermission] = Camera.useCameraPermissions();

--- a/fe1-web/src/features/rollCall/screens/ViewSingleRollCall.tsx
+++ b/fe1-web/src/features/rollCall/screens/ViewSingleRollCall.tsx
@@ -42,8 +42,11 @@ const ViewSingleRollCall = () => {
   const rollCall = useSelector(selectRollCall);
 
   const attendeePopTokens = useMemo(
-    () => attendeePopTokensStrings?.map((k) => new PublicKey(k)),
-    [attendeePopTokensStrings],
+    () => [
+      ...(attendeePopTokensStrings?.map((k) => new PublicKey(k)) || []),
+      ...(rollCall?.attendees || []),
+    ],
+    [attendeePopTokensStrings, rollCall?.attendees],
   );
 
   if (!rollCall) {

--- a/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
+++ b/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
@@ -216,12 +216,17 @@ describe('RollCallOpened', () => {
     renderRollCallOpened(mockAttendeePopTokens);
 
     await waitFor(() => {
-      fakeQrReaderScan(ScannablePopToken.encodePopToken({ pop_token: mockPublicKey2.valueOf() }));
       expect(mockGenerateToken).toHaveBeenCalled();
+      fakeQrReaderScan(ScannablePopToken.encodePopToken({ pop_token: mockPublicKey2.valueOf() }));
+      fakeQrReaderScan(ScannablePopToken.encodePopToken({ pop_token: mockPublicKey3.valueOf() }));
     });
 
     expect(setParams).toHaveBeenCalledWith({
-      attendeePopTokens: [...mockAttendeePopTokens, mockPublicKey2.valueOf()],
+      attendeePopTokens: [
+        ...mockAttendeePopTokens,
+        mockPublicKey2.valueOf(),
+        mockPublicKey3.valueOf(),
+      ],
     });
   });
 });

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
@@ -1965,7 +1965,300 @@ exports[`EventRollCall render correctly non organizers opened roll calls 1`] = `
                                   }
                                 }
                                 testID="RNE__ListItem__Accordion__Children"
-                              />
+                              >
+                                <View
+                                  style={
+                                    Array [
+                                      Object {
+                                        "backgroundColor": "#fff",
+                                      },
+                                      Object {
+                                        "borderTopLeftRadius": 8,
+                                        "borderTopRightRadius": 8,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      Object {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#fff",
+                                        "borderColor": "#bcbbc1",
+                                        "borderTopLeftRadius": 8,
+                                        "borderTopRightRadius": 8,
+                                        "flexDirection": "row",
+                                        "padding": 14,
+                                      }
+                                    }
+                                    testID="RNE__LISTITEM__padView"
+                                  >
+                                    <View
+                                      style={
+                                        Object {
+                                          "marginRight": 16,
+                                        }
+                                      }
+                                    >
+                                      <View>
+                                        {"name":"ios-qr-code","size":25,"color":"#000"}
+                                      </View>
+                                    </View>
+                                    <View
+                                      style={
+                                        Object {
+                                          "paddingLeft": 16,
+                                        }
+                                      }
+                                    />
+                                    <View
+                                      style={
+                                        Array [
+                                          Object {
+                                            "alignItems": "flex-start",
+                                            "flex": 1,
+                                            "justifyContent": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                      theme={
+                                        Object {
+                                          "colors": Object {
+                                            "background": "#ffffff",
+                                            "black": "#242424",
+                                            "disabled": "hsl(208, 8%, 90%)",
+                                            "divider": "#bcbbc1",
+                                            "error": "#ff190c",
+                                            "grey0": "#393e42",
+                                            "grey1": "#43484d",
+                                            "grey2": "#5e6977",
+                                            "grey3": "#86939e",
+                                            "grey4": "#bdc6cf",
+                                            "grey5": "#e1e8ee",
+                                            "greyOutline": "#bbb",
+                                            "platform": Object {
+                                              "android": Object {
+                                                "error": "#f44336",
+                                                "grey": "rgba(0, 0, 0, 0.54)",
+                                                "primary": "#2196f3",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#9C27B0",
+                                                "success": "#4caf50",
+                                                "warning": "#ffeb3b",
+                                              },
+                                              "default": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "ios": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "web": Object {
+                                                "error": "#ff190c",
+                                                "grey": "#393e42",
+                                                "primary": "#2089dc",
+                                                "searchBg": "#303337",
+                                                "secondary": "#ca71eb",
+                                                "success": "#52c41a",
+                                                "warning": "#faad14",
+                                              },
+                                            },
+                                            "primary": "#2089dc",
+                                            "searchBg": "#303337",
+                                            "secondary": "#03dac4",
+                                            "success": "#52c41a",
+                                            "warning": "#faad14",
+                                            "white": "#ffffff",
+                                          },
+                                          "spacing": Object {
+                                            "lg": 12,
+                                            "md": 8,
+                                            "sm": 4,
+                                            "xl": 24,
+                                            "xs": 2,
+                                          },
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="text"
+                                        numberOfLines={1}
+                                        selectable={true}
+                                        style={
+                                          Object {
+                                            "backgroundColor": "transparent",
+                                            "color": "#000",
+                                            "fontSize": 20,
+                                            "lineHeight": 26,
+                                            "textAlign": "left",
+                                          }
+                                        }
+                                        testID="listItemTitle"
+                                      >
+                                        attendee1
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                                <View
+                                  style={
+                                    Array [
+                                      Object {
+                                        "backgroundColor": "#fff",
+                                      },
+                                      Object {
+                                        "borderBottomLeftRadius": 8,
+                                        "borderBottomRightRadius": 8,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      Object {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#fff",
+                                        "borderBottomLeftRadius": 8,
+                                        "borderBottomRightRadius": 8,
+                                        "borderColor": "#bcbbc1",
+                                        "flexDirection": "row",
+                                        "padding": 14,
+                                      }
+                                    }
+                                    testID="RNE__LISTITEM__padView"
+                                  >
+                                    <View
+                                      style={
+                                        Object {
+                                          "marginRight": 16,
+                                        }
+                                      }
+                                    >
+                                      <View>
+                                        {"name":"ios-qr-code","size":25,"color":"#000"}
+                                      </View>
+                                    </View>
+                                    <View
+                                      style={
+                                        Object {
+                                          "paddingLeft": 16,
+                                        }
+                                      }
+                                    />
+                                    <View
+                                      style={
+                                        Array [
+                                          Object {
+                                            "alignItems": "flex-start",
+                                            "flex": 1,
+                                            "justifyContent": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                      theme={
+                                        Object {
+                                          "colors": Object {
+                                            "background": "#ffffff",
+                                            "black": "#242424",
+                                            "disabled": "hsl(208, 8%, 90%)",
+                                            "divider": "#bcbbc1",
+                                            "error": "#ff190c",
+                                            "grey0": "#393e42",
+                                            "grey1": "#43484d",
+                                            "grey2": "#5e6977",
+                                            "grey3": "#86939e",
+                                            "grey4": "#bdc6cf",
+                                            "grey5": "#e1e8ee",
+                                            "greyOutline": "#bbb",
+                                            "platform": Object {
+                                              "android": Object {
+                                                "error": "#f44336",
+                                                "grey": "rgba(0, 0, 0, 0.54)",
+                                                "primary": "#2196f3",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#9C27B0",
+                                                "success": "#4caf50",
+                                                "warning": "#ffeb3b",
+                                              },
+                                              "default": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "ios": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "web": Object {
+                                                "error": "#ff190c",
+                                                "grey": "#393e42",
+                                                "primary": "#2089dc",
+                                                "searchBg": "#303337",
+                                                "secondary": "#ca71eb",
+                                                "success": "#52c41a",
+                                                "warning": "#faad14",
+                                              },
+                                            },
+                                            "primary": "#2089dc",
+                                            "searchBg": "#303337",
+                                            "secondary": "#03dac4",
+                                            "success": "#52c41a",
+                                            "warning": "#faad14",
+                                            "white": "#ffffff",
+                                          },
+                                          "spacing": Object {
+                                            "lg": 12,
+                                            "md": 8,
+                                            "sm": 4,
+                                            "xl": 24,
+                                            "xs": 2,
+                                          },
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="text"
+                                        numberOfLines={1}
+                                        selectable={true}
+                                        style={
+                                          Object {
+                                            "backgroundColor": "transparent",
+                                            "color": "#000",
+                                            "fontSize": 20,
+                                            "lineHeight": 26,
+                                            "textAlign": "left",
+                                          }
+                                        }
+                                        testID="listItemTitle"
+                                      >
+                                        attendee2
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
                             </View>
                           </View>
                         </RCTScrollView>
@@ -2608,7 +2901,300 @@ exports[`EventRollCall render correctly non organizers re-opened roll calls 1`] 
                                   }
                                 }
                                 testID="RNE__ListItem__Accordion__Children"
-                              />
+                              >
+                                <View
+                                  style={
+                                    Array [
+                                      Object {
+                                        "backgroundColor": "#fff",
+                                      },
+                                      Object {
+                                        "borderTopLeftRadius": 8,
+                                        "borderTopRightRadius": 8,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      Object {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#fff",
+                                        "borderColor": "#bcbbc1",
+                                        "borderTopLeftRadius": 8,
+                                        "borderTopRightRadius": 8,
+                                        "flexDirection": "row",
+                                        "padding": 14,
+                                      }
+                                    }
+                                    testID="RNE__LISTITEM__padView"
+                                  >
+                                    <View
+                                      style={
+                                        Object {
+                                          "marginRight": 16,
+                                        }
+                                      }
+                                    >
+                                      <View>
+                                        {"name":"ios-qr-code","size":25,"color":"#000"}
+                                      </View>
+                                    </View>
+                                    <View
+                                      style={
+                                        Object {
+                                          "paddingLeft": 16,
+                                        }
+                                      }
+                                    />
+                                    <View
+                                      style={
+                                        Array [
+                                          Object {
+                                            "alignItems": "flex-start",
+                                            "flex": 1,
+                                            "justifyContent": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                      theme={
+                                        Object {
+                                          "colors": Object {
+                                            "background": "#ffffff",
+                                            "black": "#242424",
+                                            "disabled": "hsl(208, 8%, 90%)",
+                                            "divider": "#bcbbc1",
+                                            "error": "#ff190c",
+                                            "grey0": "#393e42",
+                                            "grey1": "#43484d",
+                                            "grey2": "#5e6977",
+                                            "grey3": "#86939e",
+                                            "grey4": "#bdc6cf",
+                                            "grey5": "#e1e8ee",
+                                            "greyOutline": "#bbb",
+                                            "platform": Object {
+                                              "android": Object {
+                                                "error": "#f44336",
+                                                "grey": "rgba(0, 0, 0, 0.54)",
+                                                "primary": "#2196f3",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#9C27B0",
+                                                "success": "#4caf50",
+                                                "warning": "#ffeb3b",
+                                              },
+                                              "default": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "ios": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "web": Object {
+                                                "error": "#ff190c",
+                                                "grey": "#393e42",
+                                                "primary": "#2089dc",
+                                                "searchBg": "#303337",
+                                                "secondary": "#ca71eb",
+                                                "success": "#52c41a",
+                                                "warning": "#faad14",
+                                              },
+                                            },
+                                            "primary": "#2089dc",
+                                            "searchBg": "#303337",
+                                            "secondary": "#03dac4",
+                                            "success": "#52c41a",
+                                            "warning": "#faad14",
+                                            "white": "#ffffff",
+                                          },
+                                          "spacing": Object {
+                                            "lg": 12,
+                                            "md": 8,
+                                            "sm": 4,
+                                            "xl": 24,
+                                            "xs": 2,
+                                          },
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="text"
+                                        numberOfLines={1}
+                                        selectable={true}
+                                        style={
+                                          Object {
+                                            "backgroundColor": "transparent",
+                                            "color": "#000",
+                                            "fontSize": 20,
+                                            "lineHeight": 26,
+                                            "textAlign": "left",
+                                          }
+                                        }
+                                        testID="listItemTitle"
+                                      >
+                                        attendee1
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                                <View
+                                  style={
+                                    Array [
+                                      Object {
+                                        "backgroundColor": "#fff",
+                                      },
+                                      Object {
+                                        "borderBottomLeftRadius": 8,
+                                        "borderBottomRightRadius": 8,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      Object {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#fff",
+                                        "borderBottomLeftRadius": 8,
+                                        "borderBottomRightRadius": 8,
+                                        "borderColor": "#bcbbc1",
+                                        "flexDirection": "row",
+                                        "padding": 14,
+                                      }
+                                    }
+                                    testID="RNE__LISTITEM__padView"
+                                  >
+                                    <View
+                                      style={
+                                        Object {
+                                          "marginRight": 16,
+                                        }
+                                      }
+                                    >
+                                      <View>
+                                        {"name":"ios-qr-code","size":25,"color":"#000"}
+                                      </View>
+                                    </View>
+                                    <View
+                                      style={
+                                        Object {
+                                          "paddingLeft": 16,
+                                        }
+                                      }
+                                    />
+                                    <View
+                                      style={
+                                        Array [
+                                          Object {
+                                            "alignItems": "flex-start",
+                                            "flex": 1,
+                                            "justifyContent": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                      theme={
+                                        Object {
+                                          "colors": Object {
+                                            "background": "#ffffff",
+                                            "black": "#242424",
+                                            "disabled": "hsl(208, 8%, 90%)",
+                                            "divider": "#bcbbc1",
+                                            "error": "#ff190c",
+                                            "grey0": "#393e42",
+                                            "grey1": "#43484d",
+                                            "grey2": "#5e6977",
+                                            "grey3": "#86939e",
+                                            "grey4": "#bdc6cf",
+                                            "grey5": "#e1e8ee",
+                                            "greyOutline": "#bbb",
+                                            "platform": Object {
+                                              "android": Object {
+                                                "error": "#f44336",
+                                                "grey": "rgba(0, 0, 0, 0.54)",
+                                                "primary": "#2196f3",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#9C27B0",
+                                                "success": "#4caf50",
+                                                "warning": "#ffeb3b",
+                                              },
+                                              "default": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "ios": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "web": Object {
+                                                "error": "#ff190c",
+                                                "grey": "#393e42",
+                                                "primary": "#2089dc",
+                                                "searchBg": "#303337",
+                                                "secondary": "#ca71eb",
+                                                "success": "#52c41a",
+                                                "warning": "#faad14",
+                                              },
+                                            },
+                                            "primary": "#2089dc",
+                                            "searchBg": "#303337",
+                                            "secondary": "#03dac4",
+                                            "success": "#52c41a",
+                                            "warning": "#faad14",
+                                            "white": "#ffffff",
+                                          },
+                                          "spacing": Object {
+                                            "lg": 12,
+                                            "md": 8,
+                                            "sm": 4,
+                                            "xl": 24,
+                                            "xs": 2,
+                                          },
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="text"
+                                        numberOfLines={1}
+                                        selectable={true}
+                                        style={
+                                          Object {
+                                            "backgroundColor": "transparent",
+                                            "color": "#000",
+                                            "fontSize": 20,
+                                            "lineHeight": 26,
+                                            "textAlign": "left",
+                                          }
+                                        }
+                                        testID="listItemTitle"
+                                      >
+                                        attendee2
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
                             </View>
                           </View>
                         </RCTScrollView>
@@ -4542,19 +5128,6 @@ exports[`EventRollCall render correctly organizers opened roll calls 1`] = `
                                 1 day from now
                               </time>
                             </Text>
-                            <Text
-                              style={
-                                Object {
-                                  "color": "#000",
-                                  "fontSize": 20,
-                                  "lineHeight": 26,
-                                  "marginBottom": 16,
-                                  "textAlign": "left",
-                                }
-                              }
-                            >
-                              The Roll Call is currently open and you as the organizer should start adding attendees by scanning their PoP tokens.
-                            </Text>
                             <View
                               style={
                                 Object {
@@ -4741,7 +5314,300 @@ exports[`EventRollCall render correctly organizers opened roll calls 1`] = `
                                   }
                                 }
                                 testID="RNE__ListItem__Accordion__Children"
-                              />
+                              >
+                                <View
+                                  style={
+                                    Array [
+                                      Object {
+                                        "backgroundColor": "#fff",
+                                      },
+                                      Object {
+                                        "borderTopLeftRadius": 8,
+                                        "borderTopRightRadius": 8,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      Object {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#fff",
+                                        "borderColor": "#bcbbc1",
+                                        "borderTopLeftRadius": 8,
+                                        "borderTopRightRadius": 8,
+                                        "flexDirection": "row",
+                                        "padding": 14,
+                                      }
+                                    }
+                                    testID="RNE__LISTITEM__padView"
+                                  >
+                                    <View
+                                      style={
+                                        Object {
+                                          "marginRight": 16,
+                                        }
+                                      }
+                                    >
+                                      <View>
+                                        {"name":"ios-qr-code","size":25,"color":"#000"}
+                                      </View>
+                                    </View>
+                                    <View
+                                      style={
+                                        Object {
+                                          "paddingLeft": 16,
+                                        }
+                                      }
+                                    />
+                                    <View
+                                      style={
+                                        Array [
+                                          Object {
+                                            "alignItems": "flex-start",
+                                            "flex": 1,
+                                            "justifyContent": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                      theme={
+                                        Object {
+                                          "colors": Object {
+                                            "background": "#ffffff",
+                                            "black": "#242424",
+                                            "disabled": "hsl(208, 8%, 90%)",
+                                            "divider": "#bcbbc1",
+                                            "error": "#ff190c",
+                                            "grey0": "#393e42",
+                                            "grey1": "#43484d",
+                                            "grey2": "#5e6977",
+                                            "grey3": "#86939e",
+                                            "grey4": "#bdc6cf",
+                                            "grey5": "#e1e8ee",
+                                            "greyOutline": "#bbb",
+                                            "platform": Object {
+                                              "android": Object {
+                                                "error": "#f44336",
+                                                "grey": "rgba(0, 0, 0, 0.54)",
+                                                "primary": "#2196f3",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#9C27B0",
+                                                "success": "#4caf50",
+                                                "warning": "#ffeb3b",
+                                              },
+                                              "default": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "ios": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "web": Object {
+                                                "error": "#ff190c",
+                                                "grey": "#393e42",
+                                                "primary": "#2089dc",
+                                                "searchBg": "#303337",
+                                                "secondary": "#ca71eb",
+                                                "success": "#52c41a",
+                                                "warning": "#faad14",
+                                              },
+                                            },
+                                            "primary": "#2089dc",
+                                            "searchBg": "#303337",
+                                            "secondary": "#03dac4",
+                                            "success": "#52c41a",
+                                            "warning": "#faad14",
+                                            "white": "#ffffff",
+                                          },
+                                          "spacing": Object {
+                                            "lg": 12,
+                                            "md": 8,
+                                            "sm": 4,
+                                            "xl": 24,
+                                            "xs": 2,
+                                          },
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="text"
+                                        numberOfLines={1}
+                                        selectable={true}
+                                        style={
+                                          Object {
+                                            "backgroundColor": "transparent",
+                                            "color": "#000",
+                                            "fontSize": 20,
+                                            "lineHeight": 26,
+                                            "textAlign": "left",
+                                          }
+                                        }
+                                        testID="listItemTitle"
+                                      >
+                                        attendee1
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                                <View
+                                  style={
+                                    Array [
+                                      Object {
+                                        "backgroundColor": "#fff",
+                                      },
+                                      Object {
+                                        "borderBottomLeftRadius": 8,
+                                        "borderBottomRightRadius": 8,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      Object {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#fff",
+                                        "borderBottomLeftRadius": 8,
+                                        "borderBottomRightRadius": 8,
+                                        "borderColor": "#bcbbc1",
+                                        "flexDirection": "row",
+                                        "padding": 14,
+                                      }
+                                    }
+                                    testID="RNE__LISTITEM__padView"
+                                  >
+                                    <View
+                                      style={
+                                        Object {
+                                          "marginRight": 16,
+                                        }
+                                      }
+                                    >
+                                      <View>
+                                        {"name":"ios-qr-code","size":25,"color":"#000"}
+                                      </View>
+                                    </View>
+                                    <View
+                                      style={
+                                        Object {
+                                          "paddingLeft": 16,
+                                        }
+                                      }
+                                    />
+                                    <View
+                                      style={
+                                        Array [
+                                          Object {
+                                            "alignItems": "flex-start",
+                                            "flex": 1,
+                                            "justifyContent": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                      theme={
+                                        Object {
+                                          "colors": Object {
+                                            "background": "#ffffff",
+                                            "black": "#242424",
+                                            "disabled": "hsl(208, 8%, 90%)",
+                                            "divider": "#bcbbc1",
+                                            "error": "#ff190c",
+                                            "grey0": "#393e42",
+                                            "grey1": "#43484d",
+                                            "grey2": "#5e6977",
+                                            "grey3": "#86939e",
+                                            "grey4": "#bdc6cf",
+                                            "grey5": "#e1e8ee",
+                                            "greyOutline": "#bbb",
+                                            "platform": Object {
+                                              "android": Object {
+                                                "error": "#f44336",
+                                                "grey": "rgba(0, 0, 0, 0.54)",
+                                                "primary": "#2196f3",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#9C27B0",
+                                                "success": "#4caf50",
+                                                "warning": "#ffeb3b",
+                                              },
+                                              "default": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "ios": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "web": Object {
+                                                "error": "#ff190c",
+                                                "grey": "#393e42",
+                                                "primary": "#2089dc",
+                                                "searchBg": "#303337",
+                                                "secondary": "#ca71eb",
+                                                "success": "#52c41a",
+                                                "warning": "#faad14",
+                                              },
+                                            },
+                                            "primary": "#2089dc",
+                                            "searchBg": "#303337",
+                                            "secondary": "#03dac4",
+                                            "success": "#52c41a",
+                                            "warning": "#faad14",
+                                            "white": "#ffffff",
+                                          },
+                                          "spacing": Object {
+                                            "lg": 12,
+                                            "md": 8,
+                                            "sm": 4,
+                                            "xl": 24,
+                                            "xs": 2,
+                                          },
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="text"
+                                        numberOfLines={1}
+                                        selectable={true}
+                                        style={
+                                          Object {
+                                            "backgroundColor": "transparent",
+                                            "color": "#000",
+                                            "fontSize": 20,
+                                            "lineHeight": 26,
+                                            "textAlign": "left",
+                                          }
+                                        }
+                                        testID="listItemTitle"
+                                      >
+                                        attendee2
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
                             </View>
                           </View>
                         </RCTScrollView>
@@ -5326,19 +6192,6 @@ exports[`EventRollCall render correctly organizers re-opened roll calls 1`] = `
                                 1 day from now
                               </time>
                             </Text>
-                            <Text
-                              style={
-                                Object {
-                                  "color": "#000",
-                                  "fontSize": 20,
-                                  "lineHeight": 26,
-                                  "marginBottom": 16,
-                                  "textAlign": "left",
-                                }
-                              }
-                            >
-                              The Roll Call is currently open and you as the organizer should start adding attendees by scanning their PoP tokens.
-                            </Text>
                             <View
                               style={
                                 Object {
@@ -5548,7 +6401,300 @@ exports[`EventRollCall render correctly organizers re-opened roll calls 1`] = `
                                   }
                                 }
                                 testID="RNE__ListItem__Accordion__Children"
-                              />
+                              >
+                                <View
+                                  style={
+                                    Array [
+                                      Object {
+                                        "backgroundColor": "#fff",
+                                      },
+                                      Object {
+                                        "borderTopLeftRadius": 8,
+                                        "borderTopRightRadius": 8,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      Object {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#fff",
+                                        "borderColor": "#bcbbc1",
+                                        "borderTopLeftRadius": 8,
+                                        "borderTopRightRadius": 8,
+                                        "flexDirection": "row",
+                                        "padding": 14,
+                                      }
+                                    }
+                                    testID="RNE__LISTITEM__padView"
+                                  >
+                                    <View
+                                      style={
+                                        Object {
+                                          "marginRight": 16,
+                                        }
+                                      }
+                                    >
+                                      <View>
+                                        {"name":"ios-qr-code","size":25,"color":"#000"}
+                                      </View>
+                                    </View>
+                                    <View
+                                      style={
+                                        Object {
+                                          "paddingLeft": 16,
+                                        }
+                                      }
+                                    />
+                                    <View
+                                      style={
+                                        Array [
+                                          Object {
+                                            "alignItems": "flex-start",
+                                            "flex": 1,
+                                            "justifyContent": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                      theme={
+                                        Object {
+                                          "colors": Object {
+                                            "background": "#ffffff",
+                                            "black": "#242424",
+                                            "disabled": "hsl(208, 8%, 90%)",
+                                            "divider": "#bcbbc1",
+                                            "error": "#ff190c",
+                                            "grey0": "#393e42",
+                                            "grey1": "#43484d",
+                                            "grey2": "#5e6977",
+                                            "grey3": "#86939e",
+                                            "grey4": "#bdc6cf",
+                                            "grey5": "#e1e8ee",
+                                            "greyOutline": "#bbb",
+                                            "platform": Object {
+                                              "android": Object {
+                                                "error": "#f44336",
+                                                "grey": "rgba(0, 0, 0, 0.54)",
+                                                "primary": "#2196f3",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#9C27B0",
+                                                "success": "#4caf50",
+                                                "warning": "#ffeb3b",
+                                              },
+                                              "default": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "ios": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "web": Object {
+                                                "error": "#ff190c",
+                                                "grey": "#393e42",
+                                                "primary": "#2089dc",
+                                                "searchBg": "#303337",
+                                                "secondary": "#ca71eb",
+                                                "success": "#52c41a",
+                                                "warning": "#faad14",
+                                              },
+                                            },
+                                            "primary": "#2089dc",
+                                            "searchBg": "#303337",
+                                            "secondary": "#03dac4",
+                                            "success": "#52c41a",
+                                            "warning": "#faad14",
+                                            "white": "#ffffff",
+                                          },
+                                          "spacing": Object {
+                                            "lg": 12,
+                                            "md": 8,
+                                            "sm": 4,
+                                            "xl": 24,
+                                            "xs": 2,
+                                          },
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="text"
+                                        numberOfLines={1}
+                                        selectable={true}
+                                        style={
+                                          Object {
+                                            "backgroundColor": "transparent",
+                                            "color": "#000",
+                                            "fontSize": 20,
+                                            "lineHeight": 26,
+                                            "textAlign": "left",
+                                          }
+                                        }
+                                        testID="listItemTitle"
+                                      >
+                                        attendee1
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                                <View
+                                  style={
+                                    Array [
+                                      Object {
+                                        "backgroundColor": "#fff",
+                                      },
+                                      Object {
+                                        "borderBottomLeftRadius": 8,
+                                        "borderBottomRightRadius": 8,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      Object {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#fff",
+                                        "borderBottomLeftRadius": 8,
+                                        "borderBottomRightRadius": 8,
+                                        "borderColor": "#bcbbc1",
+                                        "flexDirection": "row",
+                                        "padding": 14,
+                                      }
+                                    }
+                                    testID="RNE__LISTITEM__padView"
+                                  >
+                                    <View
+                                      style={
+                                        Object {
+                                          "marginRight": 16,
+                                        }
+                                      }
+                                    >
+                                      <View>
+                                        {"name":"ios-qr-code","size":25,"color":"#000"}
+                                      </View>
+                                    </View>
+                                    <View
+                                      style={
+                                        Object {
+                                          "paddingLeft": 16,
+                                        }
+                                      }
+                                    />
+                                    <View
+                                      style={
+                                        Array [
+                                          Object {
+                                            "alignItems": "flex-start",
+                                            "flex": 1,
+                                            "justifyContent": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                      theme={
+                                        Object {
+                                          "colors": Object {
+                                            "background": "#ffffff",
+                                            "black": "#242424",
+                                            "disabled": "hsl(208, 8%, 90%)",
+                                            "divider": "#bcbbc1",
+                                            "error": "#ff190c",
+                                            "grey0": "#393e42",
+                                            "grey1": "#43484d",
+                                            "grey2": "#5e6977",
+                                            "grey3": "#86939e",
+                                            "grey4": "#bdc6cf",
+                                            "grey5": "#e1e8ee",
+                                            "greyOutline": "#bbb",
+                                            "platform": Object {
+                                              "android": Object {
+                                                "error": "#f44336",
+                                                "grey": "rgba(0, 0, 0, 0.54)",
+                                                "primary": "#2196f3",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#9C27B0",
+                                                "success": "#4caf50",
+                                                "warning": "#ffeb3b",
+                                              },
+                                              "default": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "ios": Object {
+                                                "error": "#ff3b30",
+                                                "grey": "#7d7d7d",
+                                                "primary": "#007aff",
+                                                "searchBg": "#dcdce1",
+                                                "secondary": "#5856d6",
+                                                "success": "#4cd964",
+                                                "warning": "#ffcc00",
+                                              },
+                                              "web": Object {
+                                                "error": "#ff190c",
+                                                "grey": "#393e42",
+                                                "primary": "#2089dc",
+                                                "searchBg": "#303337",
+                                                "secondary": "#ca71eb",
+                                                "success": "#52c41a",
+                                                "warning": "#faad14",
+                                              },
+                                            },
+                                            "primary": "#2089dc",
+                                            "searchBg": "#303337",
+                                            "secondary": "#03dac4",
+                                            "success": "#52c41a",
+                                            "warning": "#faad14",
+                                            "white": "#ffffff",
+                                          },
+                                          "spacing": Object {
+                                            "lg": 12,
+                                            "md": 8,
+                                            "sm": 4,
+                                            "xl": 24,
+                                            "xs": 2,
+                                          },
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="text"
+                                        numberOfLines={1}
+                                        selectable={true}
+                                        style={
+                                          Object {
+                                            "backgroundColor": "transparent",
+                                            "color": "#000",
+                                            "fontSize": 20,
+                                            "lineHeight": 26,
+                                            "textAlign": "left",
+                                          }
+                                        }
+                                        testID="listItemTitle"
+                                      >
+                                        attendee2
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
                             </View>
                           </View>
                         </RCTScrollView>


### PR DESCRIPTION
This PR fixes the issue discovered today where no more than 2 attendees can be added to a roll call. The problem is actually not directly our code but rather a bug in `react-camera`.

It seems as if the barcodescanner handle function is only set initially by expo-camera and if the passed prop changes,  this is ignored. Hence variables such as the current list of attendees referenced by the function won‘t update. You can see the problem in this snack: https://snack.expo.dev/0MS_5nPEp. Observer the counter value after scanning a few qr codes. Previously this problem did not occur since `setState(oldState => …)` was used where `oldState` received in the callback is always the latest and the reference to `setState` did not change. This PR works around this issue by additionally using a mutable reference that allows for proper duplicate checking which most likely was broken since the migration to `react-camera`.