### PR TITLE
fix Scala tests redundant error

### DIFF
--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandlerTest.scala
@@ -57,7 +57,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
           system.log.info(s"Received - error $x")
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-NACK")
+    system.actorOf(dbActorMock)
   }
 
   def mockDbWithAck: AskableActorRef = {
@@ -78,7 +78,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
           sender() ! DbActor.DbActorReadElectionDataAck(electionData)
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-ACK")
+    system.actorOf(dbActorMock)
   }
 
   def mockDbElectionNotSetUp: AskableActorRef = {
@@ -103,7 +103,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
           sender() ! DbActor.DbActorReadElectionDataAck(electionData)
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-ElectionNotCreated")
+    system.actorOf(dbActorMock)
   }
 
   def mockDbElectionSecretBallotReadFailed: AskableActorRef = {
@@ -124,7 +124,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
           sender() ! Status.Failure(DbActorNAckException(1, "no"))
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-ElectionNotCreated")
+    system.actorOf(dbActorMock)
   }
 
   def mockDbWithAckEndElection: AskableActorRef = {
@@ -164,7 +164,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
           sender() ! DbActor.DbActorCatchupAck(messages)
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-ACK-EndElection")
+    system.actorOf(dbActorMock)
   }
 
   def mockDbWithNAckEndElection: AskableActorRef = {
@@ -197,7 +197,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
           sender() ! Status.Failure(DbActorNAckException(1, "error"))
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-NACK-EndElection")
+    system.actorOf(dbActorMock)
   }
 
   test("SetupElection should fail if the database fails storing the message") {

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandlerTest.scala
@@ -36,7 +36,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
           system.log.info(s"Received - error $x")
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-NACK")
+    system.actorOf(dbActorMock)
   }
 
   def mockDbRollCallNotCreated: AskableActorRef = {
@@ -63,7 +63,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
           system.log.info(s"Received - error $x")
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-RollCallNotCreated")
+    system.actorOf(dbActorMock)
   }
 
   def mockDbRollCallAlreadyCreated: AskableActorRef = {
@@ -86,7 +86,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
           system.log.info(s"Received - error $x")
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-RollCallAlreadyCreated")
+    system.actorOf(dbActorMock)
   }
 
   test("CreateRollCall should fail if the database fails storing the message") {

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandlerSuite.scala
@@ -36,7 +36,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
           sender() ! Status.Failure(DbActorNAckException(1, "error"))
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-NACK")
+    system.actorOf(dbActorMock)
   }
 
   def mockDbWithAck: AskableActorRef = {
@@ -56,7 +56,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
           sender() ! DbActor.DbActorReadLaoDataAck(LaoDataExample.LAODATA)
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-ACK")
+    system.actorOf(dbActorMock)
   }
 
   def mockDbWithAckAndNotifyNAck: AskableActorRef = {
@@ -83,7 +83,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
           sender() ! DbActor.DbActorReadLaoDataAck(LaoDataExample.LAODATA)
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-ACK-NAck-on-Notify")
+    system.actorOf(dbActorMock)
   }
 
   def mockDbWithAckButEmptyAckLaoData: AskableActorRef = {
@@ -103,7 +103,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
           sender() ! Status.Failure(DbActorNAckException(1, "No corresponding lao data (mocked)"))
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-ACK-EmptyAckLaoData")
+    system.actorOf(dbActorMock)
   }
 
   def mockDbWithAckButNAckLaoData: AskableActorRef = {
@@ -123,7 +123,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
           sender() ! Status.Failure(DbActorNAckException(1, "error"))
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-ACK-NAckLaoData")
+    system.actorOf(dbActorMock)
   }
 
   test("AddReaction fails if the database fails storing the message") {

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandlerTest.scala
@@ -54,7 +54,7 @@ class WitnessHandlerTest extends TestKit(ActorSystem("Witness-DB-System")) with 
           system.log.info(s"Received - error $x")
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-NACK")
+    system.actorOf(dbActorMock)
   }
 
   def mockDbWithAck: AskableActorRef = {
@@ -72,7 +72,7 @@ class WitnessHandlerTest extends TestKit(ActorSystem("Witness-DB-System")) with 
           system.log.info(s"Received - error $x")
       }
     })
-    system.actorOf(dbActorMock, "MockedDB-ACK")
+    system.actorOf(dbActorMock)
   }
 
   def mockDbWithNackAddWitnessSignature: AskableActorRef = {
@@ -90,7 +90,7 @@ class WitnessHandlerTest extends TestKit(ActorSystem("Witness-DB-System")) with 
           system.log.info(s"Received - error $x")
       }
     })
-    system.actorOf(dbActorMock, "MockedDBAddWitnessSignature-ACK")
+    system.actorOf(dbActorMock)
   }
 
   test("WitnessMessage fails if the database fails storing the message") {


### PR DESCRIPTION
remove non-unique Actor names that could conflict due to tests running in parallel