### PR TITLE
Add overlay texts to all QRCodes

### DIFF
--- a/fe1-web/src/core/components/QRCode.tsx
+++ b/fe1-web/src/core/components/QRCode.tsx
@@ -21,7 +21,7 @@ const styles = StyleSheet.create({
       and a height of 50%. centering this gives us 25% margin on every side
     */
     position: 'absolute',
-    padding: '4px',
+    padding: '4',
     top: '25%',
     left: '25%',
     right: '25%',

--- a/fe1-web/src/core/components/QRCode.tsx
+++ b/fe1-web/src/core/components/QRCode.tsx
@@ -21,6 +21,7 @@ const styles = StyleSheet.create({
       and a height of 50%. centering this gives us 25% margin on every side
     */
     position: 'absolute',
+    padding: '1%',
     top: '25%',
     left: '25%',
     right: '25%',

--- a/fe1-web/src/core/components/QRCode.tsx
+++ b/fe1-web/src/core/components/QRCode.tsx
@@ -21,7 +21,7 @@ const styles = StyleSheet.create({
       and a height of 50%. centering this gives us 25% margin on every side
     */
     position: 'absolute',
-    padding: '1%',
+    padding: '4px',
     top: '25%',
     left: '25%',
     right: '25%',

--- a/fe1-web/src/features/digital-cash/screens/SendReceive/SendReceive.tsx
+++ b/fe1-web/src/features/digital-cash/screens/SendReceive/SendReceive.tsx
@@ -327,7 +327,10 @@ export const SendReceiveHeaderRight = () => {
           </ModalHeader>
 
           <View>
-            <QRCode value={ScannablePopToken.encodePopToken({ pop_token: popToken })} />
+            <QRCode
+              value={ScannablePopToken.encodePopToken({ pop_token: popToken })}
+              overlayText={STRINGS.digital_cash_wallet_QRcode_text}
+            />
           </View>
 
           <Text style={[Typography.small, styles.publicKey]} selectable>

--- a/fe1-web/src/features/digital-cash/screens/SendReceive/SendReceive.tsx
+++ b/fe1-web/src/features/digital-cash/screens/SendReceive/SendReceive.tsx
@@ -329,7 +329,7 @@ export const SendReceiveHeaderRight = () => {
           <View>
             <QRCode
               value={ScannablePopToken.encodePopToken({ pop_token: popToken })}
-              overlayText={STRINGS.digital_cash_wallet_QRcode_text}
+              overlayText={STRINGS.digital_cash_wallet_qrcode_text}
             />
           </View>
 

--- a/fe1-web/src/features/lao/components/__tests__/__snapshots__/LaoProperties.test.tsx.snap
+++ b/fe1-web/src/features/lao/components/__tests__/__snapshots__/LaoProperties.test.tsx.snap
@@ -336,8 +336,7 @@ exports[`LaoProperties renders correctly as attendee 1`] = `
                           }
                         >
                           <qrcode
-                            overlayText="Scan to
-Connect"
+                            overlayText="Scan to connect"
                             value="{"lao":"-M259c5JlakLVlXBRa893pcE-4s7ssO8Jv5gXOvtreE="}"
                           />
                         </View>
@@ -1411,8 +1410,7 @@ exports[`LaoProperties renders correctly as witness 1`] = `
                           }
                         >
                           <qrcode
-                            overlayText="Scan to
-Connect"
+                            overlayText="Scan to connect"
                             value="{"lao":"-M259c5JlakLVlXBRa893pcE-4s7ssO8Jv5gXOvtreE="}"
                           />
                         </View>

--- a/fe1-web/src/features/lao/components/__tests__/__snapshots__/LaoProperties.test.tsx.snap
+++ b/fe1-web/src/features/lao/components/__tests__/__snapshots__/LaoProperties.test.tsx.snap
@@ -874,8 +874,7 @@ exports[`LaoProperties renders correctly as organizer 1`] = `
                           }
                         >
                           <qrcode
-                            overlayText="Scan to
-Connect"
+                            overlayText="Scan to connect"
                             value="{"lao":"-M259c5JlakLVlXBRa893pcE-4s7ssO8Jv5gXOvtreE="}"
                           />
                         </View>

--- a/fe1-web/src/features/lao/screens/__tests__/__snapshots__/InviteScreen.test.tsx.snap
+++ b/fe1-web/src/features/lao/screens/__tests__/__snapshots__/InviteScreen.test.tsx.snap
@@ -363,8 +363,7 @@ exports[`LaoHomeScreen renders correctly 1`] = `
                                 }
                               >
                                 <qrcode
-                                  overlayText="Scan to
-Connect"
+                                  overlayText="Scan to connect"
                                   value="{"lao":"-M259c5JlakLVlXBRa893pcE-4s7ssO8Jv5gXOvtreE="}"
                                 />
                               </View>

--- a/fe1-web/src/features/rollCall/components/RollCallOpen.tsx
+++ b/fe1-web/src/features/rollCall/components/RollCallOpen.tsx
@@ -173,7 +173,7 @@ const RollCallOpen = ({
           <Text style={Typography.paragraph}>{STRINGS.roll_call_open_attendee}</Text>
           <QRCode
             value={ScannablePopToken.encodePopToken({ pop_token: popToken })}
-            overlayText={STRINGS.roll_call_QRcode_text}
+            overlayText={STRINGS.roll_call_qrcode_text}
           />
         </>
       )}

--- a/fe1-web/src/features/rollCall/components/RollCallOpen.tsx
+++ b/fe1-web/src/features/rollCall/components/RollCallOpen.tsx
@@ -171,7 +171,10 @@ const RollCallOpen = ({
       {!isOrganizer && (
         <>
           <Text style={Typography.paragraph}>{STRINGS.roll_call_open_attendee}</Text>
-          <QRCode value={ScannablePopToken.encodePopToken({ pop_token: popToken })} />
+          <QRCode
+            value={ScannablePopToken.encodePopToken({ pop_token: popToken })}
+            overlayText={STRINGS.roll_call_QRcode_text}
+          />
         </>
       )}
 

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
@@ -1720,7 +1720,7 @@ exports[`EventRollCall render correctly non organizers opened roll calls 1`] = `
                               The Roll Call is currently open and you as an attendee should let the organizer scan your PoP token encoded in the QR Code below.
                             </Text>
                             <qrcode
-                              overlayText="To be scanned"
+                              overlayText="To be scanned to connect"
                               value="{"pop_token":""}"
                             />
                             <View
@@ -2607,7 +2607,7 @@ exports[`EventRollCall render correctly non organizers re-opened roll calls 1`] 
                               The Roll Call is currently open and you as an attendee should let the organizer scan your PoP token encoded in the QR Code below.
                             </Text>
                             <qrcode
-                              overlayText="To be scanned"
+                              overlayText="To be scanned to connect"
                               value="{"pop_token":""}"
                             />
                             <View

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
@@ -1720,7 +1720,7 @@ exports[`EventRollCall render correctly non organizers opened roll calls 1`] = `
                               The Roll Call is currently open and you as an attendee should let the organizer scan your PoP token encoded in the QR Code below.
                             </Text>
                             <qrcode
-                              overlayText="To be scanned to connect"
+                              overlayText="Scan to add attendee"
                               value="{"pop_token":""}"
                             />
                             <View
@@ -2607,7 +2607,7 @@ exports[`EventRollCall render correctly non organizers re-opened roll calls 1`] 
                               The Roll Call is currently open and you as an attendee should let the organizer scan your PoP token encoded in the QR Code below.
                             </Text>
                             <qrcode
-                              overlayText="To be scanned to connect"
+                              overlayText="Scan to add attendee"
                               value="{"pop_token":""}"
                             />
                             <View

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
@@ -1720,6 +1720,7 @@ exports[`EventRollCall render correctly non organizers opened roll calls 1`] = `
                               The Roll Call is currently open and you as an attendee should let the organizer scan your PoP token encoded in the QR Code below.
                             </Text>
                             <qrcode
+                              overlayText="To be scanned"
                               value="{"pop_token":""}"
                             />
                             <View
@@ -2606,6 +2607,7 @@ exports[`EventRollCall render correctly non organizers re-opened roll calls 1`] 
                               The Roll Call is currently open and you as an attendee should let the organizer scan your PoP token encoded in the QR Code below.
                             </Text>
                             <qrcode
+                              overlayText="To be scanned"
                               value="{"pop_token":""}"
                             />
                             <View

--- a/fe1-web/src/features/wallet/screens/WalletSingleRollCall.tsx
+++ b/fe1-web/src/features/wallet/screens/WalletSingleRollCall.tsx
@@ -35,7 +35,10 @@ const WalletSingleRollCall = () => {
   return (
     <ScreenWrapper>
       <View>
-        <QRCode value={ScannablePopToken.encodePopToken({ pop_token: rollCallTokenPublicKey })} />
+        <QRCode
+          value={ScannablePopToken.encodePopToken({ pop_token: rollCallTokenPublicKey })}
+          overlayText={STRINGS.roll_call_QRcode_text}
+        />
       </View>
 
       <Text style={[Typography.small, styles.publicKey]} selectable>

--- a/fe1-web/src/features/wallet/screens/WalletSingleRollCall.tsx
+++ b/fe1-web/src/features/wallet/screens/WalletSingleRollCall.tsx
@@ -37,7 +37,7 @@ const WalletSingleRollCall = () => {
       <View>
         <QRCode
           value={ScannablePopToken.encodePopToken({ pop_token: rollCallTokenPublicKey })}
-          overlayText={STRINGS.wallet_home_rollcall_QRcode_text}
+          overlayText={STRINGS.wallet_home_rollcall_qrcode_text}
         />
       </View>
 

--- a/fe1-web/src/features/wallet/screens/WalletSingleRollCall.tsx
+++ b/fe1-web/src/features/wallet/screens/WalletSingleRollCall.tsx
@@ -37,7 +37,7 @@ const WalletSingleRollCall = () => {
       <View>
         <QRCode
           value={ScannablePopToken.encodePopToken({ pop_token: rollCallTokenPublicKey })}
-          overlayText={STRINGS.roll_call_QRcode_text}
+          overlayText={STRINGS.wallet_home_rollcall_QRcode_text}
         />
       </View>
 

--- a/fe1-web/src/features/wallet/screens/__tests__/__snapshots__/WalletSingleRollCall.test.tsx.snap
+++ b/fe1-web/src/features/wallet/screens/__tests__/__snapshots__/WalletSingleRollCall.test.tsx.snap
@@ -356,8 +356,7 @@ exports[`ViewSingleRollCallScreenHeader renders correctly 1`] = `
                           <View>
                             <View>
                               <qrcode
-                                overlayText="Scan to get
-user token"
+                                overlayText="Scan to get user token"
                                 value="{"pop_token":"oKHk3AivbpNXk_SfFcHDaVHcCcY8IBfHE7auXJ7h4ms="}"
                               />
                             </View>

--- a/fe1-web/src/features/wallet/screens/__tests__/__snapshots__/WalletSingleRollCall.test.tsx.snap
+++ b/fe1-web/src/features/wallet/screens/__tests__/__snapshots__/WalletSingleRollCall.test.tsx.snap
@@ -356,7 +356,8 @@ exports[`ViewSingleRollCallScreenHeader renders correctly 1`] = `
                           <View>
                             <View>
                               <qrcode
-                                overlayText="To be scanned"
+                                overlayText="Scan to get
+user token"
                                 value="{"pop_token":"oKHk3AivbpNXk_SfFcHDaVHcCcY8IBfHE7auXJ7h4ms="}"
                               />
                             </View>
@@ -829,7 +830,8 @@ exports[`WalletSingleRollCall renders correctly 1`] = `
                           <View>
                             <View>
                               <qrcode
-                                overlayText="To be scanned"
+                                overlayText="Scan to get
+user token"
                                 value="{"pop_token":"oKHk3AivbpNXk_SfFcHDaVHcCcY8IBfHE7auXJ7h4ms="}"
                               />
                             </View>

--- a/fe1-web/src/features/wallet/screens/__tests__/__snapshots__/WalletSingleRollCall.test.tsx.snap
+++ b/fe1-web/src/features/wallet/screens/__tests__/__snapshots__/WalletSingleRollCall.test.tsx.snap
@@ -830,8 +830,7 @@ exports[`WalletSingleRollCall renders correctly 1`] = `
                           <View>
                             <View>
                               <qrcode
-                                overlayText="Scan to get
-user token"
+                                overlayText="Scan to get user token"
                                 value="{"pop_token":"oKHk3AivbpNXk_SfFcHDaVHcCcY8IBfHE7auXJ7h4ms="}"
                               />
                             </View>

--- a/fe1-web/src/features/wallet/screens/__tests__/__snapshots__/WalletSingleRollCall.test.tsx.snap
+++ b/fe1-web/src/features/wallet/screens/__tests__/__snapshots__/WalletSingleRollCall.test.tsx.snap
@@ -356,6 +356,7 @@ exports[`ViewSingleRollCallScreenHeader renders correctly 1`] = `
                           <View>
                             <View>
                               <qrcode
+                                overlayText="To be scanned"
                                 value="{"pop_token":"oKHk3AivbpNXk_SfFcHDaVHcCcY8IBfHE7auXJ7h4ms="}"
                               />
                             </View>
@@ -828,6 +829,7 @@ exports[`WalletSingleRollCall renders correctly 1`] = `
                           <View>
                             <View>
                               <qrcode
+                                overlayText="To be scanned"
                                 value="{"pop_token":"oKHk3AivbpNXk_SfFcHDaVHcCcY8IBfHE7auXJ7h4ms="}"
                               />
                             </View>

--- a/fe1-web/src/resources/strings.ts
+++ b/fe1-web/src/resources/strings.ts
@@ -291,6 +291,7 @@ namespace STRINGS {
     'The Roll Call is currently open and you as the organizer should start adding attendees by scanning their PoP tokens.';
   export const roll_call_open_attendee =
     'The Roll Call is currently open and you as an attendee should let the organizer scan your PoP token encoded in the QR Code below.';
+  export const roll_call_QRcode_text = 'To be scanned';
 
   export const roll_call_error_open_roll_call = 'Unable to send roll call open request';
   export const roll_call_error_scanning_no_alias =
@@ -427,6 +428,7 @@ namespace STRINGS {
   export const wallet_home_rollcall_current_pop_tokens = 'Current tokens';
   export const wallet_home_rollcall_previous_pop_tokens = 'Previous tokens';
   export const wallet_home_rollcall_pop_token_valid = 'Current';
+  export const wallet_home_rollcall_QRcode_text = 'Scan to get token';
 
   export const wallet_home_rollcall_no_pop_tokens = 'No PoP tokens';
   export const wallet_home_rollcall_no_pop_tokens_description =
@@ -448,6 +450,7 @@ namespace STRINGS {
     'Your balance for this lao is the sum of the balances of each roll call token you own in this lao. ' +
     'The distribution of your total balance is visible in the list below. ' +
     'To send cash from one of the accounts, simply tap on it.';
+  export const digital_cash_wallet_QRcode_text = 'Scan to set\nas recipient';
 
   export const digital_cash_coin_issuance = 'Coin Issuance';
   export const digital_cash_coin_issuance_description =

--- a/fe1-web/src/resources/strings.ts
+++ b/fe1-web/src/resources/strings.ts
@@ -291,7 +291,7 @@ namespace STRINGS {
     'The Roll Call is currently open and you as the organizer should start adding attendees by scanning their PoP tokens.';
   export const roll_call_open_attendee =
     'The Roll Call is currently open and you as an attendee should let the organizer scan your PoP token encoded in the QR Code below.';
-  export const roll_call_QRcode_text = 'To be scanned';
+  export const roll_call_qrcode_text = 'To be scanned to connect';
 
   export const roll_call_error_open_roll_call = 'Unable to send roll call open request';
   export const roll_call_error_scanning_no_alias =
@@ -428,7 +428,7 @@ namespace STRINGS {
   export const wallet_home_rollcall_current_pop_tokens = 'Current tokens';
   export const wallet_home_rollcall_previous_pop_tokens = 'Previous tokens';
   export const wallet_home_rollcall_pop_token_valid = 'Current';
-  export const wallet_home_rollcall_QRcode_text = 'Scan to get\nuser token';
+  export const wallet_home_rollcall_qrcode_text = 'Scan to get\nuser token';
 
   export const wallet_home_rollcall_no_pop_tokens = 'No PoP tokens';
   export const wallet_home_rollcall_no_pop_tokens_description =
@@ -450,7 +450,7 @@ namespace STRINGS {
     'Your balance for this lao is the sum of the balances of each roll call token you own in this lao. ' +
     'The distribution of your total balance is visible in the list below. ' +
     'To send cash from one of the accounts, simply tap on it.';
-  export const digital_cash_wallet_QRcode_text = 'Scan to set\nas recipient';
+  export const digital_cash_wallet_qrcode_text = 'Scan to set\nas recipient';
 
   export const digital_cash_coin_issuance = 'Coin Issuance';
   export const digital_cash_coin_issuance_description =

--- a/fe1-web/src/resources/strings.ts
+++ b/fe1-web/src/resources/strings.ts
@@ -121,7 +121,7 @@ namespace STRINGS {
 
   /* --- Lao Strings --- */
   export const lao_properties_modal_heading = 'Lao Properties';
-  export const lao_qr_code_overlay = 'Scan to\nConnect';
+  export const lao_qr_code_overlay = 'Scan to connect';
   export const lao_properties_name = 'Name';
   export const lao_properties_id = 'Identifier';
   export const lao_properties_your_role = 'Your role';
@@ -428,7 +428,7 @@ namespace STRINGS {
   export const wallet_home_rollcall_current_pop_tokens = 'Current tokens';
   export const wallet_home_rollcall_previous_pop_tokens = 'Previous tokens';
   export const wallet_home_rollcall_pop_token_valid = 'Current';
-  export const wallet_home_rollcall_qrcode_text = 'Scan to get\nuser token';
+  export const wallet_home_rollcall_qrcode_text = 'Scan to get user token';
 
   export const wallet_home_rollcall_no_pop_tokens = 'No PoP tokens';
   export const wallet_home_rollcall_no_pop_tokens_description =
@@ -450,7 +450,7 @@ namespace STRINGS {
     'Your balance for this lao is the sum of the balances of each roll call token you own in this lao. ' +
     'The distribution of your total balance is visible in the list below. ' +
     'To send cash from one of the accounts, simply tap on it.';
-  export const digital_cash_wallet_qrcode_text = 'Scan to set\nas recipient';
+  export const digital_cash_wallet_qrcode_text = 'Scan to set as recipient';
 
   export const digital_cash_coin_issuance = 'Coin Issuance';
   export const digital_cash_coin_issuance_description =

--- a/fe1-web/src/resources/strings.ts
+++ b/fe1-web/src/resources/strings.ts
@@ -291,7 +291,7 @@ namespace STRINGS {
     'The Roll Call is currently open and you as the organizer should start adding attendees by scanning their PoP tokens.';
   export const roll_call_open_attendee =
     'The Roll Call is currently open and you as an attendee should let the organizer scan your PoP token encoded in the QR Code below.';
-  export const roll_call_qrcode_text = 'To be scanned to connect';
+  export const roll_call_qrcode_text = 'Scan to add attendee';
 
   export const roll_call_error_open_roll_call = 'Unable to send roll call open request';
   export const roll_call_error_scanning_no_alias =

--- a/fe1-web/src/resources/strings.ts
+++ b/fe1-web/src/resources/strings.ts
@@ -428,7 +428,7 @@ namespace STRINGS {
   export const wallet_home_rollcall_current_pop_tokens = 'Current tokens';
   export const wallet_home_rollcall_previous_pop_tokens = 'Previous tokens';
   export const wallet_home_rollcall_pop_token_valid = 'Current';
-  export const wallet_home_rollcall_QRcode_text = 'Scan to get token';
+  export const wallet_home_rollcall_QRcode_text = 'Scan to get\nuser token';
 
   export const wallet_home_rollcall_no_pop_tokens = 'No PoP tokens';
   export const wallet_home_rollcall_no_pop_tokens_description =


### PR DESCRIPTION
This PR adds overlays to all the QR codes that are actually shown (and that did not have already an overlay). 
This includes : 
- The QR code in the digital cash feature
![image](https://user-images.githubusercontent.com/42808302/223178426-e861f32c-c53b-4f23-9832-1c2426784ed8.png)
- The QR code that displays user tokens 
![image](https://user-images.githubusercontent.com/42808302/223180232-14040a4c-1440-4504-9d96-1c2299462d89.png)
- The QR code that should be scanned in order to enter
![image](https://user-images.githubusercontent.com/42808302/223181413-27f2aca2-5111-475d-b3ea-de676586b97f.png)

This resolves #1332