### PR TITLE
Adresses 1399 - Returning an error when processing a message received twice 

### DIFF
--- a/be1-go/hub/standard_hub/message_handling.go
+++ b/be1-go/hub/standard_hub/message_handling.go
@@ -3,7 +3,6 @@ package standard_hub
 import (
 	"encoding/base64"
 	"encoding/json"
-	"github.com/rs/zerolog/log"
 	"popstellar/crypto"
 	jsonrpc "popstellar/message"
 	"popstellar/message/answer"
@@ -306,7 +305,6 @@ func (h *Hub) handlePublish(socket socket.Socket, byteMessage []byte) (int, erro
 	}
 
 	alreadyReceived, err := h.broadcastToServers(publish.Params.Message, publish.Params.Channel)
-	log.Error().Msg("broadcast to servers")
 	if alreadyReceived {
 		return publish.ID, xerrors.Errorf("message %s was already received", publish.Params.Message.MessageID)
 	}

--- a/be1-go/hub/standard_hub/message_handling.go
+++ b/be1-go/hub/standard_hub/message_handling.go
@@ -3,6 +3,7 @@ package standard_hub
 import (
 	"encoding/base64"
 	"encoding/json"
+	"github.com/rs/zerolog/log"
 	"popstellar/crypto"
 	jsonrpc "popstellar/message"
 	"popstellar/message/answer"
@@ -305,9 +306,9 @@ func (h *Hub) handlePublish(socket socket.Socket, byteMessage []byte) (int, erro
 	}
 
 	alreadyReceived, err := h.broadcastToServers(publish.Params.Message, publish.Params.Channel)
+	log.Error().Msg("broadcast to servers")
 	if alreadyReceived {
-		h.log.Info().Msg("message was already received")
-		return publish.ID, nil
+		return publish.ID, xerrors.Errorf("message %s was already received", publish.Params.Message.MessageID)
 	}
 
 	if err != nil {


### PR DESCRIPTION
This PR adresses the issue #1399. Before, when a server receives a "publish" message for the second time, it used to simply log an error. This fix makes it return an error instead. It also splits the Test_Handle_Publish test in two parts: one to test receiving a publish from a client and another one from a server since the previous test used to test both at the same time and would fail since the fix doesn't allow receiving a message twice. A new test for handling receiving a publish message twice is also added. 