### PR TITLE
Fix CI go

### DIFF
--- a/be1-go/Makefile
+++ b/be1-go/Makefile
@@ -9,7 +9,7 @@ lint:
 	staticcheck ./...
 
 test: protocol
-	go test -v -race ./...
+	go test -v -race ./... -count=1
 
 test-cov: protocol
 	go test -v -coverpkg=./... -coverprofile=coverage.out ./... -json > report.json

--- a/be1-go/Makefile
+++ b/be1-go/Makefile
@@ -9,6 +9,9 @@ lint:
 	staticcheck ./...
 
 test: protocol
+	go test -v -race ./...
+
+test-no-cache: protocol
 	go test -v -race ./... -count=1
 
 test-cov: protocol

--- a/be1-go/channel/chirp/mod_test.go
+++ b/be1-go/channel/chirp/mod_test.go
@@ -348,6 +348,8 @@ func Test_Delete_Chirp(t *testing.T) {
 	// publish add chirp message
 	require.NoError(t, cha.Publish(pub, socket.ClientSocket{}))
 
+	time.Sleep(time.Millisecond)
+
 	// create delete chirp message
 	file = filepath.Join(relativeMsgDataExamplePath, "chirp_delete_publish",
 		"chirp_delete_publish.json")
@@ -403,15 +405,6 @@ func Test_Delete_Chirp(t *testing.T) {
 	checkDataBufDelete, err := json.Marshal(checkDataDelete)
 	require.Nil(t, err)
 	checkData64Delete := base64.URLEncoding.EncodeToString(checkDataBufDelete)
-
-	var notifyAddMessage messagedata.ChirpNotifyAdd
-	err = msg[0].UnmarshalData(&notifyAddMessage)
-	require.NoError(t, err)
-	require.Equal(t, checkDataAdd.Object, notifyAddMessage.Object)
-	require.Equal(t, checkDataAdd.Action, notifyAddMessage.Action)
-	require.Equal(t, checkDataAdd.ChirpID, notifyAddMessage.ChirpID)
-	require.Equal(t, checkDataAdd.Channel, notifyAddMessage.Channel)
-	require.Equal(t, checkDataAdd.Timestamp, notifyAddMessage.Timestamp)
 
 	// check if the data on the general is the same as the one we sent
 	require.Equal(t, checkData64Add, msg[0].Data)

--- a/be1-go/channel/chirp/mod_test.go
+++ b/be1-go/channel/chirp/mod_test.go
@@ -404,6 +404,15 @@ func Test_Delete_Chirp(t *testing.T) {
 	require.Nil(t, err)
 	checkData64Delete := base64.URLEncoding.EncodeToString(checkDataBufDelete)
 
+	var notifyAddMessage messagedata.ChirpNotifyAdd
+	err = msg[0].UnmarshalData(&notifyAddMessage)
+	require.NoError(t, err)
+	require.Equal(t, checkDataAdd.Object, notifyAddMessage.Object)
+	require.Equal(t, checkDataAdd.Action, notifyAddMessage.Action)
+	require.Equal(t, checkDataAdd.ChirpID, notifyAddMessage.ChirpID)
+	require.Equal(t, checkDataAdd.Channel, notifyAddMessage.Channel)
+	require.Equal(t, checkDataAdd.Timestamp, notifyAddMessage.Timestamp)
+
 	// check if the data on the general is the same as the one we sent
 	require.Equal(t, checkData64Add, msg[0].Data)
 	require.Equal(t, checkData64Delete, msg[1].Data)

--- a/be1-go/channel/consensus/mod_test.go
+++ b/be1-go/channel/consensus/mod_test.go
@@ -1458,14 +1458,13 @@ func Test_Timeout_Prepare(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that a prepare message was sent and empty the socket
-	// Unmarshal the failure message sent to other servers to verify its values
 	var sentPrepare method.Publish
 	err = json.Unmarshal(fakeHub.fakeSock.msg, &sentPrepare)
 	require.NoError(t, err)
 
 	sentMsg := sentPrepare.Params.Message
 
-	// Unmarshal the failure message data to check its values
+	// Unmarshal the prepare message data to check its values
 	jsonData, err := base64.URLEncoding.DecodeString(sentMsg.Data)
 	require.NoError(t, err)
 	var prepare messagedata.ConsensusPrepare
@@ -1477,7 +1476,9 @@ func Test_Timeout_Prepare(t *testing.T) {
 
 	fakeHub.fakeSock.msg = nil
 
-	clock.Add(12 * time.Second)
+	clock.Add(4 * time.Second)
+	time.Sleep(500 * time.Millisecond)
+	clock.Add(4 * time.Second)
 	time.Sleep(500 * time.Millisecond)
 
 	// A failure message should be sent to the socket

--- a/be1-go/channel/consensus/mod_test.go
+++ b/be1-go/channel/consensus/mod_test.go
@@ -1476,9 +1476,7 @@ func Test_Timeout_Prepare(t *testing.T) {
 
 	fakeHub.fakeSock.msg = nil
 
-	clock.Add(4 * time.Second)
-	time.Sleep(500 * time.Millisecond)
-	clock.Add(4 * time.Second)
+	clock.Add(12 * time.Second)
 	time.Sleep(500 * time.Millisecond)
 
 	// A failure message should be sent to the socket

--- a/be1-go/channel/election/mod_test.go
+++ b/be1-go/channel/election/mod_test.go
@@ -476,13 +476,10 @@ func Test_Sending_Election_Key(t *testing.T) {
 
 	electionKeyMsg := catchupAnswer[1]
 
-	data := messagedata.ElectionKey{}.NewEmpty()
+	var dataKey messagedata.ElectionKey
 
-	err := electionKeyMsg.UnmarshalData(data)
+	err := electionKeyMsg.UnmarshalData(&dataKey)
 	require.NoError(t, err, electionKeyMsg)
-
-	dataKey, ok := data.(*messagedata.ElectionKey)
-	require.True(t, ok)
 
 	key, err := base64.URLEncoding.DecodeString(dataKey.Key)
 	require.NoError(t, err)

--- a/be1-go/channel/election/mod_test.go
+++ b/be1-go/channel/election/mod_test.go
@@ -479,7 +479,7 @@ func Test_Sending_Election_Key(t *testing.T) {
 	data := messagedata.ElectionKey{}.NewEmpty()
 
 	err := electionKeyMsg.UnmarshalData(data)
-	require.NoError(t, err)
+	require.NoError(t, err, electionKeyMsg)
 
 	dataKey, ok := data.(*messagedata.ElectionKey)
 	require.True(t, ok)

--- a/be1-go/channel/lao/mod.go
+++ b/be1-go/channel/lao/mod.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"go.dedis.ch/kyber/v3"
 
@@ -127,6 +128,9 @@ func NewChannel(channelID string, hub channel.HubFunctionalities, msg message.Me
 	}
 
 	newChannel.registry = newChannel.NewLAORegistry()
+
+	// sleep to avoid misordering messages
+	time.Sleep(time.Nanosecond)
 
 	err := newChannel.createAndSendLAOGreet()
 	if err != nil {

--- a/be1-go/channel/lao/mod.go
+++ b/be1-go/channel/lao/mod.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"go.dedis.ch/kyber/v3"
 
@@ -128,9 +127,6 @@ func NewChannel(channelID string, hub channel.HubFunctionalities, msg message.Me
 	}
 
 	newChannel.registry = newChannel.NewLAORegistry()
-
-	// sleep to avoid misordering messages
-	time.Sleep(time.Nanosecond)
 
 	err := newChannel.createAndSendLAOGreet()
 	if err != nil {

--- a/be1-go/channel/lao/mod_test.go
+++ b/be1-go/channel/lao/mod_test.go
@@ -207,7 +207,7 @@ func TestLAOChannel_Catchup(t *testing.T) {
 	// Create the channel
 	channel, err := NewChannel("channel0", fakeHub, messages[0], nolog, keypair.public, nil)
 	require.NoError(t, err)
-	require.Equal(t, "0", messages[0])
+	require.Equal(t, "0", messages[0].MessageID)
 
 	laoChannel, ok := channel.(*Channel)
 	require.True(t, ok)

--- a/be1-go/channel/lao/mod_test.go
+++ b/be1-go/channel/lao/mod_test.go
@@ -554,7 +554,7 @@ func TestLAOChannel_Sends_Greeting(t *testing.T) {
 	var laoGreet messagedata.LaoGreet
 
 	err = greetMsg.UnmarshalData(&laoGreet)
-	require.NoError(t, err, laoGreet, catchupAnswer)
+	require.NoError(t, err)
 
 	require.Equal(t, messagedata.LAOObject, laoGreet.Object)
 	require.Equal(t, messagedata.LAOActionGreet, laoGreet.Action)

--- a/be1-go/channel/lao/mod_test.go
+++ b/be1-go/channel/lao/mod_test.go
@@ -207,6 +207,7 @@ func TestLAOChannel_Catchup(t *testing.T) {
 	// Create the channel
 	channel, err := NewChannel("channel0", fakeHub, messages[0], nolog, keypair.public, nil)
 	require.NoError(t, err)
+	require.Equal(t, "0", messages[0])
 
 	laoChannel, ok := channel.(*Channel)
 	require.True(t, ok)

--- a/be1-go/channel/lao/mod_test.go
+++ b/be1-go/channel/lao/mod_test.go
@@ -207,9 +207,11 @@ func TestLAOChannel_Catchup(t *testing.T) {
 	// Create the channel
 	channel, err := NewChannel("channel0", fakeHub, messages[0], nolog, keypair.public, nil)
 	require.NoError(t, err)
-	require.Equal(t, "0", messages[0].MessageID)
 
 	laoChannel, ok := channel.(*Channel)
+	require.True(t, ok)
+
+	_, ok = laoChannel.inbox.GetMessage(messages[0].MessageID)
 	require.True(t, ok)
 
 	time.Sleep(time.Millisecond)

--- a/be1-go/channel/lao/mod_test.go
+++ b/be1-go/channel/lao/mod_test.go
@@ -211,9 +211,6 @@ func TestLAOChannel_Catchup(t *testing.T) {
 	laoChannel, ok := channel.(*Channel)
 	require.True(t, ok)
 
-	_, ok = laoChannel.inbox.GetMessage(messages[0].MessageID)
-	require.True(t, ok)
-
 	time.Sleep(time.Millisecond)
 
 	for i := 2; i < numMessages+1; i++ {

--- a/be1-go/inbox/mod.go
+++ b/be1-go/inbox/mod.go
@@ -81,7 +81,7 @@ func (i *Inbox) GetSortedMessages() []message.Message {
 	}
 
 	// sort.Slice on messages based on the timestamp
-	sort.Slice(messages, func(i, j int) bool {
+	sort.SliceStable(messages, func(i, j int) bool {
 		return messages[i].storedTime < messages[j].storedTime
 	})
 

--- a/be1-go/inbox/mod_test.go
+++ b/be1-go/inbox/mod_test.go
@@ -20,7 +20,7 @@ func TestInbox_AddWitnessSignature(t *testing.T) {
 	// Add a message to the inbox
 	inbox.StoreMessage(msg)
 
-	require.Equal(t, 1, len(inbox.msgs))
+	require.Equal(t, 1, len(inbox.msgsMap))
 
 	// Add the witness signature to the message in the inbox
 	err := inbox.AddWitnessSignature(msg.MessageID, "456", "789")
@@ -47,7 +47,7 @@ func TestInbox_AddSigWrongMessages(t *testing.T) {
 	_, ok := inbox.GetMessage(string(buf))
 	require.False(t, ok)
 
-	require.Equal(t, 0, len(inbox.msgs))
+	require.Equal(t, 0, len(inbox.msgsMap))
 }
 
 func TestInbox_AddWitnessSignatures(t *testing.T) {
@@ -58,7 +58,7 @@ func TestInbox_AddWitnessSignatures(t *testing.T) {
 	// Add a message to the inbox
 	inbox.StoreMessage(msg)
 
-	require.Equal(t, 1, len(inbox.msgs))
+	require.Equal(t, 1, len(inbox.msgsMap))
 
 	signaturesNumber := 100
 	for i := 0; i < signaturesNumber; i++ {


### PR DESCRIPTION
Fix some of the errors happening sometimes with the go tests.

5 different errors have been identified:

1.  When testing the chirp deletion, the deletechirp message was sometimes processed before the addchirp message, failing the test.
For now, a small delay has been added in the test to avoid the issue, but ultimately a way for the program to retry when receiving out of order messages should be implemented. It wasn't done for now as it would probably need to be added in multiple places of the program.

2. When catching up on a LAO channel, the first two messages were sometimes out of order when they had the same timestamp.
It was fixed in two steps : first the sort function used previously didn't guarantee the order to stay the same when the timestamp is equal. The sort function has therefore been changed. Second a map in go doesn't guarantee the order when transformed to an array. An array has therefore been added, containing pointers to the messages to keep this order.

3. Sometimes when testing if the greeting sending worked, the test failed because some arguments couldn't be converted to string for the error message.
The arguments were probably missused in the test, and have been removed as they aren't necessary, even if they help when fixing bugs.

4. Sometimes when testing the transmission of the election key, the message couldn't be unmarshaled.
The unmarshall in itself was done weirdly, and the error didn't appear again after it was cleaned up, but the bug may not be fixed.

5. When testing the timeout of the consensus, sometimes the timout doesn't happen. Locally, the failure happens after multiple thousands of test run, and takes too much time to gather more information. This bug isn't fixed yet because of this.
