### PR TITLE
Fix small bugs found on the android front-end

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QRCodeScanningFragment.java
@@ -213,7 +213,7 @@ public final class QRCodeScanningFragment extends Fragment {
     AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
     builder.setTitle("Close Roll Call");
     builder.setMessage("You have scanned " + nbAttendees + " attendees.");
-    builder.setOnDismissListener(dialog -> startCamera());
+    builder.setOnDismissListener(dialog -> applyPermissionToView());
     builder.setPositiveButton(
         R.string.confirm,
         (dialog, which) ->
@@ -240,7 +240,7 @@ public final class QRCodeScanningFragment extends Fragment {
     AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
     builder.setTitle("Warning");
     builder.setMessage(msg);
-    builder.setOnDismissListener(dialog -> startCamera());
+    builder.setOnDismissListener(dialog -> applyPermissionToView());
     builder.setPositiveButton(
         "Ok",
         (dialog, which) -> {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/MessageHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/MessageHandler.java
@@ -40,8 +40,11 @@ public final class MessageHandler {
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
           NoRollCallException {
     Log.d(TAG, "handle incoming message");
-    // Put the message in the state
-    messageRepo.addMessage(message);
+
+    if (messageRepo.isMessagePresent(message.getMessageId())) {
+      Log.d(TAG, "the message has already been handled in the past");
+      return;
+    }
 
     Data data = message.getData();
     Log.d(TAG, "data with class: " + data.getClass());
@@ -53,5 +56,8 @@ public final class MessageHandler {
         data,
         dataObj,
         dataAction);
+
+    // Put the message in the state
+    messageRepo.addMessage(message);
   }
 }


### PR DESCRIPTION
This PR fixes two issues :
 1. In the `QRScanningFragment`, when a dialog is dismissed, it used the wrong function and this could lead to an application crash if the camera permission was not granted
 2. The `MessageHandler` was not checking that a message had already been handled before. This could lead to infinite loops and performance drops