### PR TITLE
Prevent text overflow on lao item

### DIFF
--- a/fe1-web/src/features/lao/components/LaoItem.tsx
+++ b/fe1-web/src/features/lao/components/LaoItem.tsx
@@ -83,7 +83,9 @@ const LaoItem = ({ lao, isFirstItem, isLastItem }: IPropTypes) => {
       onPress={reconnectToLao}
       bottomDivider>
       <ListItem.Content>
-        <ListItem.Title style={Typography.base}>{lao.name}</ListItem.Title>
+        <ListItem.Title style={Typography.base} numberOfLines={1}>
+          {lao.name}
+        </ListItem.Title>
         <ListItem.Subtitle style={Typography.small}>
           {STRINGS.user_role}: {role}
         </ListItem.Subtitle>

--- a/fe1-web/src/features/lao/components/__tests__/__snapshots__/LaoItem.test.tsx.snap
+++ b/fe1-web/src/features/lao/components/__tests__/__snapshots__/LaoItem.test.tsx.snap
@@ -444,6 +444,7 @@ exports[`LaoItem renders correctly as attendee 1`] = `
                           >
                             <Text
                               accessibilityRole="text"
+                              numberOfLines={1}
                               style={
                                 Object {
                                   "backgroundColor": "transparent",
@@ -1010,6 +1011,7 @@ exports[`LaoItem renders correctly as organizer 1`] = `
                           >
                             <Text
                               accessibilityRole="text"
+                              numberOfLines={1}
                               style={
                                 Object {
                                   "backgroundColor": "transparent",
@@ -1553,6 +1555,7 @@ exports[`LaoItem renders correctly as witness 1`] = `
                           >
                             <Text
                               accessibilityRole="text"
+                              numberOfLines={1}
                               style={
                                 Object {
                                   "backgroundColor": "transparent",

--- a/fe1-web/src/features/lao/components/__tests__/__snapshots__/LaoList.test.tsx.snap
+++ b/fe1-web/src/features/lao/components/__tests__/__snapshots__/LaoList.test.tsx.snap
@@ -812,6 +812,7 @@ exports[`LaoList renders correctly with one item 1`] = `
                             >
                               <Text
                                 accessibilityRole="text"
+                                numberOfLines={1}
                                 style={
                                   Object {
                                     "backgroundColor": "transparent",


### PR DESCRIPTION
In case of very long lao titles, the text overflowed over the screen. With this PR the name is truncated at the end and adds ellipsis (...). On web this will be `text-overflow: ellipsis` (https://www.w3schools.com/cssref/playdemo.php?filename=playcss_text-overflow&preval=ellipsis)