### PR TITLE
Prevent the user to submit an election with duplicated questions names

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/adapters/ElectionSetupViewPagerAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/adapters/ElectionSetupViewPagerAdapter.java
@@ -85,12 +85,17 @@ public class ElectionSetupViewPagerAdapter
             // On each text change we edit the list of questions
             // and we add or remove the question from the list of filled question
             String questionText = s.toString();
+            // Prevents the user from creating two different questions with the same name
+            if (questions.contains(questionText)) {
+              electionQuestionText.setError("Two different questions can't have the same name");
+            }
             if (!electionQuestionText.getText().toString().trim().isEmpty()) {
               questions.set(holder.getAdapterPosition(), questionText);
               listOfValidQuestions.add(holder.getAdapterPosition());
             } else {
               listOfValidQuestions.remove(holder.getAdapterPosition());
             }
+
             checkIfAnInputIsValid();
           }
         });
@@ -162,6 +167,12 @@ public class ElectionSetupViewPagerAdapter
       }
     }
 
+    // Check if there's a duplicate question, if true invalidate the input
+    if (hasDuplicate(questions)) {
+      isAnInputValid.setValue(false);
+      return;
+    }
+
     for (Integer i : listOfValidQuestions) {
       if (listOfValidBallots.contains(i)) {
         isAnInputValid.setValue(true);
@@ -182,6 +193,11 @@ public class ElectionSetupViewPagerAdapter
       }
     }
     return listOfValidInputs;
+  }
+
+  private boolean hasDuplicate(List<String> strings) {
+    Set<String> uniqueStrings = new HashSet<>();
+    return strings.stream().map(String::toLowerCase).anyMatch(s -> !uniqueStrings.add(s));
   }
 
   /** Adds a view of ballot option to the layout when user clicks the button */

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/adapters/ElectionSetupViewPagerAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/adapters/ElectionSetupViewPagerAdapter.java
@@ -87,15 +87,15 @@ public class ElectionSetupViewPagerAdapter
             String questionText = s.toString();
 
             // Prevents the user from creating two different questions with the same name
-            if (questions.contains(questionText)) {
+            if (!questionText.isEmpty() && questions.contains(questionText)) {
               electionQuestionText.setError("Two different questions can't have the same name");
             }
             if (!electionQuestionText.getText().toString().trim().isEmpty()) {
-              questions.set(holder.getAdapterPosition(), questionText);
               listOfValidQuestions.add(holder.getAdapterPosition());
             } else {
               listOfValidQuestions.remove(holder.getAdapterPosition());
             }
+            questions.set(holder.getAdapterPosition(), questionText);
 
             checkIfAnInputIsValid();
           }
@@ -197,15 +197,15 @@ public class ElectionSetupViewPagerAdapter
   }
 
   /**
-   * This function checks if a given list of strings has at least a duplicate. The comparison is
-   * performed case-insensitive.
+   * This function checks if a given list of strings has at least a duplicate. The comparison
+   * performed is case-sensitive.
    *
    * @param strings List of Strings
    * @return true if the list of strings has at least a duplicate, false otherwise
    */
   public static boolean hasDuplicate(List<String> strings) {
     Set<String> uniqueStrings = new HashSet<>();
-    return strings.stream().map(String::toLowerCase).anyMatch(s -> !uniqueStrings.add(s));
+    return strings.stream().anyMatch(s -> !uniqueStrings.add(s));
   }
 
   /** Adds a view of ballot option to the layout when user clicks the button */

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/adapters/ElectionSetupViewPagerAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/adapters/ElectionSetupViewPagerAdapter.java
@@ -85,6 +85,7 @@ public class ElectionSetupViewPagerAdapter
             // On each text change we edit the list of questions
             // and we add or remove the question from the list of filled question
             String questionText = s.toString();
+
             // Prevents the user from creating two different questions with the same name
             if (questions.contains(questionText)) {
               electionQuestionText.setError("Two different questions can't have the same name");
@@ -195,7 +196,14 @@ public class ElectionSetupViewPagerAdapter
     return listOfValidInputs;
   }
 
-  private boolean hasDuplicate(List<String> strings) {
+  /**
+   * This function checks if a given list of strings has at least a duplicate. The comparison is
+   * performed case-insensitive.
+   *
+   * @param strings List of Strings
+   * @return true if the list of strings has at least a duplicate, false otherwise
+   */
+  public static boolean hasDuplicate(List<String> strings) {
     Set<String> uniqueStrings = new HashSet<>();
     return strings.stream().map(String::toLowerCase).anyMatch(s -> !uniqueStrings.add(s));
   }

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/ElectionSetupFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/ElectionSetupFragmentTest.java
@@ -540,9 +540,9 @@ public class ElectionSetupFragmentTest {
   @Test
   public void detectDuplicates() {
     List<String> questionsDuplicated =
-        new ArrayList<>(Arrays.asList("QuesTion 1", "Question 2", "QuestiON 1", "question 4"));
+        new ArrayList<>(Arrays.asList("Question 1", "Question 2", "Question 2", "Question 4"));
     List<String> questionsNotDuplicated =
-        new ArrayList<>(Arrays.asList("QuesTion 1", "Question 2", "QuestiON 3", "question 4"));
+        new ArrayList<>(Arrays.asList("Question 1", "Question 2", "Question 3", "Question 4"));
 
     assertTrue(hasDuplicate(questionsDuplicated));
     assertFalse(hasDuplicate(questionsNotDuplicated));

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/ElectionSetupFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/ElectionSetupFragmentTest.java
@@ -50,6 +50,7 @@ import static com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObj
 import static com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject.laoIdExtra;
 import static com.github.dedis.popstellar.testutils.pages.lao.event.EventCreationPageObject.*;
 import static com.github.dedis.popstellar.testutils.pages.lao.event.election.ElectionSetupPageObject.*;
+import static com.github.dedis.popstellar.ui.lao.event.election.adapters.ElectionSetupViewPagerAdapter.hasDuplicate;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.containsString;
@@ -508,5 +509,42 @@ public class ElectionSetupFragmentTest {
             matches(
                 withSpinnerText(
                     containsString(ElectionVersion.SECRET_BALLOT.getStringBallotVersion()))));
+  }
+
+  @Test
+  public void cannotSubmitWithIdenticalQuestionName() {
+    electionName().perform(click(), typeText(ELECTION_NAME), closeSoftKeyboard());
+    pickValidDateAndTime();
+
+    // Add Question 1, with 3 ballots options, no write in
+    questionText().perform(click(), typeText("Question 1"), closeSoftKeyboard());
+    addBallot().perform(click());
+
+    for (int i = 0; i < 3; ++i) {
+      ballotOptionAtPosition(i).perform(click(), typeText("answer 1." + i), closeSoftKeyboard());
+    }
+
+    // Add Question 2, with 2 ballots options, with write in, with same name as Question 1
+    addQuestion().perform(click());
+    questionText().perform(click(), typeText("Question 1"), closeSoftKeyboard());
+    writeIn().perform(click());
+
+    for (int i = 0; i < 2; ++i) {
+      ballotOptionAtPosition(i).perform(click(), typeText("answer 2." + i), closeSoftKeyboard());
+    }
+
+    // Ensure that the submit button is not enabled
+    submit().check(matches(isNotEnabled()));
+  }
+
+  @Test
+  public void detectDuplicates() {
+    List<String> questionsDuplicated =
+        new ArrayList<>(Arrays.asList("QuesTion 1", "Question 2", "QuestiON 1", "question 4"));
+    List<String> questionsNotDuplicated =
+        new ArrayList<>(Arrays.asList("QuesTion 1", "Question 2", "QuestiON 3", "question 4"));
+
+    assertTrue(hasDuplicate(questionsDuplicated));
+    assertFalse(hasDuplicate(questionsNotDuplicated));
   }
 }


### PR DESCRIPTION
This addresses the issue #1380 in response to the PR #1418.

The new version checks whether the user types a question with the same name as a previous one; in that case an error box notifies the problem and the submit button becomes unavailabe to create the election.

Changes made include:

- Added a new function `hasDuplicate()`, which verifies if in a list of strings there is any duplicate (case-insensitive comparison).

- Added the check perfomed by that function to the ViewHolder of the question title, within the function `checkIfAnInputIsValid()`. If a duplicate in the list of questions is found, a flag is set to False to prevent the user pressing on submit.

- Added the relative tests to the code written.