### PR TITLE
Display election status on election detail screens

### DIFF
--- a/fe1-web/src/features/evoting/components/ElectionHeader.tsx
+++ b/fe1-web/src/features/evoting/components/ElectionHeader.tsx
@@ -4,8 +4,16 @@ import { Text } from 'react-native';
 
 import DateRange from 'core/components/DateRange';
 import { Typography } from 'core/styles';
+import STRINGS from 'resources/strings';
 
-import { Election } from '../objects';
+import { Election, ElectionStatus } from '../objects';
+
+const LABEL_BY_ELECTION_STATUS: Record<ElectionStatus, string> = {
+  [ElectionStatus.NOT_STARTED]: STRINGS.election_status_not_started,
+  [ElectionStatus.OPENED]: STRINGS.election_status_opened,
+  [ElectionStatus.TERMINATED]: STRINGS.election_status_terminated,
+  [ElectionStatus.RESULT]: STRINGS.election_status_results,
+};
 
 const ElectionHeader = ({ election }: IPropTypes) => {
   return (
@@ -15,6 +23,8 @@ const ElectionHeader = ({ election }: IPropTypes) => {
       <Text style={Typography.paragraph}>
         <DateRange start={election.start.toDate()} end={election.end.toDate()} />
       </Text>
+      {'\n'}
+      <Text style={Typography.paragraph}>{LABEL_BY_ELECTION_STATUS[election.electionStatus]}</Text>
     </Text>
   );
 };

--- a/fe1-web/src/features/evoting/screens/__tests__/__snapshots__/ViewSingleElection.test.tsx.snap
+++ b/fe1-web/src/features/evoting/screens/__tests__/__snapshots__/ViewSingleElection.test.tsx.snap
@@ -408,6 +408,21 @@ exports[`ViewSingleElection renders correctly non organizers election with resul
                                   </Text>
                                 </Text>
                               </Text>
+                              
+
+                              <Text
+                                style={
+                                  Object {
+                                    "color": "#000",
+                                    "fontSize": 20,
+                                    "lineHeight": 26,
+                                    "marginBottom": 16,
+                                    "textAlign": "left",
+                                  }
+                                }
+                              >
+                                Ended, Results available
+                              </Text>
                             </Text>
                             <View
                               style={
@@ -1853,6 +1868,21 @@ exports[`ViewSingleElection renders correctly non organizers not started electio
                                     00:00:00
                                   </Text>
                                 </Text>
+                              </Text>
+                              
+
+                              <Text
+                                style={
+                                  Object {
+                                    "color": "#000",
+                                    "fontSize": 20,
+                                    "lineHeight": 26,
+                                    "marginBottom": 16,
+                                    "textAlign": "left",
+                                  }
+                                }
+                              >
+                                Not Started
                               </Text>
                             </Text>
                             <View
@@ -5456,6 +5486,21 @@ exports[`ViewSingleElection renders correctly non organizers terminated election
                                   </Text>
                                 </Text>
                               </Text>
+                              
+
+                              <Text
+                                style={
+                                  Object {
+                                    "color": "#000",
+                                    "fontSize": 20,
+                                    "lineHeight": 26,
+                                    "marginBottom": 16,
+                                    "textAlign": "left",
+                                  }
+                                }
+                              >
+                                Ended
+                              </Text>
                             </Text>
                             <Text
                               style={
@@ -7191,6 +7236,21 @@ exports[`ViewSingleElection renders correctly organizers election with results 1
                                   </Text>
                                 </Text>
                               </Text>
+                              
+
+                              <Text
+                                style={
+                                  Object {
+                                    "color": "#000",
+                                    "fontSize": 20,
+                                    "lineHeight": 26,
+                                    "marginBottom": 16,
+                                    "textAlign": "left",
+                                  }
+                                }
+                              >
+                                Ended, Results available
+                              </Text>
                             </Text>
                             <View
                               style={
@@ -8636,6 +8696,21 @@ exports[`ViewSingleElection renders correctly organizers not started election 1`
                                     00:00:00
                                   </Text>
                                 </Text>
+                              </Text>
+                              
+
+                              <Text
+                                style={
+                                  Object {
+                                    "color": "#000",
+                                    "fontSize": 20,
+                                    "lineHeight": 26,
+                                    "marginBottom": 16,
+                                    "textAlign": "left",
+                                  }
+                                }
+                              >
+                                Not Started
                               </Text>
                             </Text>
                             <View
@@ -12269,6 +12344,21 @@ exports[`ViewSingleElection renders correctly organizers terminated election 1`]
                                     00:00:00
                                   </Text>
                                 </Text>
+                              </Text>
+                              
+
+                              <Text
+                                style={
+                                  Object {
+                                    "color": "#000",
+                                    "fontSize": 20,
+                                    "lineHeight": 26,
+                                    "marginBottom": 16,
+                                    "textAlign": "left",
+                                  }
+                                }
+                              >
+                                Ended
                               </Text>
                             </Text>
                             <Text

--- a/fe1-web/src/resources/strings.ts
+++ b/fe1-web/src/resources/strings.ts
@@ -253,6 +253,11 @@ namespace STRINGS {
   export const election_questions = 'Questions';
   export const election_results = 'Election Results';
 
+  export const election_status_not_started = 'Not Started';
+  export const election_status_opened = 'Ongoing';
+  export const election_status_terminated = 'Ended';
+  export const election_status_results = 'Ended, Results available';
+
   export const election_warning_open_ballot =
     'This is an open ballot election, your cast votes will be visible to all members of the LAO.';
   export const election_info_secret_ballot =


### PR DESCRIPTION
As discussed in the last meeting, for non-organizer it was previously not clear what the current state of an election is once they are on the detail screen.

<img width="562" alt="Screenshot 2023-02-01 at 21 29 04" src="https://user-images.githubusercontent.com/2634739/216156314-10298038-fea0-49e2-a4fc-c7f837c8bf3c.png">
