### PR TITLE
Make reaction buttons less attention grabbing

### DIFF
--- a/fe1-web/src/core/components/PoPIconButton.tsx
+++ b/fe1-web/src/core/components/PoPIconButton.tsx
@@ -15,6 +15,18 @@ const SIZE_MAP = {
 const PoPIconButton = (props: IPropTypes) => {
   const { onPress, buttonStyle, disabled, toolbar, size, testID, name } = props;
 
+  let iconColor = Color.contrast;
+
+  if (buttonStyle === 'secondary') {
+    // in case of an outlined button, the icon color
+    // should be the same as the border's
+    if (disabled) {
+      iconColor = Color.inactive;
+    } else {
+      iconColor = Color.accent;
+    }
+  }
+
   return (
     <PoPButton
       onPress={onPress}
@@ -22,11 +34,7 @@ const PoPIconButton = (props: IPropTypes) => {
       disabled={disabled}
       toolbar={toolbar}
       testID={testID}>
-      <PoPIcon
-        name={name}
-        size={SIZE_MAP[size]}
-        color={buttonStyle === 'primary' ? Color.contrast : Color.accent}
-      />
+      <PoPIcon name={name} size={SIZE_MAP[size]} color={iconColor} />
     </PoPButton>
   );
 };

--- a/fe1-web/src/features/social/components/ChirpCard.tsx
+++ b/fe1-web/src/features/social/components/ChirpCard.tsx
@@ -198,6 +198,7 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
                   onPress={() => addReaction('👍')}
                   disabled={reactionsDisabled['👍']}
                   size="small"
+                  buttonStyle="secondary"
                   toolbar
                 />
                 <Text style={[Typography.base, Typography.small, styles.reactionCounter]}>
@@ -211,6 +212,7 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
                   onPress={() => addReaction('👎')}
                   disabled={reactionsDisabled['👎']}
                   size="small"
+                  buttonStyle="secondary"
                   toolbar
                 />
                 <Text style={[Typography.base, Typography.small, styles.reactionCounter]}>
@@ -224,6 +226,7 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
                   onPress={() => addReaction('❤️')}
                   disabled={reactionsDisabled['❤️']}
                   size="small"
+                  buttonStyle="secondary"
                   toolbar
                 />
                 <Text style={[Typography.base, Typography.small, styles.reactionCounter]}>
@@ -237,6 +240,7 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
                     testID="chirp_action_options"
                     onPress={() => showActionSheet(actionSheetOptions)}
                     size="small"
+                    buttonStyle="secondary"
                     toolbar
                   />
                 </View>

--- a/fe1-web/src/features/social/components/__tests__/__snapshots__/ChirpCard.test.tsx.snap
+++ b/fe1-web/src/features/social/components/__tests__/__snapshots__/ChirpCard.test.tsx.snap
@@ -1199,11 +1199,14 @@ exports[`ChirpCard for deletion renders correctly for non-sender 1`] = `
                                               "backgroundColor": "#8E8E8E",
                                               "borderColor": "#8E8E8E",
                                             },
+                                            Object {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"thumbs-up-sharp","size":16,"color":"#fff"}
+                                          {"name":"thumbs-up-sharp","size":16,"color":"#8E8E8E"}
                                         </View>
                                       </View>
                                     </View>
@@ -1288,11 +1291,14 @@ exports[`ChirpCard for deletion renders correctly for non-sender 1`] = `
                                               "borderWidth": 1,
                                               "padding": 8,
                                             },
+                                            Object {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"thumbs-down-sharp","size":16,"color":"#fff"}
+                                          {"name":"thumbs-down-sharp","size":16,"color":"#3742fa"}
                                         </View>
                                       </View>
                                     </View>
@@ -1377,11 +1383,14 @@ exports[`ChirpCard for deletion renders correctly for non-sender 1`] = `
                                               "borderWidth": 1,
                                               "padding": 8,
                                             },
+                                            Object {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"heart","size":16,"color":"#fff"}
+                                          {"name":"heart","size":16,"color":"#3742fa"}
                                         </View>
                                       </View>
                                     </View>
@@ -2065,11 +2074,14 @@ exports[`ChirpCard for deletion renders correctly for sender 1`] = `
                                               "backgroundColor": "#8E8E8E",
                                               "borderColor": "#8E8E8E",
                                             },
+                                            Object {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"thumbs-up-sharp","size":16,"color":"#fff"}
+                                          {"name":"thumbs-up-sharp","size":16,"color":"#8E8E8E"}
                                         </View>
                                       </View>
                                     </View>
@@ -2154,11 +2166,14 @@ exports[`ChirpCard for deletion renders correctly for sender 1`] = `
                                               "borderWidth": 1,
                                               "padding": 8,
                                             },
+                                            Object {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"thumbs-down-sharp","size":16,"color":"#fff"}
+                                          {"name":"thumbs-down-sharp","size":16,"color":"#3742fa"}
                                         </View>
                                       </View>
                                     </View>
@@ -2243,11 +2258,14 @@ exports[`ChirpCard for deletion renders correctly for sender 1`] = `
                                               "borderWidth": 1,
                                               "padding": 8,
                                             },
+                                            Object {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"heart","size":16,"color":"#fff"}
+                                          {"name":"heart","size":16,"color":"#3742fa"}
                                         </View>
                                       </View>
                                     </View>
@@ -2332,11 +2350,14 @@ exports[`ChirpCard for deletion renders correctly for sender 1`] = `
                                               "borderWidth": 1,
                                               "padding": 8,
                                             },
+                                            Object {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"ios-ellipsis-horizontal","size":16,"color":"#fff"}
+                                          {"name":"ios-ellipsis-horizontal","size":16,"color":"#3742fa"}
                                         </View>
                                       </View>
                                     </View>
@@ -2999,11 +3020,14 @@ exports[`ChirpCard for reaction renders correctly with reaction 1`] = `
                                               "backgroundColor": "#8E8E8E",
                                               "borderColor": "#8E8E8E",
                                             },
+                                            Object {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"thumbs-up-sharp","size":16,"color":"#fff"}
+                                          {"name":"thumbs-up-sharp","size":16,"color":"#8E8E8E"}
                                         </View>
                                       </View>
                                     </View>
@@ -3088,11 +3112,14 @@ exports[`ChirpCard for reaction renders correctly with reaction 1`] = `
                                               "borderWidth": 1,
                                               "padding": 8,
                                             },
+                                            Object {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"thumbs-down-sharp","size":16,"color":"#fff"}
+                                          {"name":"thumbs-down-sharp","size":16,"color":"#3742fa"}
                                         </View>
                                       </View>
                                     </View>
@@ -3177,11 +3204,14 @@ exports[`ChirpCard for reaction renders correctly with reaction 1`] = `
                                               "borderWidth": 1,
                                               "padding": 8,
                                             },
+                                            Object {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"heart","size":16,"color":"#fff"}
+                                          {"name":"heart","size":16,"color":"#3742fa"}
                                         </View>
                                       </View>
                                     </View>
@@ -3266,11 +3296,14 @@ exports[`ChirpCard for reaction renders correctly with reaction 1`] = `
                                               "borderWidth": 1,
                                               "padding": 8,
                                             },
+                                            Object {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"ios-ellipsis-horizontal","size":16,"color":"#fff"}
+                                          {"name":"ios-ellipsis-horizontal","size":16,"color":"#3742fa"}
                                         </View>
                                       </View>
                                     </View>
@@ -3933,11 +3966,14 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
                                               "backgroundColor": "#8E8E8E",
                                               "borderColor": "#8E8E8E",
                                             },
+                                            Object {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"thumbs-up-sharp","size":16,"color":"#fff"}
+                                          {"name":"thumbs-up-sharp","size":16,"color":"#8E8E8E"}
                                         </View>
                                       </View>
                                     </View>
@@ -4022,11 +4058,14 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
                                               "borderWidth": 1,
                                               "padding": 8,
                                             },
+                                            Object {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"thumbs-down-sharp","size":16,"color":"#fff"}
+                                          {"name":"thumbs-down-sharp","size":16,"color":"#3742fa"}
                                         </View>
                                       </View>
                                     </View>
@@ -4111,11 +4150,14 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
                                               "borderWidth": 1,
                                               "padding": 8,
                                             },
+                                            Object {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"heart","size":16,"color":"#fff"}
+                                          {"name":"heart","size":16,"color":"#3742fa"}
                                         </View>
                                       </View>
                                     </View>

--- a/fe1-web/src/features/social/screens/__tests__/__snapshots__/SocialTopChirps.test.tsx.snap
+++ b/fe1-web/src/features/social/screens/__tests__/__snapshots__/SocialTopChirps.test.tsx.snap
@@ -635,11 +635,14 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                                       "borderWidth": 1,
                                                       "padding": 8,
                                                     },
+                                                    Object {
+                                                      "backgroundColor": "transparent",
+                                                    },
                                                   ]
                                                 }
                                               >
                                                 <View>
-                                                  {"name":"thumbs-up-sharp","size":16,"color":"#fff"}
+                                                  {"name":"thumbs-up-sharp","size":16,"color":"#3742fa"}
                                                 </View>
                                               </View>
                                             </View>
@@ -724,11 +727,14 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                                       "borderWidth": 1,
                                                       "padding": 8,
                                                     },
+                                                    Object {
+                                                      "backgroundColor": "transparent",
+                                                    },
                                                   ]
                                                 }
                                               >
                                                 <View>
-                                                  {"name":"thumbs-down-sharp","size":16,"color":"#fff"}
+                                                  {"name":"thumbs-down-sharp","size":16,"color":"#3742fa"}
                                                 </View>
                                               </View>
                                             </View>
@@ -813,11 +819,14 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                                       "borderWidth": 1,
                                                       "padding": 8,
                                                     },
+                                                    Object {
+                                                      "backgroundColor": "transparent",
+                                                    },
                                                   ]
                                                 }
                                               >
                                                 <View>
-                                                  {"name":"heart","size":16,"color":"#fff"}
+                                                  {"name":"heart","size":16,"color":"#3742fa"}
                                                 </View>
                                               </View>
                                             </View>
@@ -1163,11 +1172,14 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                                       "borderWidth": 1,
                                                       "padding": 8,
                                                     },
+                                                    Object {
+                                                      "backgroundColor": "transparent",
+                                                    },
                                                   ]
                                                 }
                                               >
                                                 <View>
-                                                  {"name":"thumbs-up-sharp","size":16,"color":"#fff"}
+                                                  {"name":"thumbs-up-sharp","size":16,"color":"#3742fa"}
                                                 </View>
                                               </View>
                                             </View>
@@ -1252,11 +1264,14 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                                       "borderWidth": 1,
                                                       "padding": 8,
                                                     },
+                                                    Object {
+                                                      "backgroundColor": "transparent",
+                                                    },
                                                   ]
                                                 }
                                               >
                                                 <View>
-                                                  {"name":"thumbs-down-sharp","size":16,"color":"#fff"}
+                                                  {"name":"thumbs-down-sharp","size":16,"color":"#3742fa"}
                                                 </View>
                                               </View>
                                             </View>
@@ -1341,11 +1356,14 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                                       "borderWidth": 1,
                                                       "padding": 8,
                                                     },
+                                                    Object {
+                                                      "backgroundColor": "transparent",
+                                                    },
                                                   ]
                                                 }
                                               >
                                                 <View>
-                                                  {"name":"heart","size":16,"color":"#fff"}
+                                                  {"name":"heart","size":16,"color":"#3742fa"}
                                                 </View>
                                               </View>
                                             </View>
@@ -1697,11 +1715,14 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                                       "borderWidth": 1,
                                                       "padding": 8,
                                                     },
+                                                    Object {
+                                                      "backgroundColor": "transparent",
+                                                    },
                                                   ]
                                                 }
                                               >
                                                 <View>
-                                                  {"name":"thumbs-up-sharp","size":16,"color":"#fff"}
+                                                  {"name":"thumbs-up-sharp","size":16,"color":"#3742fa"}
                                                 </View>
                                               </View>
                                             </View>
@@ -1786,11 +1807,14 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                                       "borderWidth": 1,
                                                       "padding": 8,
                                                     },
+                                                    Object {
+                                                      "backgroundColor": "transparent",
+                                                    },
                                                   ]
                                                 }
                                               >
                                                 <View>
-                                                  {"name":"thumbs-down-sharp","size":16,"color":"#fff"}
+                                                  {"name":"thumbs-down-sharp","size":16,"color":"#3742fa"}
                                                 </View>
                                               </View>
                                             </View>
@@ -1875,11 +1899,14 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                                       "borderWidth": 1,
                                                       "padding": 8,
                                                     },
+                                                    Object {
+                                                      "backgroundColor": "transparent",
+                                                    },
                                                   ]
                                                 }
                                               >
                                                 <View>
-                                                  {"name":"heart","size":16,"color":"#fff"}
+                                                  {"name":"heart","size":16,"color":"#3742fa"}
                                                 </View>
                                               </View>
                                             </View>


### PR DESCRIPTION
This PR changes the button style of the chirp reaction buttons to be less attention grabbing as depicted bellow. (Based on discussion in the last meeting). Moreover it contains a small fix for the icon color of disabled PopIconButtons.

<img width="562" alt="Screenshot 2023-01-05 at 15 28 17" src="https://user-images.githubusercontent.com/2634739/210804522-da1e8210-7be2-4eff-92dd-764006784f52.png">

<img width="562" alt="Screenshot 2023-01-05 at 15 30 30" src="https://user-images.githubusercontent.com/2634739/210804310-44559bd6-d534-4dab-b369-e24b118680b8.png">
