### PR TITLE
Show only user's transactions in digital cash's transactions history

### DIFF
--- a/fe1-web/src/core/navigation/typing/DigitalCashParamList.ts
+++ b/fe1-web/src/core/navigation/typing/DigitalCashParamList.ts
@@ -1,9 +1,7 @@
 import STRINGS from 'resources/strings';
 
 export type DigitalCashParamList = {
-  [STRINGS.navigation_digital_cash_wallet]: {
-    rollCallId?: string;
-  };
+  [STRINGS.navigation_digital_cash_wallet]: undefined;
 
   [STRINGS.navigation_digital_cash_send_receive]: {
     /* undefined indicates coinbase transactions (coin issuance from the organizer) */

--- a/fe1-web/src/core/navigation/typing/DigitalCashParamList.ts
+++ b/fe1-web/src/core/navigation/typing/DigitalCashParamList.ts
@@ -1,7 +1,9 @@
 import STRINGS from 'resources/strings';
 
 export type DigitalCashParamList = {
-  [STRINGS.navigation_digital_cash_wallet]: undefined;
+  [STRINGS.navigation_digital_cash_wallet]: {
+    rollCallId?: string;
+  };
 
   [STRINGS.navigation_digital_cash_send_receive]: {
     /* undefined indicates coinbase transactions (coin issuance from the organizer) */

--- a/fe1-web/src/features/digital-cash/components/TransactionHistory.tsx
+++ b/fe1-web/src/features/digital-cash/components/TransactionHistory.tsx
@@ -5,7 +5,7 @@ import { Modal, View } from 'react-native';
 import { ScrollView, TouchableWithoutFeedback } from 'react-native-gesture-handler';
 
 import ModalHeader from 'core/components/ModalHeader';
-import { Hash } from 'core/objects';
+import { Hash, PublicKey } from 'core/objects';
 import { List, ModalStyles, Typography } from 'core/styles';
 import { COINBASE_HASH } from 'resources/const';
 import STRINGS from 'resources/strings';
@@ -14,9 +14,10 @@ import { DigitalCashHooks } from '../hooks';
 import { Transaction, TransactionState } from '../objects/transaction';
 
 /**
- * UI for the transactions history
+ * UI for the transactions history. If a public key is given, it displays only the transactions involving the user.
+ * Otherwise, it displays the entire history.
  */
-const TransactionHistory = ({ laoId }: IPropTypes) => {
+const TransactionHistory = ({ laoId, publicKey }: IPropTypes) => {
   const [showTransactionHistory, setShowTransactionHistory] = useState<boolean>(false);
   const [showInputs, setShowInputs] = useState<boolean>(true);
   const [showOutputs, setShowOutputs] = useState<boolean>(true);
@@ -24,7 +25,7 @@ const TransactionHistory = ({ laoId }: IPropTypes) => {
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null);
   const [showModal, setShowModal] = useState<boolean>(false);
 
-  const transactions: Transaction[] = DigitalCashHooks.useTransactions(laoId);
+  const transactions: Transaction[] = DigitalCashHooks.useTransactionsByPublicKey(laoId, publicKey);
 
   // We need this mapping to show the amount for each input
   const transactionsByHash: Record<string, TransactionState> =
@@ -193,9 +194,14 @@ const TransactionHistory = ({ laoId }: IPropTypes) => {
 
 const propTypes = {
   laoId: PropTypes.instanceOf(Hash).isRequired,
+  publicKey: PropTypes.instanceOf(PublicKey),
 };
 
 TransactionHistory.propTypes = propTypes;
+
+TransactionHistory.defaultProps = {
+  publicKey: undefined,
+};
 
 type IPropTypes = PropTypes.InferProps<typeof propTypes>;
 

--- a/fe1-web/src/features/digital-cash/components/TransactionHistory.tsx
+++ b/fe1-web/src/features/digital-cash/components/TransactionHistory.tsx
@@ -25,7 +25,13 @@ const TransactionHistory = ({ laoId, publicKey }: IPropTypes) => {
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null);
   const [showModal, setShowModal] = useState<boolean>(false);
 
-  const transactions: Transaction[] = DigitalCashHooks.useTransactionsByPublicKey(laoId, publicKey);
+  let pubKey;
+  if (publicKey === null) {
+    pubKey = undefined;
+  } else {
+    pubKey = publicKey;
+  }
+  const transactions: Transaction[] = DigitalCashHooks.useTransactionsByPublicKey(laoId, pubKey);
 
   // We need this mapping to show the amount for each input
   const transactionsByHash: Record<string, TransactionState> =

--- a/fe1-web/src/features/digital-cash/components/TransactionHistory.tsx
+++ b/fe1-web/src/features/digital-cash/components/TransactionHistory.tsx
@@ -5,7 +5,7 @@ import { Modal, View } from 'react-native';
 import { ScrollView, TouchableWithoutFeedback } from 'react-native-gesture-handler';
 
 import ModalHeader from 'core/components/ModalHeader';
-import { Hash, PublicKey } from 'core/objects';
+import { Hash, RollCallToken } from 'core/objects';
 import { List, ModalStyles, Typography } from 'core/styles';
 import { COINBASE_HASH } from 'resources/const';
 import STRINGS from 'resources/strings';
@@ -14,10 +14,9 @@ import { DigitalCashHooks } from '../hooks';
 import { Transaction, TransactionState } from '../objects/transaction';
 
 /**
- * UI for the transactions history. If a public key is given, it displays only the transactions involving the user.
- * Otherwise, it displays the entire history.
+ * UI for the transactions history given roll call tokens of the user in the lao.
  */
-const TransactionHistory = ({ laoId, publicKey }: IPropTypes) => {
+const TransactionHistory = ({ laoId, rollCallTokens }: IPropTypes) => {
   const [showTransactionHistory, setShowTransactionHistory] = useState<boolean>(false);
   const [showInputs, setShowInputs] = useState<boolean>(true);
   const [showOutputs, setShowOutputs] = useState<boolean>(true);
@@ -25,13 +24,11 @@ const TransactionHistory = ({ laoId, publicKey }: IPropTypes) => {
   const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null);
   const [showModal, setShowModal] = useState<boolean>(false);
 
-  let pubKey;
-  if (publicKey === null) {
-    pubKey = undefined;
-  } else {
-    pubKey = publicKey;
-  }
-  const transactions: Transaction[] = DigitalCashHooks.useTransactionsByPublicKey(laoId, pubKey);
+  // If we want to show all transactions, just use DigitalCashHooks.useTransactions(laoId)
+  const transactions: Transaction[] = DigitalCashHooks.useTransactionsByRollCallTokens(
+    laoId,
+    rollCallTokens,
+  );
 
   // We need this mapping to show the amount for each input
   const transactionsByHash: Record<string, TransactionState> =
@@ -200,14 +197,10 @@ const TransactionHistory = ({ laoId, publicKey }: IPropTypes) => {
 
 const propTypes = {
   laoId: PropTypes.instanceOf(Hash).isRequired,
-  publicKey: PropTypes.instanceOf(PublicKey),
+  rollCallTokens: PropTypes.arrayOf(PropTypes.instanceOf(RollCallToken).isRequired).isRequired,
 };
 
 TransactionHistory.propTypes = propTypes;
-
-TransactionHistory.defaultProps = {
-  publicKey: undefined,
-};
 
 type IPropTypes = PropTypes.InferProps<typeof propTypes>;
 

--- a/fe1-web/src/features/digital-cash/components/__tests__/TransactionHistory.test.tsx
+++ b/fe1-web/src/features/digital-cash/components/__tests__/TransactionHistory.test.tsx
@@ -10,8 +10,8 @@ import { Transaction } from 'features/digital-cash/objects/transaction';
 import {
   mockCBHash,
   mockCoinbaseTransactionJSON,
-  mockTransactionHash,
   mockTransactionState,
+  mockRollCallToken,
   mockDigitalCashContextValue,
 } from '../../__tests__/utils';
 import TransactionHistory from '../TransactionHistory';
@@ -20,19 +20,16 @@ jest.mock('features/digital-cash/hooks');
 
 const mockCoinbase = Transaction.fromJSON(mockCoinbaseTransactionJSON, mockCBHash);
 
-(DigitalCashHooks.useTransactions as jest.Mock).mockReturnValue([
+(DigitalCashHooks.useTransactionsByRollCallTokens as jest.Mock).mockReturnValue([
   mockCoinbase,
   Transaction.fromState(mockTransactionState),
 ]);
 
-(DigitalCashHooks.useTransactionsByHash as jest.Mock).mockReturnValue({
-  [mockCBHash.valueOf()]: mockCoinbase.toState(),
-  [mockTransactionHash.valueOf()]: mockTransactionState,
-});
-
 describe('TransactionHistory', () => {
   it('renders correctly', () => {
-    const Screen = () => <TransactionHistory laoId={mockLaoId} />;
+    const Screen = () => (
+      <TransactionHistory laoId={mockLaoId} rollCallTokens={[mockRollCallToken]} />
+    );
 
     const { toJSON } = render(
       <FeatureContext.Provider value={mockDigitalCashContextValue(true)}>

--- a/fe1-web/src/features/digital-cash/hooks/DigitalCashHooks.ts
+++ b/fe1-web/src/features/digital-cash/hooks/DigitalCashHooks.ts
@@ -2,13 +2,14 @@ import { useContext, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import FeatureContext from 'core/contexts/FeatureContext';
-import { Hash } from 'core/objects';
+import { Hash, PublicKey } from 'core/objects';
 
 import { DigitalCashReactContext, DIGITAL_CASH_FEATURE_IDENTIFIER } from '../interface';
 import { Transaction } from '../objects/transaction';
 import {
   makeBalancesSelector,
   makeTransactionsByHashSelector,
+  makeTransactionsByPublicKeySelector,
   makeTransactionsSelector,
 } from '../reducer';
 
@@ -111,6 +112,27 @@ export namespace DigitalCashHooks {
           0,
         ),
       [rollCallTokens, balances],
+    );
+  };
+
+  /**
+   * Gets the list of all transactions where a user is involved. If the public key is undefined,
+   * it returns all transactions.
+   * To use only in a React component.
+   * @param laoId
+   * @param userPublicKey
+   */
+  export const useTransactionsByPublicKey = (laoId: Hash, userPublicKey?: PublicKey) => {
+    const transactionsByPubKeySelector = useMemo(
+      () => makeTransactionsByPublicKeySelector(laoId, userPublicKey),
+      [laoId, userPublicKey],
+    );
+
+    const transactionStates = useSelector(transactionsByPubKeySelector);
+
+    return useMemo(
+      () => transactionStates.map((state) => Transaction.fromState(state)),
+      [transactionStates],
     );
   };
 }

--- a/fe1-web/src/features/digital-cash/hooks/DigitalCashHooks.ts
+++ b/fe1-web/src/features/digital-cash/hooks/DigitalCashHooks.ts
@@ -117,10 +117,10 @@ export namespace DigitalCashHooks {
 
   /**
    * Gets the list of all transactions where a user is involved. If the public key is undefined,
-   * it returns all transactions.
+   * it returns all transactions of the LAO.
    * To use only in a React component.
    * @param laoId
-   * @param userPublicKey
+   * @param userPublicKey?
    */
   export const useTransactionsByPublicKey = (laoId: Hash, userPublicKey?: PublicKey) => {
     const transactionsByPubKeySelector = useMemo(

--- a/fe1-web/src/features/digital-cash/hooks/DigitalCashHooks.ts
+++ b/fe1-web/src/features/digital-cash/hooks/DigitalCashHooks.ts
@@ -9,7 +9,7 @@ import { Transaction } from '../objects/transaction';
 import {
   makeBalancesSelector,
   makeTransactionsByHashSelector,
-  makeTransactionsByRollCallTokens,
+  makeTransactionsByRollCallTokenSelector,
   makeTransactionsSelector,
 } from '../reducer';
 
@@ -123,7 +123,7 @@ export namespace DigitalCashHooks {
    */
   export const useTransactionsByRollCallTokens = (laoId: Hash, rollCallTokens: RollCallToken[]) => {
     const transactionsByTokensSelector = useMemo(
-      () => makeTransactionsByRollCallTokens(laoId, rollCallTokens),
+      () => makeTransactionsByRollCallTokenSelector(laoId, rollCallTokens),
       [laoId, rollCallTokens],
     );
 

--- a/fe1-web/src/features/digital-cash/hooks/DigitalCashHooks.ts
+++ b/fe1-web/src/features/digital-cash/hooks/DigitalCashHooks.ts
@@ -2,14 +2,14 @@ import { useContext, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import FeatureContext from 'core/contexts/FeatureContext';
-import { Hash, PublicKey } from 'core/objects';
+import { Hash, RollCallToken } from 'core/objects';
 
 import { DigitalCashReactContext, DIGITAL_CASH_FEATURE_IDENTIFIER } from '../interface';
 import { Transaction } from '../objects/transaction';
 import {
   makeBalancesSelector,
   makeTransactionsByHashSelector,
-  makeTransactionsByPublicKeySelector,
+  makeTransactionsByRollCallTokens,
   makeTransactionsSelector,
 } from '../reducer';
 
@@ -116,19 +116,18 @@ export namespace DigitalCashHooks {
   };
 
   /**
-   * Gets the list of all transactions where a user is involved. If the public key is undefined,
-   * it returns all transactions of the LAO.
+   * Gets the list of all transactions where a list of roll call tokens are involved.
    * To use only in a React component.
    * @param laoId
-   * @param userPublicKey?
+   * @param rollCallTokens
    */
-  export const useTransactionsByPublicKey = (laoId: Hash, userPublicKey?: PublicKey) => {
-    const transactionsByPubKeySelector = useMemo(
-      () => makeTransactionsByPublicKeySelector(laoId, userPublicKey),
-      [laoId, userPublicKey],
+  export const useTransactionsByRollCallTokens = (laoId: Hash, rollCallTokens: RollCallToken[]) => {
+    const transactionsByTokensSelector = useMemo(
+      () => makeTransactionsByRollCallTokens(laoId, rollCallTokens),
+      [laoId, rollCallTokens],
     );
 
-    const transactionStates = useSelector(transactionsByPubKeySelector);
+    const transactionStates = useSelector(transactionsByTokensSelector);
 
     return useMemo(
       () => transactionStates.map((state) => Transaction.fromState(state)),

--- a/fe1-web/src/features/digital-cash/network/DigitalCashMessageApi.ts
+++ b/fe1-web/src/features/digital-cash/network/DigitalCashMessageApi.ts
@@ -22,7 +22,7 @@ export async function requestSendTransaction(
   amount: number,
   laoId: Hash,
 ): Promise<void> {
-  const transactionStates = DigitalCashStore.getTransactionsByPublicKey(laoId, from.publicKey);
+  const transactionStates = DigitalCashStore.getTransactionsByOutPublicKey(laoId, from.publicKey);
 
   if (transactionStates.length === 0) {
     throw new Error(makeErr('no transaction out were found for this public key'));

--- a/fe1-web/src/features/digital-cash/network/__tests__/DigitalCashMessageApi.test.tsx
+++ b/fe1-web/src/features/digital-cash/network/__tests__/DigitalCashMessageApi.test.tsx
@@ -15,7 +15,7 @@ import {
 import { requestSendTransaction, requestCoinbaseTransaction } from '../DigitalCashMessageApi';
 
 jest.mock('features/digital-cash/store/DigitalCashStore');
-const getTransactionsByPublicKeyMock = DigitalCashStore.getTransactionsByPublicKey as jest.Mock;
+const getTransactionsByPublicKeyMock = DigitalCashStore.getTransactionsByOutPublicKey as jest.Mock;
 
 jest.mock('core/network/JsonRpcApi');
 const publishMock = publish as jest.Mock;

--- a/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
+++ b/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
@@ -193,14 +193,19 @@ export const makeTransactionsByHashSelector = (laoId: Hash) =>
  */
 export const makeTransactionsByPublicKeySelector = (laoId: Hash, publicKey?: PublicKey) =>
   createSelector(
+    (state: any) => getDigitalCashState(state).byLaoId[laoId.valueOf()]?.allTransactionsHash,
     (state: any) => getDigitalCashState(state).byLaoId[laoId.valueOf()]?.transactionsByHash,
     (state: any) => getDigitalCashState(state).byLaoId[laoId.valueOf()]?.transactionsByPubHash,
     (
+      transactionHashes: string[] | undefined,
       transactionsByHash: Record<string, TransactionState> | undefined,
       transactionsByPubHash: Record<string, string[]> | undefined,
     ) => {
       if (!publicKey) {
-        return makeTransactionsSelector(laoId);
+        if (transactionHashes && transactionsByHash) {
+          return transactionHashes.map((hash) => transactionsByHash[hash]);
+        }
+        return [];
       }
       if (transactionsByHash && transactionsByPubHash) {
         return transactionsByPubHash[Hash.fromPublicKey(publicKey).valueOf()].map(

--- a/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
+++ b/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
@@ -28,7 +28,7 @@ export interface DigitalCashReducerState {
 
   /**
    * A mapping between public key hashes and an array of hash of transactions which contains
-   * this public key hash in one or more of their TxOuts
+   * this public key hash in one or more of their TxOuts or their TxIns
    */
   transactionsByPubHash: Record<string, string[]>;
 }
@@ -98,7 +98,7 @@ const digitalCashSlice = createSlice({
           // If this is not a coinbase transaction, then as we are sure that all inputs are used
           if (input.txOutHash !== COINBASE_HASH) {
             laoState.balances[pubHash] = 0;
-            laoState.transactionsByPubHash[pubHash] = [];
+            laoState.transactionsByPubHash[pubHash] = [transactionHash];
           }
         });
 
@@ -113,7 +113,10 @@ const digitalCashSlice = createSlice({
           if (!(pubKeyHash in laoState.transactionsByPubHash)) {
             laoState.transactionsByPubHash[pubKeyHash] = [];
           }
-          laoState.transactionsByPubHash[pubKeyHash].push(transactionHash);
+
+          if (!(transactionHash in laoState.transactionsByPubHash[pubKeyHash])) {
+            laoState.transactionsByPubHash[pubKeyHash].push(transactionHash);
+          }
         });
       },
     },

--- a/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
+++ b/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
@@ -184,3 +184,29 @@ export const makeTransactionsByHashSelector = (laoId: Hash) =>
       return transactionsByHash || {};
     },
   );
+
+/**
+ * Selector for the transactions that involve a user (characterized by its public key). If the public key
+ * is undefined, it returns all transactions.
+ * @param laoId
+ * @param publicKey
+ */
+export const makeTransactionsByPublicKeySelector = (laoId: Hash, publicKey?: PublicKey) =>
+  createSelector(
+    (state: any) => getDigitalCashState(state).byLaoId[laoId.valueOf()]?.transactionsByHash,
+    (state: any) => getDigitalCashState(state).byLaoId[laoId.valueOf()]?.transactionsByPubHash,
+    (
+      transactionsByHash: Record<string, TransactionState> | undefined,
+      transactionsByPubHash: Record<string, string[]> | undefined,
+    ) => {
+      if (!publicKey) {
+        return makeTransactionsSelector(laoId);
+      }
+      if (transactionsByHash && transactionsByPubHash) {
+        return transactionsByPubHash[Hash.fromPublicKey(publicKey).valueOf()].map(
+          (hash) => transactionsByHash[hash],
+        );
+      }
+      return [];
+    },
+  );

--- a/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
+++ b/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
@@ -51,6 +51,20 @@ const initialState: DigitalCashLaoReducerState = {
 /* Name of digital cash slice in storage */
 export const DIGITAL_CASH_REDUCER_PATH = 'digitalCash';
 
+const createEntryAndAddInvPubHash = (
+  laoState: DigitalCashReducerState,
+  pubHash: string,
+  transactionHash: string,
+) => {
+  if (!(pubHash in laoState.transactionsByInvPubHash)) {
+    laoState.transactionsByInvPubHash[pubHash] = [];
+  }
+
+  if (!laoState.transactionsByInvPubHash[pubHash].includes(transactionHash)) {
+    laoState.transactionsByInvPubHash[pubHash].push(transactionHash);
+  }
+};
+
 const digitalCashSlice = createSlice({
   name: DIGITAL_CASH_REDUCER_PATH,
   initialState,
@@ -108,13 +122,7 @@ const digitalCashSlice = createSlice({
             laoState.transactionsByPubHash[pubHash] = [];
           }
 
-          if (!(pubHash in laoState.transactionsByInvPubHash)) {
-            laoState.transactionsByInvPubHash[pubHash] = [];
-          }
-
-          if (!laoState.transactionsByInvPubHash[pubHash].includes(transactionHash)) {
-            laoState.transactionsByInvPubHash[pubHash].push(transactionHash);
-          }
+          createEntryAndAddInvPubHash(laoState, pubHash, transactionHash);
         });
 
         transactionState.outputs.forEach((output) => {
@@ -130,13 +138,7 @@ const digitalCashSlice = createSlice({
           }
           laoState.transactionsByPubHash[pubKeyHash].push(transactionHash);
 
-          if (!(pubKeyHash in laoState.transactionsByInvPubHash)) {
-            laoState.transactionsByInvPubHash[pubKeyHash] = [];
-          }
-
-          if (!laoState.transactionsByInvPubHash[pubKeyHash].includes(transactionHash)) {
-            laoState.transactionsByInvPubHash[pubKeyHash].push(transactionHash);
-          }
+          createEntryAndAddInvPubHash(laoState, pubKeyHash, transactionHash);
         });
       },
     },
@@ -224,8 +226,8 @@ export const makeTransactionsByRollCallTokens = (laoId: Hash, rollCallTokens: Ro
       if (transactionsByHash && transactionsByInvPubHash) {
         const transactions: TransactionState[] = [];
 
-        for (let i = 0; i < rollCallTokens.length; i += 1) {
-          const { publicKey } = rollCallTokens[i].token;
+        for (const rollCallToken of rollCallTokens) {
+          const { publicKey } = rollCallToken.token;
           const transactionsOfToken = transactionsByInvPubHash[
             Hash.fromPublicKey(publicKey).valueOf()
           ].map((hash) => transactionsByHash[hash]);

--- a/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
+++ b/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
@@ -215,7 +215,10 @@ export const makeTransactionsByHashSelector = (laoId: Hash) =>
  * @param laoId
  * @param rollCallTokens
  */
-export const makeTransactionsByRollCallTokenSelector = (laoId: Hash, rollCallTokens: RollCallToken[]) =>
+export const makeTransactionsByRollCallTokenSelector = (
+  laoId: Hash,
+  rollCallTokens: RollCallToken[],
+) =>
   createSelector(
     (state: any) => getDigitalCashState(state).byLaoId[laoId.valueOf()]?.transactionsByHash,
     (state: any) => getDigitalCashState(state).byLaoId[laoId.valueOf()]?.transactionsByPubHash,

--- a/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
+++ b/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
@@ -51,7 +51,7 @@ const initialState: DigitalCashLaoReducerState = {
 /* Name of digital cash slice in storage */
 export const DIGITAL_CASH_REDUCER_PATH = 'digitalCash';
 
-const createEntryAndAddInvPubHash = (
+const createEntryAndAddPubHash = (
   laoState: DigitalCashReducerState,
   pubHash: string,
   transactionHash: string,
@@ -122,7 +122,7 @@ const digitalCashSlice = createSlice({
             laoState.transactionsByOutPubHash[pubHash] = [];
           }
 
-          createEntryAndAddInvPubHash(laoState, pubHash, transactionHash);
+          createEntryAndAddPubHash(laoState, pubHash, transactionHash);
         });
 
         transactionState.outputs.forEach((output) => {
@@ -138,7 +138,7 @@ const digitalCashSlice = createSlice({
           }
           laoState.transactionsByOutPubHash[pubKeyHash].push(transactionHash);
 
-          createEntryAndAddInvPubHash(laoState, pubKeyHash, transactionHash);
+          createEntryAndAddPubHash(laoState, pubKeyHash, transactionHash);
         });
       },
     },
@@ -224,14 +224,14 @@ export const makeTransactionsByRollCallTokenSelector = (
     (state: any) => getDigitalCashState(state).byLaoId[laoId.valueOf()]?.transactionsByPubHash,
     (
       transactionsByHash: Record<string, TransactionState> | undefined,
-      transactionsByInvPubHash: Record<string, string[]> | undefined,
+      transactionsByPubHash: Record<string, string[]> | undefined,
     ) => {
-      if (transactionsByHash && transactionsByInvPubHash) {
+      if (transactionsByHash && transactionsByPubHash) {
         const transactions: TransactionState[] = [];
 
         for (const rollCallToken of rollCallTokens) {
           const { publicKey } = rollCallToken.token;
-          const transactionsOfToken = transactionsByInvPubHash[
+          const transactionsOfToken = transactionsByPubHash[
             Hash.fromPublicKey(publicKey).valueOf()
           ].map((hash) => transactionsByHash[hash]);
 

--- a/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
+++ b/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
@@ -98,7 +98,14 @@ const digitalCashSlice = createSlice({
           // If this is not a coinbase transaction, then as we are sure that all inputs are used
           if (input.txOutHash !== COINBASE_HASH) {
             laoState.balances[pubHash] = 0;
-            laoState.transactionsByPubHash[pubHash] = [transactionHash];
+          }
+
+          if (!(pubHash in laoState.transactionsByPubHash)) {
+            laoState.transactionsByPubHash[pubHash] = [];
+          }
+
+          if (!laoState.transactionsByPubHash[pubHash].includes(transactionHash)) {
+            laoState.transactionsByPubHash[pubHash].push(transactionHash);
           }
         });
 
@@ -114,10 +121,11 @@ const digitalCashSlice = createSlice({
             laoState.transactionsByPubHash[pubKeyHash] = [];
           }
 
-          if (!(transactionHash in laoState.transactionsByPubHash[pubKeyHash])) {
+          if (!laoState.transactionsByPubHash[pubKeyHash].includes(transactionHash)) {
             laoState.transactionsByPubHash[pubKeyHash].push(transactionHash);
           }
         });
+        console.log(JSON.stringify(laoState.transactionsByPubHash));
       },
     },
   },

--- a/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
+++ b/fe1-web/src/features/digital-cash/reducer/DigitalCashReducer.ts
@@ -28,15 +28,15 @@ export interface DigitalCashReducerState {
 
   /**
    * A mapping between public key hashes and an array of hash of transactions which contains
-   * this public key hash in one or more of their TxOuts or their TxIns
+   * this public key hash in one or more of their TxOuts.
    */
-  transactionsByPubHash: Record<string, string[]>;
+  transactionsByOutPubHash: Record<string, string[]>;
 
   /**
    * A mapping between public key hashes and an array of hash of transactions in which the public
    * key is involved, as input or output.
    */
-  transactionsByInvPubHash: Record<string, string[]>;
+  transactionsByPubHash: Record<string, string[]>;
 }
 
 export interface DigitalCashLaoReducerState {
@@ -56,12 +56,12 @@ const createEntryAndAddInvPubHash = (
   pubHash: string,
   transactionHash: string,
 ) => {
-  if (!(pubHash in laoState.transactionsByInvPubHash)) {
-    laoState.transactionsByInvPubHash[pubHash] = [];
+  if (!(pubHash in laoState.transactionsByPubHash)) {
+    laoState.transactionsByPubHash[pubHash] = [];
   }
 
-  if (!laoState.transactionsByInvPubHash[pubHash].includes(transactionHash)) {
-    laoState.transactionsByInvPubHash[pubHash].push(transactionHash);
+  if (!laoState.transactionsByPubHash[pubHash].includes(transactionHash)) {
+    laoState.transactionsByPubHash[pubHash].push(transactionHash);
   }
 };
 
@@ -99,8 +99,8 @@ const digitalCashSlice = createSlice({
             balances: {},
             allTransactionsHash: [],
             transactionsByHash: {},
+            transactionsByOutPubHash: {},
             transactionsByPubHash: {},
-            transactionsByInvPubHash: {},
           };
         }
 
@@ -119,7 +119,7 @@ const digitalCashSlice = createSlice({
           // If this is not a coinbase transaction, then as we are sure that all inputs are used
           if (input.txOutHash !== COINBASE_HASH) {
             laoState.balances[pubHash] = 0;
-            laoState.transactionsByPubHash[pubHash] = [];
+            laoState.transactionsByOutPubHash[pubHash] = [];
           }
 
           createEntryAndAddInvPubHash(laoState, pubHash, transactionHash);
@@ -133,10 +133,10 @@ const digitalCashSlice = createSlice({
           }
           laoState.balances[pubKeyHash] += output.value;
 
-          if (!(pubKeyHash in laoState.transactionsByPubHash)) {
-            laoState.transactionsByPubHash[pubKeyHash] = [];
+          if (!(pubKeyHash in laoState.transactionsByOutPubHash)) {
+            laoState.transactionsByOutPubHash[pubKeyHash] = [];
           }
-          laoState.transactionsByPubHash[pubKeyHash].push(transactionHash);
+          laoState.transactionsByOutPubHash[pubKeyHash].push(transactionHash);
 
           createEntryAndAddInvPubHash(laoState, pubKeyHash, transactionHash);
         });
@@ -215,10 +215,10 @@ export const makeTransactionsByHashSelector = (laoId: Hash) =>
  * @param laoId
  * @param rollCallTokens
  */
-export const makeTransactionsByRollCallTokens = (laoId: Hash, rollCallTokens: RollCallToken[]) =>
+export const makeTransactionsByRollCallTokenSelector = (laoId: Hash, rollCallTokens: RollCallToken[]) =>
   createSelector(
     (state: any) => getDigitalCashState(state).byLaoId[laoId.valueOf()]?.transactionsByHash,
-    (state: any) => getDigitalCashState(state).byLaoId[laoId.valueOf()]?.transactionsByInvPubHash,
+    (state: any) => getDigitalCashState(state).byLaoId[laoId.valueOf()]?.transactionsByPubHash,
     (
       transactionsByHash: Record<string, TransactionState> | undefined,
       transactionsByInvPubHash: Record<string, string[]> | undefined,

--- a/fe1-web/src/features/digital-cash/reducer/__tests__/DigitalCashReducer.test.ts
+++ b/fe1-web/src/features/digital-cash/reducer/__tests__/DigitalCashReducer.test.ts
@@ -35,10 +35,10 @@ const filledState = {
       transactionsByHash: {
         [mockTransaction.transactionId.valueOf()]: mockTransaction.toState(),
       },
-      transactionsByPubHash: {
+      transactionsByOutPubHash: {
         [mockKPHash.valueOf()]: [mockTransaction.transactionId.toState()],
       },
-      transactionsByInvPubHash: {
+      transactionsByPubHash: {
         [mockKPHash.valueOf()]: [mockTransaction.transactionId.toState()],
       },
     },

--- a/fe1-web/src/features/digital-cash/reducer/__tests__/DigitalCashReducer.test.ts
+++ b/fe1-web/src/features/digital-cash/reducer/__tests__/DigitalCashReducer.test.ts
@@ -38,6 +38,9 @@ const filledState = {
       transactionsByPubHash: {
         [mockKPHash.valueOf()]: [mockTransaction.transactionId.toState()],
       },
+      transactionsByInvPubHash: {
+        [mockKPHash.valueOf()]: [mockTransaction.transactionId.toState()],
+      },
     },
   },
 };

--- a/fe1-web/src/features/digital-cash/screens/DigitalCashWallet.tsx
+++ b/fe1-web/src/features/digital-cash/screens/DigitalCashWallet.tsx
@@ -27,16 +27,11 @@ type NavigationProps = CompositeScreenProps<
 
 const DigitalCashWallet = () => {
   const navigation = useNavigation<NavigationProps['navigation']>();
-  const route = useRoute<NavigationProps['route']>();
   const laoId = DigitalCashHooks.useCurrentLaoId();
 
   const balances = useSelector(useMemo(() => makeBalancesSelector(laoId), [laoId]));
   const isOrganizer = DigitalCashHooks.useIsLaoOrganizer(laoId);
-
-  const rollCallIdHash = route.params.rollCallId ? new Hash(route.params.rollCallId) : undefined;
   const rollCallTokens = DigitalCashHooks.useRollCallTokensByLaoId(laoId);
-  const publicKey = DigitalCashHooks.useRollCallTokenByRollCallId(laoId, rollCallIdHash)?.token
-    .publicKey;
 
   const balance = rollCallTokens.reduce(
     (sum, account) => sum + (balances[Hash.fromPublicKey(account.token.publicKey).valueOf()] || 0),
@@ -109,7 +104,7 @@ const DigitalCashWallet = () => {
         })}
       </View>
 
-      <TransactionHistory laoId={laoId} publicKey={publicKey} />
+      <TransactionHistory laoId={laoId} rollCallTokens={rollCallTokens} />
     </ScreenWrapper>
   );
 };

--- a/fe1-web/src/features/digital-cash/screens/DigitalCashWallet.tsx
+++ b/fe1-web/src/features/digital-cash/screens/DigitalCashWallet.tsx
@@ -1,4 +1,4 @@
-import { CompositeScreenProps, useNavigation, useRoute } from '@react-navigation/core';
+import { CompositeScreenProps, useNavigation } from '@react-navigation/core';
 import { StackScreenProps } from '@react-navigation/stack';
 import { ListItem } from '@rneui/themed';
 import React, { useMemo } from 'react';
@@ -31,6 +31,7 @@ const DigitalCashWallet = () => {
 
   const balances = useSelector(useMemo(() => makeBalancesSelector(laoId), [laoId]));
   const isOrganizer = DigitalCashHooks.useIsLaoOrganizer(laoId);
+
   const rollCallTokens = DigitalCashHooks.useRollCallTokensByLaoId(laoId);
 
   const balance = rollCallTokens.reduce(

--- a/fe1-web/src/features/digital-cash/screens/DigitalCashWallet.tsx
+++ b/fe1-web/src/features/digital-cash/screens/DigitalCashWallet.tsx
@@ -1,4 +1,4 @@
-import { CompositeScreenProps, useNavigation } from '@react-navigation/core';
+import { CompositeScreenProps, useNavigation, useRoute } from '@react-navigation/core';
 import { StackScreenProps } from '@react-navigation/stack';
 import { ListItem } from '@rneui/themed';
 import React, { useMemo } from 'react';
@@ -27,12 +27,16 @@ type NavigationProps = CompositeScreenProps<
 
 const DigitalCashWallet = () => {
   const navigation = useNavigation<NavigationProps['navigation']>();
+  const route = useRoute<NavigationProps['route']>();
   const laoId = DigitalCashHooks.useCurrentLaoId();
 
   const balances = useSelector(useMemo(() => makeBalancesSelector(laoId), [laoId]));
   const isOrganizer = DigitalCashHooks.useIsLaoOrganizer(laoId);
 
+  const rollCallIdHash = route.params.rollCallId ? new Hash(route.params.rollCallId) : undefined;
   const rollCallTokens = DigitalCashHooks.useRollCallTokensByLaoId(laoId);
+  const publicKey = DigitalCashHooks.useRollCallTokenByRollCallId(laoId, rollCallIdHash)?.token
+    .publicKey;
 
   const balance = rollCallTokens.reduce(
     (sum, account) => sum + (balances[Hash.fromPublicKey(account.token.publicKey).valueOf()] || 0),
@@ -105,7 +109,7 @@ const DigitalCashWallet = () => {
         })}
       </View>
 
-      <TransactionHistory laoId={laoId} />
+      <TransactionHistory laoId={laoId} publicKey={publicKey} />
     </ScreenWrapper>
   );
 };

--- a/fe1-web/src/features/digital-cash/store/DigitalCashStore.ts
+++ b/fe1-web/src/features/digital-cash/store/DigitalCashStore.ts
@@ -22,9 +22,9 @@ export namespace DigitalCashStore {
   }
 
   /**
-   * Gets all transactions available for this public key in this lao
+   * Gets all transactions available for this public key as TxOut in this lao
    */
-  export function getTransactionsByPublicKey(laoId: Hash, pk: PublicKey): TransactionState[] {
+  export function getTransactionsByOutPublicKey(laoId: Hash, pk: PublicKey): TransactionState[] {
     const serializedLaoId = laoId.valueOf();
 
     const laoState = getDigitalCashState(getStore().getState()).byLaoId[serializedLaoId];
@@ -33,7 +33,9 @@ export namespace DigitalCashStore {
     }
     const pkHash = Hash.fromPublicKey(pk);
     const transactionsById = getTransactionsById(laoId);
-    return laoState.transactionsByPubHash[pkHash.valueOf()]?.map((hash) => transactionsById[hash]);
+    return laoState.transactionsByOutPubHash[pkHash.valueOf()]?.map(
+      (hash) => transactionsById[hash],
+    );
   }
 
   /**

--- a/fe1-web/src/features/digital-cash/store/__tests__/DigitalCashStore.test.tsx
+++ b/fe1-web/src/features/digital-cash/store/__tests__/DigitalCashStore.test.tsx
@@ -25,6 +25,9 @@ const filledState = {
       transactionsByHash: {
         [mockTransaction.transactionId!]: mockTransaction,
       },
+      transactionsByOutPubHash: {
+        [mockKPHash.valueOf()]: [mockTransaction.transactionId],
+      },
       transactionsByPubHash: {
         [mockKPHash.valueOf()]: [mockTransaction.transactionId],
       },
@@ -51,21 +54,24 @@ describe('Digital Cash Store', () => {
     expect(DigitalCashStore.getBalance(new Hash('mockId'), mockKeyPair.publicKey)).toEqual(0);
   });
 
-  it('should recover the transaction by public key correctly', () => {
-    expect(DigitalCashStore.getTransactionsByPublicKey(mockLaoId, mockKeyPair.publicKey)).toEqual([
-      mockTransaction,
-    ]);
+  it('should recover the transaction by txout public key correctly', () => {
+    expect(
+      DigitalCashStore.getTransactionsByOutPublicKey(mockLaoId, mockKeyPair.publicKey),
+    ).toEqual([mockTransaction]);
   });
 
   it('should recover an empty array if lao id is not found', () => {
     expect(
-      DigitalCashStore.getTransactionsByPublicKey(new Hash('mockId'), mockKeyPair.publicKey),
+      DigitalCashStore.getTransactionsByOutPublicKey(new Hash('mockId'), mockKeyPair.publicKey),
     ).toEqual([]);
   });
 
   it('should recover an empty array if public key is not found', () => {
     expect(
-      DigitalCashStore.getTransactionsByPublicKey(new Hash('mockId'), new PublicKey('publicKey')),
+      DigitalCashStore.getTransactionsByOutPublicKey(
+        new Hash('mockId'),
+        new PublicKey('publicKey'),
+      ),
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
The transaction history displayed in the digital cash wallet now shows only the transactions in which the user is involved, as an input or an output.