### PR TITLE
Roll call UI modified - list of attendees added

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
@@ -289,7 +289,7 @@ public class RollCallFragment extends Fragment {
     binding.rollCallPkQrCode.setImageBitmap(myBitmap);
     // Set the QR visible only if the rollcall is open and the user isn't the organizer
     binding.rollCallPkQrCode.setVisibility(
-        laoViewModel.isOrganizer() || !rollCall.isOpen() ? View.INVISIBLE : View.VISIBLE);
+        (laoViewModel.isOrganizer() || !rollCall.isOpen()) ? View.INVISIBLE : View.VISIBLE);
   }
 
   private EnumMap<EventState, Integer> buildManagementTextMap() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallViewModel.java
@@ -39,7 +39,7 @@ public class RollCallViewModel extends AndroidViewModel implements QRCodeScannin
   private String laoId;
 
   private final Set<PublicKey> attendees = new HashSet<>();
-  private Runnable adapterUpdate;
+  private Runnable adapterUpdate = null;
 
   private final MutableLiveData<Integer> nbScanned = new MutableLiveData<>();
   private Observable<List<RollCall>> attendedRollCalls;
@@ -189,7 +189,9 @@ public class RollCallViewModel extends AndroidViewModel implements QRCodeScannin
 
     // this to display the initial number of attendees
     nbScanned.postValue(attendees.size());
-    adapterUpdate.run();
+    if (adapterUpdate != null) {
+      adapterUpdate.run();
+    }
   }
 
   /**
@@ -285,7 +287,9 @@ public class RollCallViewModel extends AndroidViewModel implements QRCodeScannin
     Log.d(TAG, "Attendee " + publicKey + " successfully added");
     Toast.makeText(getApplication(), R.string.attendee_scan_success, Toast.LENGTH_SHORT).show();
     nbScanned.postValue(attendees.size());
-    adapterUpdate.run();
+    if (adapterUpdate != null) {
+      adapterUpdate.run();
+    }
   }
 
   @Override

--- a/fe2-android/app/src/main/res/layout/roll_call_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/roll_call_fragment.xml
@@ -21,16 +21,16 @@
 
     <com.google.android.material.button.MaterialButton
       android:id="@+id/roll_call_scanning_button"
+      style="@style/Widget.MaterialComponents.Button"
       android:layout_width="wrap_content"
       android:layout_height="@dimen/standard_button_height"
-      style="@style/Widget.MaterialComponents.Button"
       android:layout_margin="@dimen/event_button_margin"
+      android:contentDescription="@string/scan"
       android:scaleType="center"
       android:text="@string/add_attendees"
       android:textAllCaps="false"
-      android:tintMode="@color/white"
-      android:contentDescription="@string/scan"
       android:textColor="@color/white"
+      android:tintMode="@color/white"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layout_constraintStart_toStartOf="parent" />
 
@@ -132,6 +132,32 @@
       app:layout_constraintBottom_toBottomOf="@id/end_time_icon"
       app:layout_constraintStart_toStartOf="@id/roll_call_start_time"
       app:layout_constraintTop_toTopOf="@id/end_time_icon" />
+
+    <TextView
+      android:id="@+id/roll_call_attendees_text"
+      style="@style/explication_text_style"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/roll_call_attendees"
+      app:layout_constraintBottom_toTopOf="@+id/list_view_attendees"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/roll_call_fragment_end_time_title" />
+    <ListView
+      android:id="@+id/list_view_attendees"
+      android:scrollbarStyle="outsideOverlay"
+      android:layout_width="@dimen/qr_rollcall_img"
+      android:layout_height="@dimen/qr_rollcall_img"
+      android:layout_marginEnd="10dp"
+      android:fadeScrollbars="true"
+      android:scrollbarSize="@dimen/event_layout_arrow_end_margin"
+      android:scrollbars="vertical"
+      android:scrollingCache="true"
+      android:smoothScrollbar="true"
+      app:layout_constraintBottom_toTopOf="@+id/roll_call_management_button"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="@+id/roll_call_pk_qr_code" />
 
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/fe2-android/app/src/main/res/layout/roll_call_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/roll_call_fragment.xml
@@ -148,7 +148,7 @@
       android:scrollbarStyle="outsideOverlay"
       android:layout_width="@dimen/qr_rollcall_img"
       android:layout_height="@dimen/qr_rollcall_img"
-      android:layout_marginEnd="10dp"
+      android:layout_marginEnd="@dimen/roll_call_attendees_end_margin"
       android:fadeScrollbars="true"
       android:scrollbarSize="@dimen/event_layout_arrow_end_margin"
       android:scrollbars="vertical"

--- a/fe2-android/app/src/main/res/values/dimens.xml
+++ b/fe2-android/app/src/main/res/values/dimens.xml
@@ -54,6 +54,7 @@
   <dimen name="status_margin_top">16dp</dimen>
   <dimen name="event_header_between_texts_margin">5dp</dimen>
   <dimen name="pickers_horizontal_margin">16dp</dimen>
+  <dimen name="roll_call_attendees_end_margin">10dp</dimen>
 
   <!--  Event layout-->
   <dimen name="event_layout_arrow_end_margin">8dp</dimen>
@@ -144,4 +145,5 @@
   <dimen name="drawer_header_horizontal_margin">16dp</dimen>
 
   <dimen name="main_horizontal_margin">16dp</dimen>
+
 </resources>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -112,6 +112,8 @@
   <string name="roll_call_setup_title">Roll Call Setup</string>
   <string name="roll_call_title">Roll Call</string>
   <string name="add_attendee_title">Add Attendee</string>
+  <string name="roll_call_attendees">Attendees</string>
+  <string name="roll_call_scanned">Scanned tokens</string>
 
   <!-- Election Event -->
   <string name="election_title">Election</string>
@@ -295,4 +297,5 @@
   <string name="unknown_roll_call_exception">Unknown Roll Call</string>
   <string name="already_open_roll_call_exception">Another Roll Call is already open</string>
   <string name="lao_coins">LAO coins</string>
+
 </resources>

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/event/rollcall/RollCallFragmentPageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/event/rollcall/RollCallFragmentPageObject.java
@@ -36,4 +36,12 @@ public class RollCallFragmentPageObject {
   public static ViewInteraction rollCallScanButton() {
     return onView(withId(R.id.roll_call_scanning_button));
   }
+
+  public static ViewInteraction rollCallAttendeesText() {
+    return onView(withId(R.id.roll_call_attendees_text));
+  }
+
+  public static ViewInteraction rollCallListAttendees() {
+    return onView(withId(R.id.list_view_attendees));
+  }
 }

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragmentTest.java
@@ -259,4 +259,36 @@ public class RollCallFragmentTest {
     assertNotEquals(ROLL_CALL.getState(), EventState.OPENED);
     managementButton().check(matches(withText("OPEN")));
   }
+
+  @Test
+  public void attendeesTextTest() {
+    // Assert that when the roll call is not opened, the organizer has no attendees view
+    rollCallAttendeesText().check(matches(withEffectiveVisibility(Visibility.INVISIBLE)));
+
+    // Open the roll call
+    rollCallRepo.updateRollCall(LAO_ID, RollCall.openRollCall(ROLL_CALL));
+
+    rollCallAttendeesText().check(matches(withEffectiveVisibility(Visibility.VISIBLE)));
+    rollCallAttendeesText().check(matches(withText("Scanned tokens")));
+
+    // Close the roll call
+    rollCallRepo.updateRollCall(LAO_ID, RollCall.closeRollCall(ROLL_CALL));
+
+    // Check that it has switched from scanned tokens to attendees
+    rollCallAttendeesText().check(matches(withEffectiveVisibility(Visibility.VISIBLE)));
+    rollCallAttendeesText().check(matches(withText("Attendees")));
+  }
+
+  @Test
+  public void attendeesListTest() {
+    // Assert that when the roll call is not opened, the organizer has no attendees view
+    rollCallListAttendees().check(matches(withEffectiveVisibility(Visibility.INVISIBLE)));
+
+    // Open the roll call
+    rollCallRepo.updateRollCall(LAO_ID, RollCall.openRollCall(ROLL_CALL));
+
+    rollCallListAttendees().check(matches(withEffectiveVisibility(Visibility.VISIBLE)));
+    // Assert that no scanned participant is present
+    rollCallListAttendees().check(matches(hasChildCount(0)));
+  }
 }


### PR DESCRIPTION
This PR addresses the issues #1404 and #1405.

Changes made in the UI include:

- Attendee-side:
  - Removed the QR code when the Roll Call is just created. The QR is displayed as soon as the Roll Call gets opened.
  - Added the list of the attendees when the Roll Call is closed.
  
- Organizer-side:
  - Removed the QR code.
  - Added the list of the attendees when the Roll Call is closed.
  - Added the list of scanned tokens from the last time the Roll Call was opened, as it continues to stay opened.

Here some screenshots to help clarify the new changes:

<figure>
<figcaption align = "center"><em>UI for the organizer when the roll call is OPENED</em></figcaption>
<img src="https://user-images.githubusercontent.com/83547952/222991056-f2892662-f784-44ad-90a5-1a16294be6eb.png" alt="open" width="40%" height="40%"/>
</figure>

<br>

<figure>
<figcaption align = "center"><em>UI for the attendee when the roll call is OPENED (same as before)</em></figcaption>
<img src="https://user-images.githubusercontent.com/83547952/222991089-9cc0de37-a709-4daf-9a74-255297aa92ba.png" alt="open" width="40%" height="40%"/>
</figure>

<br>

<figure>
<figcaption align = "center"><em>UI for the attendee when the roll call is just CREATED</em></figcaption>
<img src="https://user-images.githubusercontent.com/83547952/222991117-1882856c-254f-40aa-8713-b76663aa8a8b.png" alt="open" width="40%" height="40%"/>
</figure>

<br>

<figure>
<figcaption align = "center"><em>UI when the roll call is CLOSED</em></figcaption>
<img src="https://user-images.githubusercontent.com/83547952/222991144-e12fed13-854f-48f0-9203-b2eb087b6163.png" alt="open" width="40%" height="40%"/>
</figure>




