### PR TITLE
Fixing the out-of-order processing for Closing Roll Calls.

### DIFF
--- a/be1-go/channel/lao/mod_test.go
+++ b/be1-go/channel/lao/mod_test.go
@@ -488,6 +488,112 @@ func TestBaseChannel_SimulateRollCall(t *testing.T) {
 	require.NoError(t, channel.Publish(messageClosePub, nil))
 }
 
+func TestBaseChannel_RollCall_OutOfOrder(t *testing.T) {
+	keypair := generateKeyPair(t)
+	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)
+
+	// Create the hub
+	fakeHub, err := NewFakeHub(keypair.public, nolog, nil)
+	require.NoError(t, err)
+
+	m := message.Message{MessageID: "0"}
+
+	// Create the channel
+	channel, err := NewChannel("fzJSZjKf-2cbXH7kds9H8NORuuFIRLkevJlN7qQemjo=", fakeHub, m, nolog, keypair.public, nil)
+	require.NoError(t, err)
+
+	_, ok := channel.(*Channel)
+	require.True(t, ok)
+
+	time.Sleep(time.Millisecond)
+
+	// Create the roll_call_create message
+	relativePathCreate := filepath.Join(protocolRelativePath,
+		"examples", "messageData")
+
+	fileCreate := filepath.Join(relativePathCreate, "roll_call_create.json")
+	bufCreate, err := os.ReadFile(fileCreate)
+	require.NoError(t, err)
+
+	bufCreate64 := base64.URLEncoding.EncodeToString(bufCreate)
+
+	m1 := message.Message{
+		Data:              bufCreate64,
+		Sender:            publicKey64,
+		Signature:         "h",
+		MessageID:         messagedata.Hash(bufCreate64, publicKey64),
+		WitnessSignatures: []message.WitnessSignature{},
+	}
+
+	relativePathCreatePub := filepath.Join(protocolRelativePath,
+		"examples", "query", "publish")
+
+	fileCreatePub := filepath.Join(relativePathCreatePub, "publish.json")
+	bufCreatePub, err := os.ReadFile(fileCreatePub)
+	require.NoError(t, err)
+
+	var messageCreatePub method.Publish
+
+	err = json.Unmarshal(bufCreatePub, &messageCreatePub)
+	require.NoError(t, err)
+
+	messageCreatePub.Params.Message = m1
+
+	require.NoError(t, channel.Publish(messageCreatePub, nil))
+
+	// Create the roll_call_open message
+	relativePathOpen := filepath.Join(protocolRelativePath,
+		"examples", "messageData")
+
+	fileOpen := filepath.Join(relativePathOpen, "roll_call_open.json")
+	bufOpen, err := os.ReadFile(fileOpen)
+	require.NoError(t, err)
+
+	bufOpen64 := base64.URLEncoding.EncodeToString(bufOpen)
+
+	m2 := message.Message{
+		Data:              bufOpen64,
+		Sender:            publicKey64,
+		Signature:         "h",
+		MessageID:         messagedata.Hash(bufOpen64, publicKey64),
+		WitnessSignatures: []message.WitnessSignature{},
+	}
+
+	messageOpenPub := messageCreatePub
+
+	messageOpenPub.Params.Message = m2
+
+	// publish the roll call opening in a go routine to simulate out-of-order processing.
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		require.NoError(t, channel.Publish(messageOpenPub, nil))
+	}()
+
+	// Create the roll_call_close message
+	relativePathClose := filepath.Join(protocolRelativePath,
+		"examples", "messageData")
+
+	fileClose := filepath.Join(relativePathClose, "roll_call_close.json")
+	bufClose, err := os.ReadFile(fileClose)
+	require.NoError(t, err)
+
+	bufClose64 := base64.URLEncoding.EncodeToString(bufClose)
+
+	m3 := message.Message{
+		Data:              bufClose64,
+		Sender:            publicKey64,
+		Signature:         "h",
+		MessageID:         messagedata.Hash(bufClose64, publicKey64),
+		WitnessSignatures: []message.WitnessSignature{},
+	}
+
+	messageClosePub := messageCreatePub
+	messageClosePub.Params.Message = m3
+
+	// requires the closing process to retry due to the out-of-order open message
+	require.NoError(t, channel.Publish(messageClosePub, nil))
+}
+
 func TestLAOChannel_Election_Creation(t *testing.T) {
 	keypair := generateKeyPair(t)
 	publicKey64 := base64.URLEncoding.EncodeToString(keypair.publicBuf)


### PR DESCRIPTION
When a roll call opens and closes quickly, it can happen that the open message is received after the close message. Fixing that issue is done by retrying to process the close message after some delay. Also replaced some method argument's names by _ when unused in the lao package.