### PR TITLE
Move build info to middle center in the navigation bar below the title

### DIFF
--- a/fe1-web/src/core/components/BuildInfo.tsx
+++ b/fe1-web/src/core/components/BuildInfo.tsx
@@ -7,12 +7,13 @@ import { Spacing, Typography } from 'core/styles';
 const styles = StyleSheet.create({
   container: {
     position: 'absolute',
-    bottom: Spacing.x05,
+    top: Spacing.x3,
     left: Spacing.x05,
+    right: Spacing.x05,
     zIndex: 100,
     display: 'flex',
     flexDirection: 'row',
-    alignItems: 'center',
+    justifyContent: 'center',
   } as ViewStyle,
 });
 

--- a/fe1-web/src/core/components/__tests__/__snapshots__/BuildInfo.test.tsx.snap
+++ b/fe1-web/src/core/components/__tests__/__snapshots__/BuildInfo.test.tsx.snap
@@ -4,12 +4,13 @@ exports[`BuildInfo renders correctly 1`] = `
 <View
   style={
     Object {
-      "alignItems": "center",
-      "bottom": 8,
       "display": "flex",
       "flexDirection": "row",
+      "justifyContent": "center",
       "left": 8,
       "position": "absolute",
+      "right": 8,
+      "top": 48,
       "zIndex": 100,
     }
   }


### PR DESCRIPTION
I hope this interferes less with any screen given (I think) there is a navigation bar on all of them.

<img width="562" alt="Screenshot 2023-02-01 at 21 17 13" src="https://user-images.githubusercontent.com/2634739/216154311-e0f7fe83-a402-4105-a674-0782ab022d6a.png">
