### PR TITLE
Display time until closest upcoming event

### DIFF
--- a/fe1-web/src/features/events/components/EventLists.tsx
+++ b/fe1-web/src/features/events/components/EventLists.tsx
@@ -4,6 +4,7 @@ import { ListItem } from '@rneui/themed';
 import React, { useEffect, useMemo, useState } from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
+import ReactTimeago from 'react-timeago';
 
 import { AppParamList } from 'core/navigation/typing/AppParamList';
 import { LaoEventsParamList } from 'core/navigation/typing/LaoEventsParamList';
@@ -53,9 +54,22 @@ const EventLists = () => {
     return () => clearInterval(interval);
   }, [events]);
 
+  // find upcoming event that is nearest / closest in the future
+  const closestUpcomingEvent = useMemo(
+    () =>
+      upcomingEvents.reduce<EventState | null>((closestEvent, event) => {
+        if (closestEvent === null || event.start < closestEvent.start) {
+          return event;
+        }
+
+        return closestEvent;
+      }, null),
+    [upcomingEvents],
+  );
+
   return (
     <View>
-      {upcomingEvents.length > 0 && (
+      {upcomingEvents.length > 0 && closestUpcomingEvent && (
         <ListItem
           containerStyle={List.getListItemStyles(true, true)}
           style={List.getListItemStyles(true, true)}
@@ -72,6 +86,10 @@ const EventLists = () => {
             <ListItem.Title style={Typography.base}>
               {STRINGS.events_upcoming_events}
             </ListItem.Title>
+            <ListItem.Subtitle style={Typography.small}>
+              {STRINGS.events_closest_upcoming_event}{' '}
+              <ReactTimeago live date={closestUpcomingEvent.start * 1000} />
+            </ListItem.Subtitle>
           </ListItem.Content>
           <ListItem.Chevron />
         </ListItem>

--- a/fe1-web/src/features/events/components/__tests__/__snapshots__/EventLists.test.tsx.snap
+++ b/fe1-web/src/features/events/components/__tests__/__snapshots__/EventLists.test.tsx.snap
@@ -470,6 +470,27 @@ exports[`EventLists renders correctly for attendees 1`] = `
                               >
                                 Upcoming Events
                               </Text>
+                              <Text
+                                accessibilityRole="text"
+                                style={
+                                  Object {
+                                    "backgroundColor": "transparent",
+                                    "color": "#242424",
+                                    "fontSize": 16,
+                                    "lineHeight": 20,
+                                  }
+                                }
+                                testID="listItemTitle"
+                              >
+                                Next Event starts
+                                 
+                                <time
+                                  dateTime="2021-05-07T02:46:40.000Z"
+                                  title="2021-05-07 02:46"
+                                >
+                                  1 day from now
+                                </time>
+                              </Text>
                             </View>
                             <View
                               style={
@@ -1607,6 +1628,27 @@ exports[`EventLists renders correctly for organizers 1`] = `
                                 testID="listItemTitle"
                               >
                                 Upcoming Events
+                              </Text>
+                              <Text
+                                accessibilityRole="text"
+                                style={
+                                  Object {
+                                    "backgroundColor": "transparent",
+                                    "color": "#242424",
+                                    "fontSize": 16,
+                                    "lineHeight": 20,
+                                  }
+                                }
+                                testID="listItemTitle"
+                              >
+                                Next Event starts
+                                 
+                                <time
+                                  dateTime="2021-05-07T02:46:40.000Z"
+                                  title="2021-05-07 02:46"
+                                >
+                                  1 day from now
+                                </time>
                               </Text>
                             </View>
                             <View

--- a/fe1-web/src/resources/strings.ts
+++ b/fe1-web/src/resources/strings.ts
@@ -345,9 +345,9 @@ namespace STRINGS {
   export const events_create_event = 'Create';
   export const events_list_past = 'Past Events';
   export const events_list_current = 'Current Events';
-  export const events_list_upcoming = 'Upcoming Events';
 
   export const events_upcoming_events = 'Upcoming Events';
+  export const events_closest_upcoming_event = 'Next Event starts';
   export const events_create_meeting = 'Create Meeting';
   export const events_view_single_meeting = 'Single Meeting';
   export const events_create_roll_call = 'Create Roll-Call';


### PR DESCRIPTION
As discussed on slack, this PR displays the time until the upcoming event closest in the future

<img width="562" alt="Screenshot 2023-02-01 at 20 58 59" src="https://user-images.githubusercontent.com/2634739/216150562-25f498ef-7471-41bc-8d65-8429bbf49ed3.png">
