### PR TITLE
Refactor rollCallValidator

### DIFF
--- a/be2-scala/project/build.properties
+++ b/be2-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.6.1
+sbt.version=1.6.1

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageDataContentValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageDataContentValidator.scala
@@ -25,7 +25,10 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
   final def validateTimestampStaleness(timestamp: Timestamp): Boolean = TIMESTAMP_BASE_TIME < timestamp
 
   def checkTimestampStaleness(rpcMessage: JsonRpcRequest, timestamp: Timestamp, error: PipelineError): GraphMessage = {
-    if (validateTimestampStaleness(timestamp)) Left(rpcMessage) else Right(error)
+    if (validateTimestampStaleness(timestamp))
+      Left(rpcMessage)
+    else
+      Right(error)
   }
 
   /** Check whether timestamp <first> is not older than timestamp <second>
@@ -39,12 +42,23 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
     */
   final def validateTimestampOrder(first: Timestamp, second: Timestamp): Boolean = first <= second
 
-  def checkTimestampOrder(rpcMessage: JsonRpcRequest, first: Timestamp, second: Timestamp, error: PipelineError): GraphMessage = {
-    if (validateTimestampOrder(first, second)) Left(rpcMessage) else Right(error)
+  def checkTimestampOrder(
+      rpcMessage: JsonRpcRequest,
+      first: Timestamp,
+      second: Timestamp,
+      error: PipelineError
+  ): GraphMessage = {
+    if (validateTimestampOrder(first, second))
+      Left(rpcMessage)
+    else
+      Right(error)
   }
 
   def checkId(rpcMessage: JsonRpcRequest, expectedId: Hash, id: Hash, error: PipelineError): GraphMessage = {
-    if (expectedId == id) Left(rpcMessage) else Right(error)
+    if (expectedId == id)
+      Left(rpcMessage)
+    else
+      Right(error)
   }
 
   /** Check whether a list of <witnesses> public keys are valid or not

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageDataContentValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageDataContentValidator.scala
@@ -24,6 +24,7 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
     */
   final def validateTimestampStaleness(timestamp: Timestamp): Boolean = TIMESTAMP_BASE_TIME < timestamp
 
+  // Same as validateTimestampStaleness except that it returns a GraphMessage
   def checkTimestampStaleness(rpcMessage: JsonRpcRequest, timestamp: Timestamp, error: PipelineError): GraphMessage = {
     if (validateTimestampStaleness(timestamp))
       Left(rpcMessage)
@@ -42,6 +43,7 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
     */
   final def validateTimestampOrder(first: Timestamp, second: Timestamp): Boolean = first <= second
 
+  // Same as validateTimestampOrder except that it returns a GraphMessage
   def checkTimestampOrder(
       rpcMessage: JsonRpcRequest,
       first: Timestamp,
@@ -54,6 +56,19 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
       Right(error)
   }
 
+  /** Checks if the id corresponds to the expected id
+    *
+    * @param rpcMessage
+    *   rpc message to check
+    * @param expectedId
+    *   expected id
+    * @param id
+    *   id to check
+    * @param error
+    *   the error to forward in case the id is not the same as the expected id
+    * @return
+    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    */
   def checkId(rpcMessage: JsonRpcRequest, expectedId: Hash, id: Hash, error: PipelineError): GraphMessage = {
     if (expectedId == id)
       Left(rpcMessage)

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageDataContentValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageDataContentValidator.scala
@@ -1,9 +1,7 @@
 package ch.epfl.pop.pubsub.graph.validators
 
 import akka.pattern.AskableActorRef
-import ch.epfl.pop.model.network.method.message.Message
-import ch.epfl.pop.model.network.{JsonRpcMessage, JsonRpcRequest}
-import ch.epfl.pop.model.network.method.message.data.election.ElectionQuestion
+import ch.epfl.pop.model.network.{JsonRpcRequest}
 import ch.epfl.pop.model.objects.{Hash, PublicKey, Timestamp, WitnessSignaturePair}
 import ch.epfl.pop.pubsub.AskPatternConstants
 import ch.epfl.pop.pubsub.graph.{ErrorCodes, GraphMessage, PipelineError}
@@ -13,16 +11,6 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
   implicit lazy val dbActor: AskableActorRef = DbActor.getInstance
 
   def validationErrorNoMessage(rpcId: Option[Int]): PipelineError = PipelineError(ErrorCodes.INVALID_DATA.id, s"RPC-params does not contain any message", rpcId)
-
-  def checkParameters[T](rpcMessage: JsonRpcRequest): (GraphMessage, Message, Option[T]) = {
-    rpcMessage.getParamsMessage match {
-      case Some(message: Message) =>
-        val message: Message = rpcMessage.getParamsMessage.get
-        val data: T = message.decodedData.get.asInstanceOf[T]
-        (Left(rpcMessage), message, Some(data))
-      case _ => (Right(validationErrorNoMessage(rpcMessage.id)), null, None)
-    }
-  }
 
   // Lower bound for a timestamp to not be stale
   final val TIMESTAMP_BASE_TIME: Timestamp = Timestamp(1577833200L) // 1st january 2020

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
@@ -33,16 +33,16 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
 
   /** Runs the multiple checks of the validators
     *
-    * @param list
-    *   List of checks which return a GraphMessage
+    * @param checks
+    *   checks which return a GraphMessage
     * @return
     *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
     */
-  def runChecks(list: List[GraphMessage]): GraphMessage = {
-    if (list.head.isLeft && !list.tail.isEmpty)
-      runChecks(list.tail)
+  def runChecks(checks: GraphMessage*): GraphMessage = {
+    if (checks.head.isLeft && !checks.tail.isEmpty)
+      runChecks(checks.tail: _*)
     else
-      list.head
+      checks.head
   }
 
   def validateMessage(rpcMessage: JsonRpcRequest): GraphMessage = {

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
@@ -48,7 +48,10 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
   }
 
   def checkAttendee(rpcMessage: JsonRpcRequest, sender: PublicKey, channel: Channel, dbActor: AskableActorRef = DbActor.getInstance, error: PipelineError): GraphMessage = {
-    if (validateAttendee(sender, channel, dbActor)) Left(rpcMessage) else Right(error)
+    if (validateAttendee(sender, channel, dbActor))
+      Left(rpcMessage)
+    else
+      Right(error)
   }
 
   /** checks whether the sender of the JsonRpcRequest is the LAO owner
@@ -69,7 +72,10 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
   }
 
   def checkOwner(rpcMessage: JsonRpcRequest, sender: PublicKey, channel: Channel, dbActor: AskableActorRef = DbActor.getInstance, error: PipelineError): GraphMessage = {
-    if (validateOwner(sender, channel, dbActor)) Left(rpcMessage) else Right(error)
+    if (validateOwner(sender, channel, dbActor))
+      Left(rpcMessage)
+    else
+      Right(error)
   }
 
   /** checks whether the channel of the JsonRpcRequest is of the given type
@@ -90,7 +96,10 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
   }
 
   def checkChannelType(rpcMessage: JsonRpcRequest, channelObjectType: ObjectType.ObjectType, channel: Channel, dbActor: AskableActorRef = DbActor.getInstance, error: PipelineError): GraphMessage = {
-    if (validateChannelType(channelObjectType, channel, dbActor)) Left(rpcMessage) else Right(error)
+    if (validateChannelType(channelObjectType, channel, dbActor))
+      Left(rpcMessage)
+    else
+      Right(error)
   }
 
   def extractData[T](rpcMessage: JsonRpcRequest): (T, Hash, PublicKey, Channel) = {

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
@@ -1,7 +1,7 @@
 package ch.epfl.pop.pubsub.graph.validators
 
 import akka.pattern.AskableActorRef
-import ch.epfl.pop.model.network.{JsonRpcMessage, JsonRpcRequest}
+import ch.epfl.pop.model.network.{JsonRpcRequest}
 import ch.epfl.pop.model.network.method.message.Message
 import ch.epfl.pop.model.network.method.message.data.ObjectType
 import ch.epfl.pop.model.objects.{Channel, Hash, PublicKey}
@@ -47,7 +47,13 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
     }
   }
 
-  def checkAttendee(rpcMessage: JsonRpcRequest, sender: PublicKey, channel: Channel, dbActor: AskableActorRef = DbActor.getInstance, error: PipelineError): GraphMessage = {
+  def checkAttendee(
+      rpcMessage: JsonRpcRequest,
+      sender: PublicKey,
+      channel: Channel,
+      dbActor: AskableActorRef = DbActor.getInstance,
+      error: PipelineError
+  ): GraphMessage = {
     if (validateAttendee(sender, channel, dbActor))
       Left(rpcMessage)
     else
@@ -71,7 +77,13 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
     }
   }
 
-  def checkOwner(rpcMessage: JsonRpcRequest, sender: PublicKey, channel: Channel, dbActor: AskableActorRef = DbActor.getInstance, error: PipelineError): GraphMessage = {
+  def checkOwner(
+      rpcMessage: JsonRpcRequest,
+      sender: PublicKey,
+      channel: Channel,
+      dbActor: AskableActorRef = DbActor.getInstance,
+      error: PipelineError
+  ): GraphMessage = {
     if (validateOwner(sender, channel, dbActor))
       Left(rpcMessage)
     else
@@ -95,7 +107,13 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
     }
   }
 
-  def checkChannelType(rpcMessage: JsonRpcRequest, channelObjectType: ObjectType.ObjectType, channel: Channel, dbActor: AskableActorRef = DbActor.getInstance, error: PipelineError): GraphMessage = {
+  def checkChannelType(
+      rpcMessage: JsonRpcRequest,
+      channelObjectType: ObjectType.ObjectType,
+      channel: Channel,
+      dbActor: AskableActorRef = DbActor.getInstance,
+      error: PipelineError
+  ): GraphMessage = {
     if (validateChannelType(channelObjectType, channel, dbActor))
       Left(rpcMessage)
     else

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
@@ -92,4 +92,21 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
   def checkChannelType(rpcMessage: JsonRpcRequest, channelObjectType: ObjectType.ObjectType, channel: Channel, dbActor: AskableActorRef = DbActor.getInstance, error: PipelineError): GraphMessage = {
     if (validateChannelType(channelObjectType, channel, dbActor)) Left(rpcMessage) else Right(error)
   }
+
+  def extractData[T](rpcMessage: JsonRpcRequest): (T, Hash, PublicKey, Channel) = {
+    val message: Message = rpcMessage.getParamsMessage.get
+    val data: T = message.decodedData.get.asInstanceOf[T]
+    val laoId: Hash = rpcMessage.extractLaoId
+    val sender: PublicKey = message.sender
+    val channel: Channel = rpcMessage.getParamsChannel
+
+    (data, laoId, sender, channel)
+  }
+
+  def runList(list: List[GraphMessage]): GraphMessage = {
+    if (list.head.isLeft && !list.tail.isEmpty)
+      runList(list.tail)
+    else
+      list.head
+  }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
@@ -130,9 +130,9 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
     (data, laoId, sender, channel)
   }
 
-  def runList(list: List[GraphMessage]): GraphMessage = {
+  def runChecks(list: List[GraphMessage]): GraphMessage = {
     if (list.head.isLeft && !list.tail.isEmpty)
-      runList(list.tail)
+      runChecks(list.tail)
     else
       list.head
   }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
@@ -62,7 +62,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
           data.name
         )
 
-        runChecks(List(
+        runChecks(
           checkTimestampStaleness(
             rpcMessage,
             data.creation,
@@ -93,7 +93,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
             dbActorRef,
             validationError(s"trying to send a CreateRollCall message on a wrong type of channel $channel")
           )
-        ))
+        )
       case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }
@@ -118,7 +118,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
           data.opened_at.toString
         )
 
-        runChecks(List(
+        runChecks(
           checkTimestampStaleness(
             rpcMessage,
             data.opened_at,
@@ -134,7 +134,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
             validationError(s"trying to send a $validatorName message on a wrong type of channel $channel")
           ),
           validateOpens(rpcMessage, laoId, data.opens, validationError("unexpected id 'opens'"))
-        ))
+        )
       case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }
@@ -188,7 +188,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
           data.closed_at.toString
         )
 
-        runChecks(List(
+        runChecks(
           checkTimestampStaleness(
             rpcMessage,
             data.closed_at,
@@ -211,7 +211,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
             dbActorRef,
             validationError(s"trying to send a CloseRollCall message on a wrong type of channel $channel")
           )
-        ))
+        )
       case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
@@ -62,7 +62,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
           data.name
         )
 
-        runList(List(
+        runChecks(List(
           checkTimestampStaleness(rpcMessage, data.creation, validationError(s"stale 'creation' timestamp (${data.creation})")),
           checkTimestampOrder(
             rpcMessage,
@@ -112,7 +112,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
           data.opened_at.toString
         )
 
-        runList(List(
+        runChecks(List(
           checkTimestampStaleness(
             rpcMessage,
             data.opened_at,
@@ -169,7 +169,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
           data.closed_at.toString
         )
 
-        runList(List(
+        runChecks(List(
           checkTimestampStaleness(
             rpcMessage,
             data.closed_at,

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
@@ -55,7 +55,12 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
         val (data, laoId, sender, channel) = extractData[CreateRollCall](rpcMessage)
-        val expectedRollCallId: Hash = Hash.fromStrings(EVENT_HASH_PREFIX, laoId.toString, data.creation.toString, data.name)
+        val expectedRollCallId: Hash = Hash.fromStrings(
+          EVENT_HASH_PREFIX,
+          laoId.toString,
+          data.creation.toString,
+          data.name
+        )
 
         runList(List(
           checkTimestampStaleness(rpcMessage, data.creation, validationError(s"stale 'creation' timestamp (${data.creation})")),
@@ -165,7 +170,11 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
         )
 
         runList(List(
-          checkTimestampStaleness(rpcMessage, data.closed_at, validationError(s"stale 'closed_at' timestamp (${data.closed_at})")),
+          checkTimestampStaleness(
+            rpcMessage,
+            data.closed_at,
+            validationError(s"stale 'closed_at' timestamp (${data.closed_at})")
+          ),
           checkAttendeeSize(
             rpcMessage,
             data.attendees.size,

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
@@ -1,10 +1,10 @@
 package ch.epfl.pop.pubsub.graph.validators
 
 import akka.pattern.AskableActorRef
-import ch.epfl.pop.model.network.JsonRpcRequest
+import ch.epfl.pop.model.network.{JsonRpcMessage, JsonRpcRequest}
 import ch.epfl.pop.model.network.method.message.Message
-import ch.epfl.pop.model.network.method.message.data.ActionType.{CLOSE, CREATE, OPEN, REOPEN}
-import ch.epfl.pop.model.network.method.message.data.ObjectType
+import ch.epfl.pop.model.network.method.message.data.ActionType.{ActionType, CLOSE, CREATE, OPEN, REOPEN}
+import ch.epfl.pop.model.network.method.message.data.{ActionType, ObjectType}
 import ch.epfl.pop.model.network.method.message.data.rollCall.{CloseRollCall, CreateRollCall, IOpenRollCall}
 import ch.epfl.pop.model.objects.{Channel, Hash, PublicKey, RollCallData}
 import ch.epfl.pop.pubsub.graph.validators.MessageValidator._
@@ -35,6 +35,27 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
 
   override val EVENT_HASH_PREFIX: String = "R"
 
+  private def runList(list: List[GraphMessage]): GraphMessage = {
+    var result = list.head
+    var newlist = list
+
+    while (result.isLeft && !newlist.tail.isEmpty) {
+      newlist = newlist.tail
+      result = newlist.head
+    }
+    result
+  }
+
+  private def extractParameters[T](rpcMessage: JsonRpcRequest): (T, Hash, PublicKey, Channel) = {
+    val message: Message = rpcMessage.getParamsMessage.get
+    val data: T = message.decodedData.get.asInstanceOf[T]
+    val laoId: Hash = rpcMessage.extractLaoId
+    val sender: PublicKey = message.sender
+    val channel: Channel = rpcMessage.getParamsChannel
+
+    (data, laoId, sender, channel)
+  }
+
   /** @param laoId
     *   LAO id of the channel
     * @return
@@ -54,29 +75,27 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
 
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
-        val data: CreateRollCall = message.decodedData.get.asInstanceOf[CreateRollCall]
-
-        val laoId: Hash = rpcMessage.extractLaoId
+        val (data, laoId, sender, channel) = extractParameters[CreateRollCall](rpcMessage)
         val expectedRollCallId: Hash = Hash.fromStrings(EVENT_HASH_PREFIX, laoId.toString, data.creation.toString, data.name)
 
-        val sender: PublicKey = message.sender
-        val channel: Channel = rpcMessage.getParamsChannel
-
-        if (!validateTimestampStaleness(data.creation)) {
-          Right(validationError(s"stale 'creation' timestamp (${data.creation})"))
-        } else if (!validateTimestampOrder(data.creation, data.proposed_start)) {
-          Right(validationError(s"'proposed_start' (${data.proposed_start}) timestamp is smaller than 'creation' (${data.creation})"))
-        } else if (!validateTimestampOrder(data.proposed_start, data.proposed_end)) {
-          Right(validationError(s"'proposed_end' (${data.proposed_end}) timestamp is smaller than 'proposed_start' (${data.proposed_start})"))
-        } else if (expectedRollCallId != data.id) {
-          Right(validationError(s"unexpected id"))
-        } else if (!validateOwner(sender, channel, dbActorRef)) {
-          Right(validationError(s"invalid sender $sender"))
-        } else if (!validateChannelType(ObjectType.LAO, channel, dbActorRef)) {
-          Right(validationError(s"trying to send a CreateRollCall message on a wrong type of channel $channel"))
-        } else {
-          Left(rpcMessage)
-        }
+        runList(List(
+          checkTimestampStaleness(rpcMessage, data.creation, validationError(s"stale 'creation' timestamp (${data.creation})")),
+          checkTimestampOrder(
+            rpcMessage,
+            data.creation,
+            data.proposed_start,
+            validationError(s"'proposed_start' (${data.proposed_start}) timestamp is smaller than 'creation' (${data.creation})")
+          ),
+          checkTimestampOrder(
+            rpcMessage,
+            data.proposed_start,
+            data.proposed_end,
+            validationError(s"'proposed_end' (${data.proposed_end}) timestamp is smaller than 'proposed_start' (${data.proposed_start})")
+          ),
+          checkId(rpcMessage, expectedRollCallId, data.id, validationError(s"unexpected id")),
+          checkOwner(rpcMessage, sender, channel, dbActorRef, validationError(s"invalid sender $sender")),
+          checkChannelType(rpcMessage, ObjectType.LAO, channel, dbActorRef, validationError(s"trying to send a CreateRollCall message on a wrong type of channel $channel"))
+        ))
       case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }
@@ -93,8 +112,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
 
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
-        val data: IOpenRollCall = message.decodedData.get.asInstanceOf[IOpenRollCall]
-        val laoId: Hash = rpcMessage.extractLaoId
+        val (data, laoId, sender, channel) = extractParameters[IOpenRollCall](rpcMessage)
         val expectedRollCallId: Hash = Hash.fromStrings(
           EVENT_HASH_PREFIX,
           laoId.toString,
@@ -102,32 +120,23 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
           data.opened_at.toString
         )
 
-        val sender: PublicKey = message.sender
-        val channel: Channel = rpcMessage.getParamsChannel
-
-        if (!validateTimestampStaleness(data.opened_at)) {
-          Right(validationError(s"stale 'opened_at' timestamp (${data.opened_at})"))
-        } else if (expectedRollCallId != data.update_id) {
-          Right(validationError("unexpected id 'update_id'"))
-        } else if (!validateOpens(laoId, data.opens)) {
-          Right(validationError("unexpected id 'opens'"))
-        } else if (!validateOwner(sender, channel, dbActorRef)) {
-          Right(validationError(s"invalid sender $sender"))
-        } else if (!validateChannelType(ObjectType.LAO, channel, dbActorRef)) {
-          Right(validationError(s"trying to send a $validatorName message on a wrong type of channel $channel"))
-        } else {
-          Left(rpcMessage)
-        }
+        runList(List(
+          checkTimestampStaleness(rpcMessage, data.opened_at, validationError(s"stale 'opened_at' timestamp (${data.opened_at})")),
+          checkId(rpcMessage, expectedRollCallId, data.update_id, validationError("unexpected id 'update_id'")),
+          checkOwner(rpcMessage, sender, channel, dbActorRef, validationError(s"invalid sender $sender")),
+          checkChannelType(rpcMessage, ObjectType.LAO, channel, dbActorRef, validationError(s"trying to send a $validatorName message on a wrong type of channel $channel")),
+          validateOpens(rpcMessage, laoId, data.opens, validationError("unexpected id 'opens'"))
+        ))
       case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }
 
-  private def validateOpens(laoId: Hash, opens: Hash): Boolean = {
+  private def validateOpens(rpcMessage: JsonRpcRequest, laoId: Hash, opens: Hash, error: PipelineError): GraphMessage = {
     val rollCallData: Option[RollCallData] = getRollCallData(laoId)
     rollCallData match {
       case Some(data) =>
-        (data.state == CREATE || data.state == CLOSE) && data.updateId == opens
-      case _ => false
+        if ((data.state == CREATE || data.state == CLOSE) && data.updateId == opens) Left(rpcMessage) else Right(error)
+      case _ => Right(error)
     }
   }
 
@@ -147,9 +156,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
 
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
-        val data: CloseRollCall = message.decodedData.get.asInstanceOf[CloseRollCall]
-
-        val laoId: Hash = rpcMessage.extractLaoId
+        val (data, laoId, sender, channel) = extractParameters[CloseRollCall](rpcMessage)
         val expectedRollCallId: Hash = Hash.fromStrings(
           EVENT_HASH_PREFIX,
           laoId.toString,
@@ -157,35 +164,28 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
           data.closed_at.toString
         )
 
-        val sender: PublicKey = message.sender
-        val channel: Channel = rpcMessage.getParamsChannel
-
-        if (!validateTimestampStaleness(data.closed_at)) {
-          Right(validationError(s"stale 'closed_at' timestamp (${data.closed_at})"))
-        } else if (data.attendees.size != data.attendees.toSet.size) {
-          Right(validationError("duplicate attendees keys"))
-        } else if (!validateAttendee(sender, channel, dbActorRef)) {
-          Right(validationError("unexpected attendees keys"))
-        } else if (expectedRollCallId != data.update_id) {
-          Right(validationError("unexpected id 'update_id'"))
-        } else if (!validateCloses(laoId, data.closes)) {
-          Right(validationError("unexpected id 'closes'"))
-        } else if (!validateOwner(sender, channel, dbActorRef)) {
-          Right(validationError(s"invalid sender $sender"))
-        } else if (!validateChannelType(ObjectType.LAO, channel, dbActorRef)) {
-          Right(validationError(s"trying to send a CloseRollCall message on a wrong type of channel $channel"))
-        } else {
-          Left(rpcMessage)
-        }
+        runList(List(
+          checkTimestampStaleness(rpcMessage, data.closed_at, validationError(s"stale 'closed_at' timestamp (${data.closed_at})")),
+          checkAttendeeSize(rpcMessage, data.attendees.size, data.attendees.toSet.size, validationError("duplicate attendees keys")),
+          checkAttendee(rpcMessage, sender, channel, dbActorRef, validationError("unexpected attendees keys")),
+          checkId(rpcMessage, expectedRollCallId, data.update_id, validationError("unexpected id 'update_id'")),
+          validateCloses(rpcMessage, laoId, data.closes, validationError("unexpected id 'closes'")),
+          checkOwner(rpcMessage, sender, channel, dbActorRef, validationError(s"invalid sender $sender")),
+          checkChannelType(rpcMessage, ObjectType.LAO, channel, dbActorRef, validationError(s"trying to send a CloseRollCall message on a wrong type of channel $channel"))
+        ))
       case _ => Right(validationErrorNoMessage(rpcMessage.id))
     }
   }
 
-  private def validateCloses(laoId: Hash, closes: Hash): Boolean = {
+  private def validateCloses(rpcMessage: JsonRpcRequest, laoId: Hash, closes: Hash, error: PipelineError): GraphMessage = {
     val rollCallData: Option[RollCallData] = getRollCallData(laoId)
     rollCallData match {
-      case Some(data) => (data.state == OPEN || data.state == REOPEN) && data.updateId == closes
-      case _          => false
+      case Some(data) => if ((data.state == OPEN || data.state == REOPEN) && data.updateId == closes) Left(rpcMessage) else Right(error)
+      case _          => Right(error)
     }
+  }
+
+  private def checkAttendeeSize(rpcMessage: JsonRpcRequest, size: Int, expectedSize: Int, error: PipelineError): GraphMessage = {
+    if (size == expectedSize) Left(rpcMessage) else Right(error)
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
@@ -36,14 +36,10 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
   override val EVENT_HASH_PREFIX: String = "R"
 
   private def runList(list: List[GraphMessage]): GraphMessage = {
-    var result = list.head
-    var newlist = list
-
-    while (result.isLeft && !newlist.tail.isEmpty) {
-      newlist = newlist.tail
-      result = newlist.head
-    }
-    result
+    if (list.head.isLeft && !list.tail.isEmpty)
+      runList(list.tail)
+    else
+      list.head
   }
 
   private def extractParameters[T](rpcMessage: JsonRpcRequest): (T, Hash, PublicKey, Channel) = {

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
@@ -35,23 +35,6 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
 
   override val EVENT_HASH_PREFIX: String = "R"
 
-  private def runList(list: List[GraphMessage]): GraphMessage = {
-    if (list.head.isLeft && !list.tail.isEmpty)
-      runList(list.tail)
-    else
-      list.head
-  }
-
-  private def extractParameters[T](rpcMessage: JsonRpcRequest): (T, Hash, PublicKey, Channel) = {
-    val message: Message = rpcMessage.getParamsMessage.get
-    val data: T = message.decodedData.get.asInstanceOf[T]
-    val laoId: Hash = rpcMessage.extractLaoId
-    val sender: PublicKey = message.sender
-    val channel: Channel = rpcMessage.getParamsChannel
-
-    (data, laoId, sender, channel)
-  }
-
   /** @param laoId
     *   LAO id of the channel
     * @return
@@ -71,7 +54,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
 
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
-        val (data, laoId, sender, channel) = extractParameters[CreateRollCall](rpcMessage)
+        val (data, laoId, sender, channel) = extractData[CreateRollCall](rpcMessage)
         val expectedRollCallId: Hash = Hash.fromStrings(EVENT_HASH_PREFIX, laoId.toString, data.creation.toString, data.name)
 
         runList(List(
@@ -108,7 +91,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
 
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
-        val (data, laoId, sender, channel) = extractParameters[IOpenRollCall](rpcMessage)
+        val (data, laoId, sender, channel) = extractData[IOpenRollCall](rpcMessage)
         val expectedRollCallId: Hash = Hash.fromStrings(
           EVENT_HASH_PREFIX,
           laoId.toString,
@@ -152,7 +135,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
 
     rpcMessage.getParamsMessage match {
       case Some(message: Message) =>
-        val (data, laoId, sender, channel) = extractParameters[CloseRollCall](rpcMessage)
+        val (data, laoId, sender, channel) = extractData[CloseRollCall](rpcMessage)
         val expectedRollCallId: Hash = Hash.fromStrings(
           EVENT_HASH_PREFIX,
           laoId.toString,

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
@@ -63,12 +63,18 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
         )
 
         runChecks(List(
-          checkTimestampStaleness(rpcMessage, data.creation, validationError(s"stale 'creation' timestamp (${data.creation})")),
+          checkTimestampStaleness(
+            rpcMessage,
+            data.creation,
+            validationError(s"stale 'creation' timestamp (${data.creation})")
+          ),
           checkTimestampOrder(
             rpcMessage,
             data.creation,
             data.proposed_start,
-            validationError(s"'proposed_start' (${data.proposed_start}) timestamp is smaller than 'creation' (${data.creation})")
+            validationError(
+              s"'proposed_start' (${data.proposed_start}) timestamp is smaller than 'creation' (${data.creation})"
+            )
           ),
           checkTimestampOrder(
             rpcMessage,
@@ -133,6 +139,19 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
     }
   }
 
+  /** Validates the opens id of a OpenRollCAll message
+    *
+    * @param rpcMessage
+    *   rpc message to validate
+    * @param laoId
+    *   id of the LAO to which the rollCallDara belongs
+    * @param opens
+    *   opens id of the OpenRollCall which needs to be checked
+    * @param error
+    *   the error to forward in case the opens id does not correspond to the expected id
+    * @return
+    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    */
   private def validateOpens(rpcMessage: JsonRpcRequest, laoId: Hash, opens: Hash, error: PipelineError): GraphMessage = {
     val rollCallData: Option[RollCallData] = getRollCallData(laoId)
     rollCallData match {
@@ -197,6 +216,19 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
     }
   }
 
+  /** Validates the closes id of CloseRollCall message
+    *
+    * @param rpcMessage
+    *   rpc message to validate
+    * @param laoId
+    *   id of the LAO to which the rollCallDara belongs
+    * @param closes
+    *   closes id of CloseRollCall message which needs to be checked
+    * @param error
+    *   the error to forward in case the closes id does not correspond to the expected id
+    * @return
+    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    */
   private def validateCloses(rpcMessage: JsonRpcRequest, laoId: Hash, closes: Hash, error: PipelineError): GraphMessage = {
     val rollCallData: Option[RollCallData] = getRollCallData(laoId)
     rollCallData match {
@@ -209,6 +241,19 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
     }
   }
 
+  /** Checks if the number of attendees is as expected
+    *
+    * @param rpcMessage
+    *   rpc message to validate
+    * @param size
+    *   size of the actual list of attendees
+    * @param expectedSize
+    *   expected size of attendees
+    * @param error
+    *   the error to forward in case the size is not as expected
+    * @return
+    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    */
   private def checkAttendeeSize(rpcMessage: JsonRpcRequest, size: Int, expectedSize: Int, error: PipelineError): GraphMessage = {
     if (size == expectedSize)
       Left(rpcMessage)


### PR DESCRIPTION
Here is a first version of refactoring the validator of RollCAll. As suggested, I tried to implement a list of checks instead of having a cascade of `if else`: 
- I implemented functions such as `checkId` in `MessageDataContentValidator.scala` file. This type of function returns a GraphMessage, so I give them as parameter the `rpcMessage` and the error message. 
- If preferred, we can reuse the functions such as `validateTimestampOrder` instead of implemented a new function (i.e. `checkTimestampOrder`). It just needs some modifications. (I added new functions so that it does not impact the other validator files). 
- I modified slightly the private functions `validateOpens` and `validateCloses` so that it returns a GraphMessage and so that I can use them in the list. 
- The function `runList` runs the checks through the entire list. It stops when we get an error (i.e the check returns a `Right(PipelineError(...))`), and so the validator returns this error. If the function goes through the list without any error, it simply returns `Left(rpcMessage)`. 
- I did not add any comments, but, of course, it should be done. 

I am open to any suggestion. 