### PR TITLE
Fix issue #1295

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Hash.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/objects/Hash.scala
@@ -20,7 +20,7 @@ object Hash {
     * @return
     *   resulting hash
     */
-  def fromStrings(data: String*): Hash = Hash.sha256Hash(data.foldLeft("")((acc, s) => acc + s.length + s))
+  def fromStrings(data: String*): Hash = Hash.sha256Hash(data.foldLeft("")((acc, s) => acc + s.getBytes(StandardCharsets.UTF_8).length + s))
 
   /** Create a hash of a string
     *

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/HashSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/HashSuite.scala
@@ -60,7 +60,7 @@ class HashSuite extends FunSuite with Matchers {
     hash should equal(expected)
   }
 
-  test("Hash 'fromStrings' works with mix pure emojis") {
+  test("Hash 'fromStrings' works with pure emojis") {
     val hash: Hash = Hash.fromStrings("🫡")
     val expected: Hash = Hash(Base64Data("ht7cQAkPdd6o-ZFVW6gTbt0gEIEUcr5FTDgOaeW8BOU="))
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/HashSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/HashSuite.scala
@@ -52,4 +52,18 @@ class HashSuite extends FunSuite with Matchers {
 
     hash should equal(expected)
   }
+
+  test("Hash 'fromStrings' works with mix text-emojis") {
+    val hash: Hash = Hash.fromStrings("test 😀")
+    val expected: Hash = Hash(Base64Data("8BMmJjQMPhtD0QwVor1uVB3B_PyMMyIbIvaDHcOQnTg="))
+
+    hash should equal(expected)
+  }
+
+  test("Hash 'fromStrings' works with mix pure emojis") {
+    val hash: Hash = Hash.fromStrings("🫡")
+    val expected: Hash = Hash(Base64Data("ht7cQAkPdd6o-ZFVW6gTbt0gEIEUcr5FTDgOaeW8BOU="))
+
+    hash should equal(expected)
+  }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/objects/HashSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/objects/HashSuite.scala
@@ -66,4 +66,12 @@ class HashSuite extends FunSuite with Matchers {
 
     hash should equal(expected)
   }
+
+  test("Hash 'fromStrings' works with more mix-emojis strings") {
+    val hash: Hash = Hash.fromStrings("text 🥰", "🏉", "more text🎃️", "♠️")
+    val expected: Hash = Hash(Base64Data("wANKJFj9q_ncRKalYmK4yozUpet33JaFXVQEpMcHdfU="))
+
+    hash should equal(expected)
+  }
+
 }


### PR DESCRIPTION
Fix issue #1295,
The problem came from our calculation of lengths for strings, instead of having our length in bytes we were counting the characters, for pure text 1byte = 1char but not for emojis. 

Two tests were added to confirm the fix.