### PR TITLE
Change how sender is displayed in chirps

### DIFF
--- a/fe1-web/src/features/social/components/ChirpCard.tsx
+++ b/fe1-web/src/features/social/components/ChirpCard.tsx
@@ -62,6 +62,9 @@ const styles = StyleSheet.create({
   profileIcon: {
     alignSelf: 'flex-start',
   } as ViewStyle,
+  senderPrefix: {
+    marginTop: Spacing.x05,
+  },
   reactionsView: {
     width: '100%',
     flexDirection: 'row',
@@ -173,14 +176,21 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
         }>
         <View style={[List.icon, styles.profileIcon]}>
           <ProfileIcon publicKey={chirp.sender} />
+          <Text
+            style={[
+              Typography.base,
+              Typography.small,
+              Typography.inactive,
+              Typography.centered,
+              styles.senderPrefix,
+            ]}
+            numberOfLines={1}
+            selectable>
+            {chirp.sender.valueOf().slice(0, 4)}
+          </Text>
         </View>
       </PoPTouchableOpacity>
       <ListItem.Content>
-        <ListItem.Title
-          style={[Typography.base, Typography.small, Typography.inactive]}
-          numberOfLines={1}>
-          {chirp.sender.valueOf()}
-        </ListItem.Title>
         <ListItem.Subtitle>
           {chirp.isDeleted ? (
             <Text style={[Typography.base, Typography.inactive]}>{STRINGS.deleted_chirp}</Text>

--- a/fe1-web/src/features/social/components/__tests__/__snapshots__/ChirpCard.test.tsx.snap
+++ b/fe1-web/src/features/social/components/__tests__/__snapshots__/ChirpCard.test.tsx.snap
@@ -397,6 +397,35 @@ exports[`ChirpCard for deletion render correct for a deleted chirp 1`] = `
                                   }
                                 >
                                   ProfileIcon
+                                  <Text
+                                    numberOfLines={1}
+                                    selectable={true}
+                                    style={
+                                      Array [
+                                        Object {
+                                          "color": "#000",
+                                          "fontSize": 20,
+                                          "lineHeight": 26,
+                                          "textAlign": "left",
+                                        },
+                                        Object {
+                                          "fontSize": 16,
+                                          "lineHeight": 20,
+                                        },
+                                        Object {
+                                          "color": "#8E8E8E",
+                                        },
+                                        Object {
+                                          "textAlign": "center",
+                                        },
+                                        Object {
+                                          "marginTop": 8,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    oKHk
+                                  </Text>
                                 </View>
                               </View>
                             </RNGestureHandlerButton>
@@ -489,22 +518,6 @@ exports[`ChirpCard for deletion render correct for a deleted chirp 1`] = `
                               }
                             }
                           >
-                            <Text
-                              accessibilityRole="text"
-                              numberOfLines={1}
-                              style={
-                                Object {
-                                  "backgroundColor": "transparent",
-                                  "color": "#8E8E8E",
-                                  "fontSize": 16,
-                                  "lineHeight": 20,
-                                  "textAlign": "left",
-                                }
-                              }
-                              testID="listItemTitle"
-                            >
-                              oKHk3AivbpNXk_SfFcHDaVHcCcY8IBfHE7auXJ7h4ms=
-                            </Text>
                             <Text
                               accessibilityRole="text"
                               style={
@@ -997,6 +1010,35 @@ exports[`ChirpCard for deletion renders correctly for non-sender 1`] = `
                                   }
                                 >
                                   ProfileIcon
+                                  <Text
+                                    numberOfLines={1}
+                                    selectable={true}
+                                    style={
+                                      Array [
+                                        Object {
+                                          "color": "#000",
+                                          "fontSize": 20,
+                                          "lineHeight": 26,
+                                          "textAlign": "left",
+                                        },
+                                        Object {
+                                          "fontSize": 16,
+                                          "lineHeight": 20,
+                                        },
+                                        Object {
+                                          "color": "#8E8E8E",
+                                        },
+                                        Object {
+                                          "textAlign": "center",
+                                        },
+                                        Object {
+                                          "marginTop": 8,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    oKHk
+                                  </Text>
                                 </View>
                               </View>
                             </RNGestureHandlerButton>
@@ -1089,22 +1131,6 @@ exports[`ChirpCard for deletion renders correctly for non-sender 1`] = `
                               }
                             }
                           >
-                            <Text
-                              accessibilityRole="text"
-                              numberOfLines={1}
-                              style={
-                                Object {
-                                  "backgroundColor": "transparent",
-                                  "color": "#8E8E8E",
-                                  "fontSize": 16,
-                                  "lineHeight": 20,
-                                  "textAlign": "left",
-                                }
-                              }
-                              testID="listItemTitle"
-                            >
-                              oKHk3AivbpNXk_SfFcHDaVHcCcY8IBfHE7auXJ7h4ms=
-                            </Text>
                             <Text
                               accessibilityRole="text"
                               style={
@@ -1863,6 +1889,35 @@ exports[`ChirpCard for deletion renders correctly for sender 1`] = `
                                   }
                                 >
                                   ProfileIcon
+                                  <Text
+                                    numberOfLines={1}
+                                    selectable={true}
+                                    style={
+                                      Array [
+                                        Object {
+                                          "color": "#000",
+                                          "fontSize": 20,
+                                          "lineHeight": 26,
+                                          "textAlign": "left",
+                                        },
+                                        Object {
+                                          "fontSize": 16,
+                                          "lineHeight": 20,
+                                        },
+                                        Object {
+                                          "color": "#8E8E8E",
+                                        },
+                                        Object {
+                                          "textAlign": "center",
+                                        },
+                                        Object {
+                                          "marginTop": 8,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    oKHk
+                                  </Text>
                                 </View>
                               </View>
                             </RNGestureHandlerButton>
@@ -1955,22 +2010,6 @@ exports[`ChirpCard for deletion renders correctly for sender 1`] = `
                               }
                             }
                           >
-                            <Text
-                              accessibilityRole="text"
-                              numberOfLines={1}
-                              style={
-                                Object {
-                                  "backgroundColor": "transparent",
-                                  "color": "#8E8E8E",
-                                  "fontSize": 16,
-                                  "lineHeight": 20,
-                                  "textAlign": "left",
-                                }
-                              }
-                              testID="listItemTitle"
-                            >
-                              oKHk3AivbpNXk_SfFcHDaVHcCcY8IBfHE7auXJ7h4ms=
-                            </Text>
                             <Text
                               accessibilityRole="text"
                               style={
@@ -2797,6 +2836,35 @@ exports[`ChirpCard for reaction renders correctly with reaction 1`] = `
                                   }
                                 >
                                   ProfileIcon
+                                  <Text
+                                    numberOfLines={1}
+                                    selectable={true}
+                                    style={
+                                      Array [
+                                        Object {
+                                          "color": "#000",
+                                          "fontSize": 20,
+                                          "lineHeight": 26,
+                                          "textAlign": "left",
+                                        },
+                                        Object {
+                                          "fontSize": 16,
+                                          "lineHeight": 20,
+                                        },
+                                        Object {
+                                          "color": "#8E8E8E",
+                                        },
+                                        Object {
+                                          "textAlign": "center",
+                                        },
+                                        Object {
+                                          "marginTop": 8,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    oKHk
+                                  </Text>
                                 </View>
                               </View>
                             </RNGestureHandlerButton>
@@ -2889,22 +2957,6 @@ exports[`ChirpCard for reaction renders correctly with reaction 1`] = `
                               }
                             }
                           >
-                            <Text
-                              accessibilityRole="text"
-                              numberOfLines={1}
-                              style={
-                                Object {
-                                  "backgroundColor": "transparent",
-                                  "color": "#8E8E8E",
-                                  "fontSize": 16,
-                                  "lineHeight": 20,
-                                  "textAlign": "left",
-                                }
-                              }
-                              testID="listItemTitle"
-                            >
-                              oKHk3AivbpNXk_SfFcHDaVHcCcY8IBfHE7auXJ7h4ms=
-                            </Text>
                             <Text
                               accessibilityRole="text"
                               style={
@@ -3731,6 +3783,35 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
                                   }
                                 >
                                   ProfileIcon
+                                  <Text
+                                    numberOfLines={1}
+                                    selectable={true}
+                                    style={
+                                      Array [
+                                        Object {
+                                          "color": "#000",
+                                          "fontSize": 20,
+                                          "lineHeight": 26,
+                                          "textAlign": "left",
+                                        },
+                                        Object {
+                                          "fontSize": 16,
+                                          "lineHeight": 20,
+                                        },
+                                        Object {
+                                          "color": "#8E8E8E",
+                                        },
+                                        Object {
+                                          "textAlign": "center",
+                                        },
+                                        Object {
+                                          "marginTop": 8,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    Anon
+                                  </Text>
                                 </View>
                               </View>
                             </RNGestureHandlerButton>
@@ -3823,22 +3904,6 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
                               }
                             }
                           >
-                            <Text
-                              accessibilityRole="text"
-                              numberOfLines={1}
-                              style={
-                                Object {
-                                  "backgroundColor": "transparent",
-                                  "color": "#8E8E8E",
-                                  "fontSize": 16,
-                                  "lineHeight": 20,
-                                  "textAlign": "left",
-                                }
-                              }
-                              testID="listItemTitle"
-                            >
-                              Anonymous
-                            </Text>
                             <Text
                               accessibilityRole="text"
                               style={

--- a/fe1-web/src/features/social/screens/__tests__/__snapshots__/SocialTopChirps.test.tsx.snap
+++ b/fe1-web/src/features/social/screens/__tests__/__snapshots__/SocialTopChirps.test.tsx.snap
@@ -437,6 +437,35 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                             size={8}
                                             spotColor="#008ec2"
                                           />
+                                          <Text
+                                            numberOfLines={1}
+                                            selectable={true}
+                                            style={
+                                              Array [
+                                                Object {
+                                                  "color": "#000",
+                                                  "fontSize": 20,
+                                                  "lineHeight": 26,
+                                                  "textAlign": "left",
+                                                },
+                                                Object {
+                                                  "fontSize": 16,
+                                                  "lineHeight": 20,
+                                                },
+                                                Object {
+                                                  "color": "#8E8E8E",
+                                                },
+                                                Object {
+                                                  "textAlign": "center",
+                                                },
+                                                Object {
+                                                  "marginTop": 8,
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            Doug
+                                          </Text>
                                         </View>
                                       </View>
                                     </RNGestureHandlerButton>
@@ -529,22 +558,6 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                       }
                                     }
                                   >
-                                    <Text
-                                      accessibilityRole="text"
-                                      numberOfLines={1}
-                                      style={
-                                        Object {
-                                          "backgroundColor": "transparent",
-                                          "color": "#8E8E8E",
-                                          "fontSize": 16,
-                                          "lineHeight": 20,
-                                          "textAlign": "left",
-                                        }
-                                      }
-                                      testID="listItemTitle"
-                                    >
-                                      Douglas Adams
-                                    </Text>
                                     <Text
                                       accessibilityRole="text"
                                       style={
@@ -965,6 +978,35 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                             size={8}
                                             spotColor="#008ec2"
                                           />
+                                          <Text
+                                            numberOfLines={1}
+                                            selectable={true}
+                                            style={
+                                              Array [
+                                                Object {
+                                                  "color": "#000",
+                                                  "fontSize": 20,
+                                                  "lineHeight": 26,
+                                                  "textAlign": "left",
+                                                },
+                                                Object {
+                                                  "fontSize": 16,
+                                                  "lineHeight": 20,
+                                                },
+                                                Object {
+                                                  "color": "#8E8E8E",
+                                                },
+                                                Object {
+                                                  "textAlign": "center",
+                                                },
+                                                Object {
+                                                  "marginTop": 8,
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            Gand
+                                          </Text>
                                         </View>
                                       </View>
                                     </RNGestureHandlerButton>
@@ -1057,22 +1099,6 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                       }
                                     }
                                   >
-                                    <Text
-                                      accessibilityRole="text"
-                                      numberOfLines={1}
-                                      style={
-                                        Object {
-                                          "backgroundColor": "transparent",
-                                          "color": "#8E8E8E",
-                                          "fontSize": 16,
-                                          "lineHeight": 20,
-                                          "textAlign": "left",
-                                        }
-                                      }
-                                      testID="listItemTitle"
-                                    >
-                                      Gandalf
-                                    </Text>
                                     <Text
                                       accessibilityRole="text"
                                       style={
@@ -1499,6 +1525,35 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                             size={8}
                                             spotColor="#008ec2"
                                           />
+                                          <Text
+                                            numberOfLines={1}
+                                            selectable={true}
+                                            style={
+                                              Array [
+                                                Object {
+                                                  "color": "#000",
+                                                  "fontSize": 20,
+                                                  "lineHeight": 26,
+                                                  "textAlign": "left",
+                                                },
+                                                Object {
+                                                  "fontSize": 16,
+                                                  "lineHeight": 20,
+                                                },
+                                                Object {
+                                                  "color": "#8E8E8E",
+                                                },
+                                                Object {
+                                                  "textAlign": "center",
+                                                },
+                                                Object {
+                                                  "marginTop": 8,
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            Doug
+                                          </Text>
                                         </View>
                                       </View>
                                     </RNGestureHandlerButton>
@@ -1591,22 +1646,6 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                       }
                                     }
                                   >
-                                    <Text
-                                      accessibilityRole="text"
-                                      numberOfLines={1}
-                                      style={
-                                        Object {
-                                          "backgroundColor": "transparent",
-                                          "color": "#8E8E8E",
-                                          "fontSize": 16,
-                                          "lineHeight": 20,
-                                          "textAlign": "left",
-                                        }
-                                      }
-                                      testID="listItemTitle"
-                                    >
-                                      Douglas Adams
-                                    </Text>
                                     <Text
                                       accessibilityRole="text"
                                       style={


### PR DESCRIPTION
As discussed in the last meeting, this PR changes the Chirp view so that no longer the full public key of the sender is show with every chirp but only the first four characters right below the profile picture.

<img width="562" alt="Screenshot 2023-01-05 at 15 40 34" src="https://user-images.githubusercontent.com/2634739/210806225-0e28c328-0b9d-4156-a628-8c0a1f526fe5.png">
