### PR TITLE
Add back navigation for selected fragments

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
@@ -7,11 +7,13 @@ import android.util.Log;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.IdRes;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.view.GravityCompat;
 import androidx.fragment.app.*;
+import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.github.dedis.popstellar.R;
@@ -332,5 +334,10 @@ public class LaoActivity extends AppCompatActivity {
     Intent intent = new Intent(ctx, LaoActivity.class);
     intent.putExtra(Constants.LAO_ID_EXTRA, laoId);
     return intent;
+  }
+
+  public static void addBackNavigationInstruction(
+      FragmentActivity activity, LifecycleOwner lifecycleOwner, OnBackPressedCallback callback) {
+    activity.getOnBackPressedDispatcher().addCallback(lifecycleOwner, callback);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
@@ -336,7 +336,8 @@ public class LaoActivity extends AppCompatActivity {
     return intent;
   }
 
-  public static void addBackNavigationInstruction(
+  /** Adds a callback that describes the action to take the next time the back button is pressed */
+  public static void addBackNavigationCallback(
       FragmentActivity activity, LifecycleOwner lifecycleOwner, OnBackPressedCallback callback) {
     activity.getOnBackPressedDispatcher().addCallback(lifecycleOwner, callback);
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHistoryFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHistoryFragment.java
@@ -63,7 +63,7 @@ public class DigitalCashHistoryFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationInstruction(
+    LaoActivity.addBackNavigationCallback(
         requireActivity(),
         getViewLifecycleOwner(),
         new OnBackPressedCallback(true) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHistoryFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHistoryFragment.java
@@ -63,19 +63,15 @@ public class DigitalCashHistoryFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    requireActivity()
-        .getOnBackPressedDispatcher()
-        .addCallback(
-            getViewLifecycleOwner(),
-            new OnBackPressedCallback(true) {
-              @Override
-              public void handleOnBackPressed() {
-                Log.d(TAG, "Back pressed, going to digital cash home");
-                LaoActivity.setCurrentFragment(
-                    getParentFragmentManager(),
-                    R.id.fragment_digital_cash_home,
-                    DigitalCashHomeFragment::new);
-              }
-            });
+    LaoActivity.addBackNavigationInstruction(
+        requireActivity(),
+        getViewLifecycleOwner(),
+        new OnBackPressedCallback(true) {
+          @Override
+          public void handleOnBackPressed() {
+            Log.d(TAG, "Back pressed, going to digital cash home");
+            DigitalCashHomeFragment.openFragment(getParentFragmentManager());
+          }
+        });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHistoryFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHistoryFragment.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.*;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.*;
 
@@ -49,6 +50,8 @@ public class DigitalCashHistoryFragment extends Fragment {
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(
                 adapter::setList, error -> Log.d(TAG, "error with history update " + error)));
+
+    handleBackNav();
     return view;
   }
 
@@ -57,5 +60,22 @@ public class DigitalCashHistoryFragment extends Fragment {
     super.onResume();
     viewModel.setPageTitle(R.string.digital_cash_history);
     viewModel.setIsTab(false);
+  }
+
+  private void handleBackNav() {
+    requireActivity()
+        .getOnBackPressedDispatcher()
+        .addCallback(
+            getViewLifecycleOwner(),
+            new OnBackPressedCallback(true) {
+              @Override
+              public void handleOnBackPressed() {
+                Log.d(TAG, "Back pressed, going to digital cash home");
+                LaoActivity.setCurrentFragment(
+                    getParentFragmentManager(),
+                    R.id.fragment_digital_cash_home,
+                    DigitalCashHomeFragment::new);
+              }
+            });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHomeFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHomeFragment.java
@@ -6,6 +6,7 @@ import android.view.*;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.DigitalCashHomeFragmentBinding;
@@ -15,7 +16,6 @@ import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
-
 
 /**
  * A simple {@link Fragment} subclass. Use the {@link DigitalCashHomeFragment#newInstance} factory
@@ -121,5 +121,10 @@ public class DigitalCashHomeFragment extends Fragment {
                 binding.issueButton.setVisibility(View.GONE);
               }
             });
+  }
+
+  public static void openFragment(FragmentManager manager) {
+    LaoActivity.setCurrentFragment(
+        manager, R.id.fragment_digital_cash_home, DigitalCashHomeFragment::new);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashIssueFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashIssueFragment.java
@@ -6,6 +6,7 @@ import android.view.*;
 import android.widget.ArrayAdapter;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -64,6 +65,8 @@ public class DigitalCashIssueFragment extends Fragment {
     selectOneMember = binding.radioButton.getId();
     selectAllRollCallAttendees = binding.radioButtonAttendees.getId();
     selectAllLaoWitnesses = binding.radioButtonWitnesses.getId();
+
+    handleBackNav();
     return binding.getRoot();
   }
 
@@ -210,5 +213,22 @@ public class DigitalCashIssueFragment extends Fragment {
                         requireContext(), TAG, error, R.string.error_post_transaction);
                   }
                 }));
+  }
+
+  private void handleBackNav() {
+    requireActivity()
+        .getOnBackPressedDispatcher()
+        .addCallback(
+            getViewLifecycleOwner(),
+            new OnBackPressedCallback(true) {
+              @Override
+              public void handleOnBackPressed() {
+                Log.d(TAG, "Back pressed, going to digital cash home");
+                LaoActivity.setCurrentFragment(
+                    getParentFragmentManager(),
+                    R.id.fragment_digital_cash_home,
+                    DigitalCashHomeFragment::new);
+              }
+            });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashReceiptFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashReceiptFragment.java
@@ -80,19 +80,15 @@ public class DigitalCashReceiptFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    requireActivity()
-        .getOnBackPressedDispatcher()
-        .addCallback(
-            getViewLifecycleOwner(),
-            new OnBackPressedCallback(true) {
-              @Override
-              public void handleOnBackPressed() {
-                Log.d(TAG, "Back pressed, going to digital cash home");
-                LaoActivity.setCurrentFragment(
-                    getParentFragmentManager(),
-                    R.id.fragment_digital_cash_home,
-                    DigitalCashHomeFragment::new);
-              }
-            });
+    LaoActivity.addBackNavigationInstruction(
+        requireActivity(),
+        getViewLifecycleOwner(),
+        new OnBackPressedCallback(true) {
+          @Override
+          public void handleOnBackPressed() {
+            Log.d(TAG, "Back pressed, going to digital cash home");
+            DigitalCashHomeFragment.openFragment(getParentFragmentManager());
+          }
+        });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashReceiptFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashReceiptFragment.java
@@ -80,7 +80,7 @@ public class DigitalCashReceiptFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationInstruction(
+    LaoActivity.addBackNavigationCallback(
         requireActivity(),
         getViewLifecycleOwner(),
         new OnBackPressedCallback(true) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashReceiptFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashReceiptFragment.java
@@ -1,8 +1,10 @@
 package com.github.dedis.popstellar.ui.lao.digitalcash;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.*;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -17,6 +19,7 @@ import com.github.dedis.popstellar.ui.lao.LaoViewModel;
  * create an instance of this fragment.
  */
 public class DigitalCashReceiptFragment extends Fragment {
+  public static final String TAG = DigitalCashReceiptFragment.class.getSimpleName();
   private DigitalCashReceiptFragmentBinding binding;
   private LaoViewModel viewModel;
   private DigitalCashViewModel digitalCashViewModel;
@@ -38,6 +41,8 @@ public class DigitalCashReceiptFragment extends Fragment {
     digitalCashViewModel =
         LaoActivity.obtainDigitalCashViewModel(requireActivity(), viewModel.getLaoId());
     binding = DigitalCashReceiptFragmentBinding.inflate(inflater, container, false);
+
+    handleBackNav();
     return binding.getRoot();
   }
 
@@ -72,5 +77,22 @@ public class DigitalCashReceiptFragment extends Fragment {
     super.onResume();
     viewModel.setPageTitle(R.string.digital_cash_receipt);
     viewModel.setIsTab(false);
+  }
+
+  private void handleBackNav() {
+    requireActivity()
+        .getOnBackPressedDispatcher()
+        .addCallback(
+            getViewLifecycleOwner(),
+            new OnBackPressedCallback(true) {
+              @Override
+              public void handleOnBackPressed() {
+                Log.d(TAG, "Back pressed, going to digital cash home");
+                LaoActivity.setCurrentFragment(
+                    getParentFragmentManager(),
+                    R.id.fragment_digital_cash_home,
+                    DigitalCashHomeFragment::new);
+              }
+            });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashReceiveFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashReceiveFragment.java
@@ -2,8 +2,10 @@ package com.github.dedis.popstellar.ui.lao.digitalcash;
 
 import android.graphics.Bitmap;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.*;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
@@ -60,6 +62,8 @@ public class DigitalCashReceiveFragment extends Fragment {
         LaoActivity.obtainDigitalCashViewModel(requireActivity(), viewModel.getLaoId());
     binding = DigitalCashReceiveFragmentBinding.inflate(inflater, container, false);
     setHomeInterface();
+
+    handleBackNav();
     return binding.getRoot();
   }
 
@@ -88,5 +92,22 @@ public class DigitalCashReceiveFragment extends Fragment {
     super.onResume();
     viewModel.setPageTitle(R.string.digital_cash_receive);
     viewModel.setIsTab(false);
+  }
+
+  private void handleBackNav() {
+    requireActivity()
+        .getOnBackPressedDispatcher()
+        .addCallback(
+            getViewLifecycleOwner(),
+            new OnBackPressedCallback(true) {
+              @Override
+              public void handleOnBackPressed() {
+                Log.d(TAG, "Back pressed, going to digital cash home");
+                LaoActivity.setCurrentFragment(
+                    getParentFragmentManager(),
+                    R.id.fragment_digital_cash_home,
+                    DigitalCashHomeFragment::new);
+              }
+            });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashSendFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashSendFragment.java
@@ -6,6 +6,7 @@ import android.view.*;
 import android.widget.ArrayAdapter;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -57,7 +58,7 @@ public class DigitalCashSendFragment extends Fragment {
         LaoActivity.obtainDigitalCashViewModel(requireActivity(), viewModel.getLaoId());
     binding = DigitalCashSendFragmentBinding.inflate(inflater, container, false);
 
-    // Inflate the layout for this fragment
+    handleBackNav();
     return binding.getRoot();
   }
 
@@ -191,6 +192,23 @@ public class DigitalCashSendFragment extends Fragment {
               } else {
                 ErrorUtils.logAndShow(
                     requireContext(), TAG, error, R.string.error_post_transaction);
+              }
+            });
+  }
+
+  private void handleBackNav() {
+    requireActivity()
+        .getOnBackPressedDispatcher()
+        .addCallback(
+            getViewLifecycleOwner(),
+            new OnBackPressedCallback(true) {
+              @Override
+              public void handleOnBackPressed() {
+                Log.d(TAG, "Back pressed, going to digital cash home");
+                LaoActivity.setCurrentFragment(
+                    getParentFragmentManager(),
+                    R.id.fragment_digital_cash_home,
+                    DigitalCashHomeFragment::new);
               }
             });
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/UpcomingEventsFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/UpcomingEventsFragment.java
@@ -55,7 +55,7 @@ public class UpcomingEventsFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationInstruction(
+    LaoActivity.addBackNavigationCallback(
         requireActivity(),
         getViewLifecycleOwner(),
         new OnBackPressedCallback(true) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/UpcomingEventsFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/UpcomingEventsFragment.java
@@ -1,8 +1,10 @@
 package com.github.dedis.popstellar.ui.lao.event;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.*;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -12,6 +14,7 @@ import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.UpcomingEventsFragmentBinding;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
+import com.github.dedis.popstellar.ui.lao.event.eventlist.EventListFragment;
 import com.github.dedis.popstellar.ui.lao.event.eventlist.UpcomingEventsAdapter;
 
 public class UpcomingEventsFragment extends Fragment {
@@ -48,5 +51,20 @@ public class UpcomingEventsFragment extends Fragment {
     super.onResume();
     viewModel.setPageTitle(R.string.future_header_title);
     viewModel.setIsTab(false);
+  }
+
+  private void handleBackNav() {
+    requireActivity()
+        .getOnBackPressedDispatcher()
+        .addCallback(
+            getViewLifecycleOwner(),
+            new OnBackPressedCallback(true) {
+              @Override
+              public void handleOnBackPressed() {
+                Log.d(TAG, "Back pressed, going to event list");
+                LaoActivity.setCurrentFragment(
+                    getParentFragmentManager(), R.id.fragment_event_list, EventListFragment::new);
+              }
+            });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/UpcomingEventsFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/UpcomingEventsFragment.java
@@ -55,17 +55,15 @@ public class UpcomingEventsFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    requireActivity()
-        .getOnBackPressedDispatcher()
-        .addCallback(
-            getViewLifecycleOwner(),
-            new OnBackPressedCallback(true) {
-              @Override
-              public void handleOnBackPressed() {
-                Log.d(TAG, "Back pressed, going to event list");
-                LaoActivity.setCurrentFragment(
-                    getParentFragmentManager(), R.id.fragment_event_list, EventListFragment::new);
-              }
-            });
+    LaoActivity.addBackNavigationInstruction(
+        requireActivity(),
+        getViewLifecycleOwner(),
+        new OnBackPressedCallback(true) {
+          @Override
+          public void handleOnBackPressed() {
+            Log.d(TAG, "Back pressed, going to event list");
+            EventListFragment.openFragment(getParentFragmentManager());
+          }
+        });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/UpcomingEventsFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/UpcomingEventsFragment.java
@@ -43,6 +43,7 @@ public class UpcomingEventsFragment extends Fragment {
     binding.upcomingEventsRecyclerView.setAdapter(
         new UpcomingEventsAdapter(eventsViewModel.getEvents(), viewModel, requireActivity(), TAG));
 
+    handleBackNav();
     return binding.getRoot();
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/CastVoteFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/CastVoteFragment.java
@@ -191,7 +191,7 @@ public class CastVoteFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationInstruction(
+    LaoActivity.addBackNavigationCallback(
         requireActivity(),
         getViewLifecycleOwner(),
         new OnBackPressedCallback(true) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/CastVoteFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/CastVoteFragment.java
@@ -191,19 +191,16 @@ public class CastVoteFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    requireActivity()
-        .getOnBackPressedDispatcher()
-        .addCallback(
-            getViewLifecycleOwner(),
-            new OnBackPressedCallback(true) {
-              @Override
-              public void handleOnBackPressed() {
-                Log.d(TAG, "Back pressed, going to election");
-                LaoActivity.setCurrentFragment(
-                    getParentFragmentManager(),
-                    R.id.fragment_election,
-                    () -> ElectionFragment.newInstance(requireArguments().getString(ELECTION_ID)));
-              }
-            });
+    LaoActivity.addBackNavigationInstruction(
+        requireActivity(),
+        getViewLifecycleOwner(),
+        new OnBackPressedCallback(true) {
+          @Override
+          public void handleOnBackPressed() {
+            Log.d(TAG, "Back pressed, going to election");
+            ElectionFragment.openFragment(
+                getParentFragmentManager(), getArguments().getString(ELECTION_ID));
+          }
+        });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/CastVoteFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/CastVoteFragment.java
@@ -1,9 +1,11 @@
 package com.github.dedis.popstellar.ui.lao.event.election.fragments;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.*;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager2.widget.ViewPager2;
@@ -108,6 +110,8 @@ public class CastVoteFragment extends Fragment {
 
     // setUp the cast Vote button
     binding.castVoteButton.setOnClickListener(this::castVote);
+
+    handleBackNav();
     return binding.getRoot();
   }
 
@@ -184,5 +188,22 @@ public class CastVoteFragment extends Fragment {
     super.onResume();
     viewModel.setPageTitle(R.string.vote);
     viewModel.setIsTab(false);
+  }
+
+  private void handleBackNav() {
+    requireActivity()
+        .getOnBackPressedDispatcher()
+        .addCallback(
+            getViewLifecycleOwner(),
+            new OnBackPressedCallback(true) {
+              @Override
+              public void handleOnBackPressed() {
+                Log.d(TAG, "Back pressed, going to election");
+                LaoActivity.setCurrentFragment(
+                    getParentFragmentManager(),
+                    R.id.fragment_election,
+                    () -> ElectionFragment.newInstance(requireArguments().getString(ELECTION_ID)));
+              }
+            });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionFragment.java
@@ -13,6 +13,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.core.widget.ImageViewCompat;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.model.objects.Election;
@@ -394,5 +395,10 @@ public class ElectionFragment extends Fragment {
                     getParentFragmentManager(), R.id.fragment_event_list, EventListFragment::new);
               }
             });
+  }
+
+  public static void openFragment(FragmentManager manager, String electionId) {
+    LaoActivity.setCurrentFragment(
+        manager, R.id.fragment_election, () -> ElectionFragment.newInstance(electionId));
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionFragment.java
@@ -3,9 +3,11 @@ package com.github.dedis.popstellar.ui.lao.event.election.fragments;
 import android.app.AlertDialog;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.*;
 import android.widget.*;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.content.res.AppCompatResources;
@@ -19,6 +21,7 @@ import com.github.dedis.popstellar.repository.ElectionRepository;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.ui.lao.event.election.ElectionViewModel;
+import com.github.dedis.popstellar.ui.lao.event.eventlist.EventListFragment;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 import com.github.dedis.popstellar.utility.error.UnknownElectionException;
 
@@ -184,6 +187,7 @@ public class ElectionFragment extends Fragment {
           }
         });
 
+    handleBackNav();
     return view;
   }
 
@@ -375,5 +379,20 @@ public class ElectionFragment extends Fragment {
   private void setButtonEnabling(Button button, boolean enabled) {
     button.setAlpha(enabled ? ENABLED_ALPHA : DISABLED_ALPHA);
     button.setEnabled(enabled);
+  }
+
+  private void handleBackNav() {
+    requireActivity()
+        .getOnBackPressedDispatcher()
+        .addCallback(
+            getViewLifecycleOwner(),
+            new OnBackPressedCallback(true) {
+              @Override
+              public void handleOnBackPressed() {
+                Log.d(TAG, "Back pressed, going to event list");
+                LaoActivity.setCurrentFragment(
+                    getParentFragmentManager(), R.id.fragment_event_list, EventListFragment::new);
+              }
+            });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionResultFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionResultFragment.java
@@ -96,19 +96,16 @@ public class ElectionResultFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    requireActivity()
-        .getOnBackPressedDispatcher()
-        .addCallback(
-            getViewLifecycleOwner(),
-            new OnBackPressedCallback(true) {
-              @Override
-              public void handleOnBackPressed() {
-                Log.d(TAG, "Back pressed, going to election");
-                LaoActivity.setCurrentFragment(
-                    getParentFragmentManager(),
-                    R.id.fragment_election,
-                    () -> ElectionFragment.newInstance(requireArguments().getString(ELECTION_ID)));
-              }
-            });
+    LaoActivity.addBackNavigationInstruction(
+        requireActivity(),
+        getViewLifecycleOwner(),
+        new OnBackPressedCallback(true) {
+          @Override
+          public void handleOnBackPressed() {
+            Log.d(TAG, "Back pressed, going to election");
+            ElectionFragment.openFragment(
+                getParentFragmentManager(), requireArguments().getString(ELECTION_ID));
+          }
+        });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionResultFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionResultFragment.java
@@ -96,7 +96,7 @@ public class ElectionResultFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationInstruction(
+    LaoActivity.addBackNavigationCallback(
         requireActivity(),
         getViewLifecycleOwner(),
         new OnBackPressedCallback(true) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionResultFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionResultFragment.java
@@ -1,8 +1,10 @@
 package com.github.dedis.popstellar.ui.lao.event.election.fragments;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.*;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager2.widget.ViewPager2;
@@ -81,6 +83,8 @@ public class ElectionResultFragment extends Fragment {
     }
 
     binding.setLifecycleOwner(getViewLifecycleOwner());
+
+    handleBackNav();
     return binding.getRoot();
   }
 
@@ -89,5 +93,22 @@ public class ElectionResultFragment extends Fragment {
     super.onResume();
     viewModel.setPageTitle(R.string.election_result_title);
     viewModel.setIsTab(false);
+  }
+
+  private void handleBackNav() {
+    requireActivity()
+        .getOnBackPressedDispatcher()
+        .addCallback(
+            getViewLifecycleOwner(),
+            new OnBackPressedCallback(true) {
+              @Override
+              public void handleOnBackPressed() {
+                Log.d(TAG, "Back pressed, going to election");
+                LaoActivity.setCurrentFragment(
+                    getParentFragmentManager(),
+                    R.id.fragment_election,
+                    () -> ElectionFragment.newInstance(requireArguments().getString(ELECTION_ID)));
+              }
+            });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionSetupFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionSetupFragment.java
@@ -8,6 +8,7 @@ import android.view.*;
 import android.widget.*;
 import android.widget.AdapterView.OnItemSelectedListener;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.viewpager2.widget.ViewPager2;
@@ -177,14 +178,10 @@ public class ElectionSetupFragment extends AbstractEventCreationFragment {
     setUpElectionVersionSpinner(versionSpinner, listener);
 
     binding.setLifecycleOwner(getActivity());
-
-    return binding.getRoot();
-  }
-
-  @Override
-  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-    super.onViewCreated(view, savedInstanceState);
     setupElectionSubmitButton();
+
+    handleBackNav();
+    return binding.getRoot();
   }
 
   @Override
@@ -297,5 +294,20 @@ public class ElectionSetupFragment extends AbstractEventCreationFragment {
     adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
     spinner.setAdapter(adapter);
     spinner.setOnItemSelectedListener(listener);
+  }
+
+  private void handleBackNav() {
+    requireActivity()
+        .getOnBackPressedDispatcher()
+        .addCallback(
+            getViewLifecycleOwner(),
+            new OnBackPressedCallback(true) {
+              @Override
+              public void handleOnBackPressed() {
+                Log.d(TAG, "Back pressed, going to event list");
+                LaoActivity.setCurrentFragment(
+                    getParentFragmentManager(), R.id.fragment_event_list, EventListFragment::new);
+              }
+            });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionSetupFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionSetupFragment.java
@@ -297,7 +297,7 @@ public class ElectionSetupFragment extends AbstractEventCreationFragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationInstruction(
+    LaoActivity.addBackNavigationCallback(
         requireActivity(),
         getViewLifecycleOwner(),
         new OnBackPressedCallback(true) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionSetupFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionSetupFragment.java
@@ -297,17 +297,15 @@ public class ElectionSetupFragment extends AbstractEventCreationFragment {
   }
 
   private void handleBackNav() {
-    requireActivity()
-        .getOnBackPressedDispatcher()
-        .addCallback(
-            getViewLifecycleOwner(),
-            new OnBackPressedCallback(true) {
-              @Override
-              public void handleOnBackPressed() {
-                Log.d(TAG, "Back pressed, going to event list");
-                LaoActivity.setCurrentFragment(
-                    getParentFragmentManager(), R.id.fragment_event_list, EventListFragment::new);
-              }
-            });
+    LaoActivity.addBackNavigationInstruction(
+        requireActivity(),
+        getViewLifecycleOwner(),
+        new OnBackPressedCallback(true) {
+          @Override
+          public void handleOnBackPressed() {
+            Log.d(TAG, "Back pressed, going to event list");
+            EventListFragment.openFragment(getParentFragmentManager());
+          }
+        });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventListFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventListFragment.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -187,5 +188,9 @@ public class EventListFragment extends Fragment {
 
   private void setupEmptyEventsTextVisibility(Set<Event> events) {
     binding.emptyEventsLayout.setVisibility(events.isEmpty() ? View.VISIBLE : View.GONE);
+  }
+
+  public static void openFragment(FragmentManager manager) {
+    LaoActivity.setCurrentFragment(manager, R.id.fragment_event_list, EventListFragment::new);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallCreationFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallCreationFragment.java
@@ -3,10 +3,12 @@ package com.github.dedis.popstellar.ui.lao.event.rollcall;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.view.*;
 import android.widget.Button;
 import android.widget.EditText;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -89,6 +91,7 @@ public final class RollCallCreationFragment extends AbstractEventCreationFragmen
 
     binding.setLifecycleOwner(getActivity());
 
+    handleBackNav();
     return binding.getRoot();
   }
 
@@ -138,5 +141,20 @@ public final class RollCallCreationFragment extends AbstractEventCreationFragmen
             error ->
                 ErrorUtils.logAndShow(
                     requireContext(), TAG, error, R.string.error_create_rollcall)));
+  }
+
+  private void handleBackNav() {
+    requireActivity()
+        .getOnBackPressedDispatcher()
+        .addCallback(
+            getViewLifecycleOwner(),
+            new OnBackPressedCallback(true) {
+              @Override
+              public void handleOnBackPressed() {
+                Log.d(TAG, "Back pressed, going to event list");
+                LaoActivity.setCurrentFragment(
+                    getParentFragmentManager(), R.id.fragment_event_list, EventListFragment::new);
+              }
+            });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallCreationFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallCreationFragment.java
@@ -144,7 +144,7 @@ public final class RollCallCreationFragment extends AbstractEventCreationFragmen
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationInstruction(
+    LaoActivity.addBackNavigationCallback(
         requireActivity(),
         getViewLifecycleOwner(),
         new OnBackPressedCallback(true) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallCreationFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallCreationFragment.java
@@ -144,17 +144,15 @@ public final class RollCallCreationFragment extends AbstractEventCreationFragmen
   }
 
   private void handleBackNav() {
-    requireActivity()
-        .getOnBackPressedDispatcher()
-        .addCallback(
-            getViewLifecycleOwner(),
-            new OnBackPressedCallback(true) {
-              @Override
-              public void handleOnBackPressed() {
-                Log.d(TAG, "Back pressed, going to event list");
-                LaoActivity.setCurrentFragment(
-                    getParentFragmentManager(), R.id.fragment_event_list, EventListFragment::new);
-              }
-            });
+    LaoActivity.addBackNavigationInstruction(
+        requireActivity(),
+        getViewLifecycleOwner(),
+        new OnBackPressedCallback(true) {
+          @Override
+          public void handleOnBackPressed() {
+            Log.d(TAG, "Back pressed, going to event list");
+            EventListFragment.openFragment(getParentFragmentManager());
+          }
+        });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
@@ -7,6 +7,7 @@ import android.util.Log;
 import android.view.*;
 import android.widget.ImageView;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.content.res.AppCompatResources;
@@ -155,6 +156,7 @@ public class RollCallFragment extends Fragment {
 
     retrieveAndDisplayPublicKey();
 
+    handleBackNav();
     return binding.getRoot();
   }
 
@@ -289,6 +291,21 @@ public class RollCallFragment extends Fragment {
     map.put(EventState.OPENED, R.drawable.ic_lock);
     map.put(EventState.CLOSED, R.drawable.ic_unlock);
     return map;
+  }
+
+  private void handleBackNav() {
+    requireActivity()
+        .getOnBackPressedDispatcher()
+        .addCallback(
+            getViewLifecycleOwner(),
+            new OnBackPressedCallback(true) {
+              @Override
+              public void handleOnBackPressed() {
+                Log.d(TAG, "Back pressed, going to event list");
+                LaoActivity.setCurrentFragment(
+                    getParentFragmentManager(), R.id.fragment_event_list, EventListFragment::new);
+              }
+            });
   }
 
   /**

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListFragment.java
@@ -7,6 +7,7 @@ import android.widget.ListView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.ChirpListFragmentBinding;
@@ -73,5 +74,10 @@ public class ChirpListFragment extends Fragment {
     ChirpListAdapter mChirpListAdapter =
         new ChirpListAdapter(requireActivity(), socialMediaViewModel, viewModel);
     listView.setAdapter(mChirpListAdapter);
+  }
+
+  public static void OpenFragment(FragmentManager manager) {
+    SocialMediaHomeFragment.setCurrentFragment(
+        manager, R.id.fragment_chirp_list, ChirpListFragment::newInstance);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaSendFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaSendFragment.java
@@ -111,7 +111,7 @@ public class SocialMediaSendFragment extends Fragment {
               @Override
               public void handleOnBackPressed() {
                 Log.d(TAG, "Back pressed, going back to chirp list");
-                LaoActivity.setCurrentFragment(
+                SocialMediaHomeFragment.setCurrentFragment(
                     getParentFragmentManager(),
                     R.id.fragment_chirp_list,
                     ChirpListFragment::newInstance);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaSendFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaSendFragment.java
@@ -3,6 +3,7 @@ package com.github.dedis.popstellar.ui.lao.socialmedia;
 import android.os.Bundle;
 import android.view.*;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -48,6 +49,7 @@ public class SocialMediaSendFragment extends Fragment {
     binding.setViewModel(socialMediaViewModel);
     binding.setLifecycleOwner(getViewLifecycleOwner());
 
+    handleBackNav();
     return binding.getRoot();
   }
 
@@ -97,5 +99,20 @@ public class SocialMediaSendFragment extends Fragment {
                   }));
       socialMediaViewModel.setBottomNavigationTab(SocialMediaTab.HOME);
     }
+  }
+
+  private void handleBackNav() {
+    requireActivity()
+        .getOnBackPressedDispatcher()
+        .addCallback(
+            new OnBackPressedCallback(true) {
+              @Override
+              public void handleOnBackPressed() {
+                LaoActivity.setCurrentFragment(
+                    getParentFragmentManager(),
+                    R.id.fragment_chirp_list,
+                    ChirpListFragment::newInstance);
+              }
+            });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaSendFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaSendFragment.java
@@ -103,19 +103,15 @@ public class SocialMediaSendFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    requireActivity()
-        .getOnBackPressedDispatcher()
-        .addCallback(
-            getViewLifecycleOwner(),
-            new OnBackPressedCallback(true) {
-              @Override
-              public void handleOnBackPressed() {
-                Log.d(TAG, "Back pressed, going back to chirp list");
-                SocialMediaHomeFragment.setCurrentFragment(
-                    getParentFragmentManager(),
-                    R.id.fragment_chirp_list,
-                    ChirpListFragment::newInstance);
-              }
-            });
+    LaoActivity.addBackNavigationInstruction(
+        requireActivity(),
+        getViewLifecycleOwner(),
+        new OnBackPressedCallback(true) {
+          @Override
+          public void handleOnBackPressed() {
+            Log.d(TAG, "Back pressed, going back to chirp list");
+            ChirpListFragment.OpenFragment(getParentFragmentManager());
+          }
+        });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaSendFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaSendFragment.java
@@ -103,7 +103,7 @@ public class SocialMediaSendFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationInstruction(
+    LaoActivity.addBackNavigationCallback(
         requireActivity(),
         getViewLifecycleOwner(),
         new OnBackPressedCallback(true) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaSendFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaSendFragment.java
@@ -1,6 +1,7 @@
 package com.github.dedis.popstellar.ui.lao.socialmedia;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.*;
 
 import androidx.activity.OnBackPressedCallback;
@@ -105,9 +106,11 @@ public class SocialMediaSendFragment extends Fragment {
     requireActivity()
         .getOnBackPressedDispatcher()
         .addCallback(
+            getViewLifecycleOwner(),
             new OnBackPressedCallback(true) {
               @Override
               public void handleOnBackPressed() {
+                Log.d(TAG, "Back pressed, going back to chirp list");
                 LaoActivity.setCurrentFragment(
                     getParentFragmentManager(),
                     R.id.fragment_chirp_list,

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenFragment.java
@@ -110,9 +110,11 @@ public class TokenFragment extends Fragment {
     requireActivity()
         .getOnBackPressedDispatcher()
         .addCallback(
+            getViewLifecycleOwner(),
             new OnBackPressedCallback(true) {
               @Override
               public void handleOnBackPressed() {
+                Log.d(TAG, "Back pressed, going to token list");
                 LaoActivity.setCurrentFragment(
                     getParentFragmentManager(), R.id.fragment_tokens, TokenListFragment::new);
               }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenFragment.java
@@ -107,17 +107,15 @@ public class TokenFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    requireActivity()
-        .getOnBackPressedDispatcher()
-        .addCallback(
-            getViewLifecycleOwner(),
-            new OnBackPressedCallback(true) {
-              @Override
-              public void handleOnBackPressed() {
-                Log.d(TAG, "Back pressed, going to token list");
-                LaoActivity.setCurrentFragment(
-                    getParentFragmentManager(), R.id.fragment_tokens, TokenListFragment::new);
-              }
-            });
+    LaoActivity.addBackNavigationInstruction(
+        requireActivity(),
+        getViewLifecycleOwner(),
+        new OnBackPressedCallback(true) {
+          @Override
+          public void handleOnBackPressed() {
+            Log.d(TAG, "Back pressed, going to token list");
+            TokenListFragment.openFragment(getParentFragmentManager());
+          }
+        });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenFragment.java
@@ -107,7 +107,7 @@ public class TokenFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationInstruction(
+    LaoActivity.addBackNavigationCallback(
         requireActivity(),
         getViewLifecycleOwner(),
         new OnBackPressedCallback(true) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenFragment.java
@@ -7,6 +7,7 @@ import android.util.Log;
 import android.view.*;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
@@ -94,6 +95,7 @@ public class TokenFragment extends Fragment {
       return null;
     }
 
+    handleBackNav();
     return binding.getRoot();
   }
 
@@ -102,5 +104,18 @@ public class TokenFragment extends Fragment {
         (ClipboardManager) getActivity().getSystemService(Context.CLIPBOARD_SERVICE);
     ClipData clip = ClipData.newPlainText(token, token);
     clipboard.setPrimaryClip(clip);
+  }
+
+  private void handleBackNav() {
+    requireActivity()
+        .getOnBackPressedDispatcher()
+        .addCallback(
+            new OnBackPressedCallback(true) {
+              @Override
+              public void handleOnBackPressed() {
+                LaoActivity.setCurrentFragment(
+                    getParentFragmentManager(), R.id.fragment_tokens, TokenListFragment::new);
+              }
+            });
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenListFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenListFragment.java
@@ -7,6 +7,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 
 import com.github.dedis.popstellar.R;
@@ -117,5 +118,9 @@ public class TokenListFragment extends Fragment {
                   binding.validTokenLayout.setVisibility(View.GONE);
                   binding.previousTokenLayout.setVisibility(View.GONE);
                 }));
+  }
+
+  public static void openFragment(FragmentManager manager) {
+    LaoActivity.setCurrentFragment(manager, R.id.fragment_tokens, TokenListFragment::new);
   }
 }


### PR DESCRIPTION
This PR adds back navigation for non tabs fragments in `LaoActivity`. Back navigation for tabs fragment (i.e. those that you can select from the navigation drawer) is still to be done.