### PR TITLE
Fix Left/Right scala pipe convention for the GraphMessage type

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/PubSubMediator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/PubSubMediator.scala
@@ -74,7 +74,7 @@ class PubSubMediator extends Actor with ActorLogging with AskPatternConstants {
     def generateAnswer(): GraphMessage = {
       val broadcast: Broadcast = Broadcast(channel, message)
       val answer: JsonRpcRequest = JsonRpcRequest(RpcValidator.JSON_RPC_VERSION, MethodType.BROADCAST, broadcast, None)
-      Left(answer)
+      Right(answer)
     }
 
     channelMap.get(channel) match {

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/PublishSubscribe.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/PublishSubscribe.scala
@@ -42,8 +42,8 @@ object PublishSubscribe {
         val methodPartitioner = builder.add(Partition[GraphMessage](
           totalPorts,
           {
-            case Left(m: JsonRpcRequest) if m.hasParamsMessage => portParamsWithMessage // Publish and Broadcast messages
-            case Left(_)                                       => portParams
+            case Right(m: JsonRpcRequest) if m.hasParamsMessage => portParamsWithMessage // Publish and Broadcast messages
+            case Right(_)                                       => portParams
             case _                                             => portPipelineError // Pipeline error goes directly in merger
           }
         ))

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/PublishSubscribe.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/PublishSubscribe.scala
@@ -44,7 +44,7 @@ object PublishSubscribe {
           {
             case Right(m: JsonRpcRequest) if m.hasParamsMessage => portParamsWithMessage // Publish and Broadcast messages
             case Right(_)                                       => portParams
-            case _                                             => portPipelineError // Pipeline error goes directly in merger
+            case _                                              => portPipelineError // Pipeline error goes directly in merger
           }
         ))
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/Answerer.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/Answerer.scala
@@ -30,9 +30,9 @@ object Answerer {
     */
   private def sendAnswer(graphMessage: GraphMessage): TextMessage = graphMessage match {
     // Note: The encoding of the answer is done here as the ClientActor must always receive a GraphMessage
-    case Left(rpcAnswer: JsonRpcResponse)    => TextMessage.Strict(rpcAnswer.toJson.toString)
-    case Left(rpcRequest: JsonRpcRequest)    => TextMessage.Strict(rpcRequest.toJson.toString) // propagate server
-    case Right(pipelineError: PipelineError) =>
+    case Right(rpcAnswer: JsonRpcResponse)    => TextMessage.Strict(rpcAnswer.toJson.toString)
+    case Right(rpcRequest: JsonRpcRequest)    => TextMessage.Strict(rpcRequest.toJson.toString) // propagate server
+    case Left(pipelineError: PipelineError) =>
       // Convert AnswerGenerator's PipelineErrors into negative JsonRpcResponses and send them back to the client
       TextMessage.Strict(errorResponseString(pipelineError.code, pipelineError.description, pipelineError.rpcId))
     case m @ _ =>

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/Answerer.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/Answerer.scala
@@ -30,8 +30,8 @@ object Answerer {
     */
   private def sendAnswer(graphMessage: GraphMessage): TextMessage = graphMessage match {
     // Note: The encoding of the answer is done here as the ClientActor must always receive a GraphMessage
-    case Right(rpcAnswer: JsonRpcResponse)    => TextMessage.Strict(rpcAnswer.toJson.toString)
-    case Right(rpcRequest: JsonRpcRequest)    => TextMessage.Strict(rpcRequest.toJson.toString) // propagate server
+    case Right(rpcAnswer: JsonRpcResponse)  => TextMessage.Strict(rpcAnswer.toJson.toString)
+    case Right(rpcRequest: JsonRpcRequest)  => TextMessage.Strict(rpcRequest.toJson.toString) // propagate server
     case Left(pipelineError: PipelineError) =>
       // Convert AnswerGenerator's PipelineErrors into negative JsonRpcResponses and send them back to the client
       TextMessage.Strict(errorResponseString(pipelineError.code, pipelineError.description, pipelineError.rpcId))

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/Handler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/Handler.scala
@@ -10,7 +10,7 @@ object Handler {
     val (_object, action) = rpcRequest.getDecodedDataHeader
     messageRegistry.getHandler(_object, action) match {
       case Some(handler) => handler(rpcRequest)
-      case _ => Right(PipelineError(
+      case _ => Left(PipelineError(
           ErrorCodes.SERVER_ERROR.id,
           s"MessageRegistry could not find any handler for JsonRpcRequest : $rpcRequest'",
           rpcRequest.getId
@@ -20,8 +20,8 @@ object Handler {
 
   // handles messages
   def handler(messageRegistry: MessageRegistry): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map {
-    case Left(rpcRequest: JsonRpcRequest) => handle(rpcRequest, messageRegistry)
-    case Left(rpcResponse: JsonRpcResponse) => Right(PipelineError(
+    case Right(rpcRequest: JsonRpcRequest) => handle(rpcRequest, messageRegistry)
+    case Right(rpcResponse: JsonRpcResponse) => Left(PipelineError(
         ErrorCodes.SERVER_ERROR.id,
         "NOT IMPLEMENTED : Server does not allow JsonRpcResponse processing (handling) currently",
         rpcResponse.getId

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/MessageDecoder.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/MessageDecoder.scala
@@ -17,8 +17,8 @@ object MessageDecoder {
 
   /** Graph component: takes a string as input and parses it into a JsonRpcMessage (stored into a GraphMessage)
     */
-  val jsonRpcParser: Flow[Either[JsonString, PipelineError], GraphMessage, NotUsed] = Flow[Either[JsonString, PipelineError]].map {
-    case Left(jsonString) => Try(jsonString.parseJson.asJsObject) match {
+  val jsonRpcParser: Flow[Either[PipelineError, JsonString], GraphMessage, NotUsed] = Flow[Either[PipelineError, JsonString]].map {
+    case Right(jsonString) => Try(jsonString.parseJson.asJsObject) match {
         case Success(obj) =>
           val fields: Set[String] = obj.fields.keySet
 
@@ -34,7 +34,7 @@ object MessageDecoder {
           ))
       }
 
-    case Right(pipelineError) => Left(pipelineError) // implicit typecasting
+    case Left(pipelineError) => Left(pipelineError) // implicit typecasting
   }
 
   /** Graph component: takes a GraphMessage and parses the 'data' field of any JsonRpcRequest query containing a message. The result is stored in the input JsonRpcRequest's Message's decodedData field

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/SchemaVerifier.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/SchemaVerifier.scala
@@ -60,15 +60,15 @@ object SchemaVerifier {
     * @return
     *   a [[GraphMessage]] containing the input if successful, or a [[PipelineError]] otherwise
     */
-  def verifyRpcSchema(jsonString: JsonString): Either[JsonString, PipelineError] = {
+  def verifyRpcSchema(jsonString: JsonString): Either[PipelineError, JsonString] = {
     verifySchema(querySchema, jsonString) match {
-      case Success(_) => Left(jsonString)
+      case Success(_) => Right(jsonString)
       case Failure(ex) =>
         val rpcId = Try(jsonString.parseJson.asJsObject.getFields("id")) match {
           case Success(Seq(JsNumber(id))) => Some(id.toInt)
           case _                          => None
         }
-        Right(PipelineError(ErrorCodes.INVALID_DATA.id, ex.getMessage, rpcId))
+        Left(PipelineError(ErrorCodes.INVALID_DATA.id, ex.getMessage, rpcId))
     }
   }
 
@@ -99,5 +99,5 @@ object SchemaVerifier {
   )
 
   // takes a string (json) input and compares it with the JsonSchema
-  val rpcSchemaVerifier: Flow[JsonString, Either[JsonString, PipelineError], NotUsed] = Flow[JsonString].map(verifyRpcSchema)
+  val rpcSchemaVerifier: Flow[JsonString, Either[PipelineError, JsonString], NotUsed] = Flow[JsonString].map(verifyRpcSchema)
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/Validator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/Validator.scala
@@ -59,7 +59,7 @@ object Validator {
     case Right(_) => validateJsonRpcContent(graphMessage) match {
         case Right(_) => validateMethodContent(graphMessage) match {
             case Right(_) => validateMessageContent(graphMessage) match {
-                case Right(_)          => graphMessage
+                case Right(_)         => graphMessage
                 case graphMessage @ _ => graphMessage
               }
             case graphMessage @ _ => graphMessage

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/CoinHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/CoinHandler.scala
@@ -19,9 +19,9 @@ case object CoinHandler extends MessageHandler {
     }
 
     Await.ready(ask, duration).value match {
-      case Some(Success(_))                        => Left(rpcMessage)
-      case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handlePostTransaction failed : ${ex.message}", rpcMessage.getId))
-      case reply => Right(PipelineError(
+      case Some(Success(_))                        => Right(rpcMessage)
+      case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(ex.code, s"handlePostTransaction failed : ${ex.message}", rpcMessage.getId))
+      case reply => Left(PipelineError(
           ErrorCodes.SERVER_ERROR.id,
           s"handlePostTransaction failed : unexpected DbActor reply '$reply'",
           rpcMessage.getId

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandler.scala
@@ -62,7 +62,7 @@ class ElectionHandler(dbRef: => AskableActorRef) extends MessageHandler {
       case Some(Success(_)) =>
         // generating a key pair in case the version is secret-ballot, to send then the public key to the frontend
         data.version match {
-          case OPEN_BALLOT => Left(rpcMessage)
+          case OPEN_BALLOT => Right(rpcMessage)
           case SECRET_BALLOT =>
             val keyElection: KeyElection = KeyElection(electionId, keyPair.publicKey)
             Await.result(
@@ -70,8 +70,8 @@ class ElectionHandler(dbRef: => AskableActorRef) extends MessageHandler {
               duration
             )
         }
-      case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleSetupElection failed : ${ex.message}", rpcMessage.getId))
-      case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleSetupElection failed : unexpected DbActor reply '$reply'", rpcMessage.getId))
+      case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(ex.code, s"handleSetupElection failed : ${ex.message}", rpcMessage.getId))
+      case reply                                   => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleSetupElection failed : unexpected DbActor reply '$reply'", rpcMessage.getId))
     }
   }
 
@@ -87,9 +87,9 @@ class ElectionHandler(dbRef: => AskableActorRef) extends MessageHandler {
       _ <- dbAskWritePropagate(rpcMessage)
     } yield ()
     Await.ready(combined, duration).value.get match {
-      case Success(_)                        => Left(rpcMessage)
-      case Failure(ex: DbActorNAckException) => Right(PipelineError(ex.code, s"handleOpenElection failed : ${ex.message}", rpcMessage.getId))
-      case reply                             => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleOpenElection failed : unknown DbActor reply $reply", rpcMessage.getId))
+      case Success(_)                        => Right(rpcMessage)
+      case Failure(ex: DbActorNAckException) => Left(PipelineError(ex.code, s"handleOpenElection failed : ${ex.message}", rpcMessage.getId))
+      case reply                             => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleOpenElection failed : unknown DbActor reply $reply", rpcMessage.getId))
     }
   }
 
@@ -98,7 +98,7 @@ class ElectionHandler(dbRef: => AskableActorRef) extends MessageHandler {
     Await.result(ask, duration)
   }
 
-  def handleResultElection(rpcMessage: JsonRpcRequest): GraphMessage = Right(
+  def handleResultElection(rpcMessage: JsonRpcRequest): GraphMessage = Left(
     PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: ElectionHandler cannot handle ResultElection messages yet", rpcMessage.id)
   )
 
@@ -118,8 +118,8 @@ class ElectionHandler(dbRef: => AskableActorRef) extends MessageHandler {
       _ <- dbBroadcast(rpcMessage, electionChannel, resultElectionFormat.write(resultElection), electionChannel)
     } yield ()
     Await.ready(combined, duration).value match {
-      case Some(Success(_)) => Left(rpcMessage)
-      case _                => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleEndElection unknown error", rpcMessage.getId))
+      case Some(Success(_)) => Right(rpcMessage)
+      case _                => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleEndElection unknown error", rpcMessage.getId))
     }
   }
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/LaoHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/LaoHandler.scala
@@ -50,9 +50,9 @@ case object LaoHandler extends MessageHandler {
       } yield ()
 
     Await.ready(ask, duration).value.get match {
-      case Success(_)                        => Left(rpcMessage)
-      case Failure(ex: DbActorNAckException) => Right(PipelineError(ex.code, s"handleCreateLao failed : ${ex.message}", rpcMessage.getId))
-      case reply                             => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleCreateLao failed : unexpected DbActor reply '$reply'", rpcMessage.getId))
+      case Success(_)                        => Right(rpcMessage)
+      case Failure(ex: DbActorNAckException) => Left(PipelineError(ex.code, s"handleCreateLao failed : ${ex.message}", rpcMessage.getId))
+      case reply                             => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleCreateLao failed : unexpected DbActor reply '$reply'", rpcMessage.getId))
     }
   }
 
@@ -63,7 +63,7 @@ case object LaoHandler extends MessageHandler {
 
   def handleStateLao(rpcMessage: JsonRpcRequest): GraphMessage = {
     val modificationId: Hash = rpcMessage.getDecodedData.asInstanceOf[StateLao].modification_id
-    Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED : handleStateLao is not implemented", rpcMessage.id))
+    Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED : handleStateLao is not implemented", rpcMessage.id))
   }
 
   def handleUpdateLao(rpcMessage: JsonRpcRequest): GraphMessage = {

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/MeetingHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/MeetingHandler.scala
@@ -19,9 +19,9 @@ case object MeetingHandler extends MessageHandler {
     }
 
     Await.ready(ask, duration).value match {
-      case Some(Success(_))                        => Left(rpcMessage)
-      case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleCreateMeeting failed : ${ex.message}", rpcMessage.getId))
-      case reply => Right(PipelineError(
+      case Some(Success(_))                        => Right(rpcMessage)
+      case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(ex.code, s"handleCreateMeeting failed : ${ex.message}", rpcMessage.getId))
+      case reply => Left(PipelineError(
           ErrorCodes.SERVER_ERROR.id,
           s"handleCreateMeeting failed : unexpected DbActor reply '$reply'",
           rpcMessage.getId
@@ -30,6 +30,6 @@ case object MeetingHandler extends MessageHandler {
   }
 
   def handleStateMeeting(rpcMessage: JsonRpcRequest): GraphMessage = {
-    Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED : handleStateMeeting is not implemented", rpcMessage.id))
+    Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED : handleStateMeeting is not implemented", rpcMessage.id))
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsHandler.scala
@@ -32,7 +32,7 @@ object ParamsHandler extends AskPatternConstants {
         val handlerPartitioner = builder.add(Partition[GraphMessage](
           totalPorts,
           {
-            case Left(jsonRpcMessage: JsonRpcRequest) => jsonRpcMessage.getParams match {
+            case Right(jsonRpcMessage: JsonRpcRequest) => jsonRpcMessage.getParams match {
                 case _: Subscribe   => portSubscribe
                 case _: Unsubscribe => portUnsubscribe
                 case _: Catchup     => portCatchup
@@ -61,54 +61,54 @@ object ParamsHandler extends AskPatternConstants {
   final case class Asking(g: GraphMessage, replyTo: ActorRef)
 
   def subscribeHandler(clientActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map {
-    case Left(jsonRpcMessage: JsonRpcRequest) =>
+    case Right(jsonRpcMessage: JsonRpcRequest) =>
       val channel: Channel = jsonRpcMessage.getParams.channel
       val ask: Future[GraphMessage] = (clientActorRef ? ClientActor.SubscribeTo(jsonRpcMessage.getParams.channel)).map {
         case PubSubMediator.SubscribeToAck(returnedChannel) if returnedChannel == channel =>
-          Left(jsonRpcMessage)
+          Right(jsonRpcMessage)
         case PubSubMediator.SubscribeToAck(returnedChannel) =>
-          Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"PubSubMediator subscribed client to channel '$returnedChannel' instead of '$channel'", jsonRpcMessage.id))
+          Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"PubSubMediator subscribed client to channel '$returnedChannel' instead of '$channel'", jsonRpcMessage.id))
         case PubSubMediator.SubscribeToNAck(returnedChannel, reason) if returnedChannel == channel =>
-          Right(PipelineError(ErrorCodes.INVALID_ACTION.id, s"Could not subscribe client to channel '$returnedChannel': $reason", jsonRpcMessage.id))
-        case PubSubMediator.SubscribeToNAck(returnedChannel, reason) => Right(PipelineError(
+          Left(PipelineError(ErrorCodes.INVALID_ACTION.id, s"Could not subscribe client to channel '$returnedChannel': $reason", jsonRpcMessage.id))
+        case PubSubMediator.SubscribeToNAck(returnedChannel, reason) => Left(PipelineError(
             ErrorCodes.SERVER_ERROR.id,
             s"PubSubMediator tried to subscribe client to channel '$returnedChannel' instead of '$channel' but could not: $reason",
             jsonRpcMessage.id
           ))
         case _ =>
-          Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "Client actor returned an unknown answer", jsonRpcMessage.id))
+          Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "Client actor returned an unknown answer", jsonRpcMessage.id))
       }
 
       Await.result(ask, duration)
 
-    case Left(jsonRpcMessage: JsonRpcResponse) =>
-      Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "SubscribeHandler received a 'JsonRpcResponse'", jsonRpcMessage.id))
+    case Right(jsonRpcMessage: JsonRpcResponse) =>
+      Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "SubscribeHandler received a 'JsonRpcResponse'", jsonRpcMessage.id))
     case graphMessage @ _ => graphMessage
   }
 
   def unsubscribeHandler(clientActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map {
-    case Left(jsonRpcMessage: JsonRpcRequest) =>
+    case Right(jsonRpcMessage: JsonRpcRequest) =>
       val channel: Channel = jsonRpcMessage.getParams.channel
       val ask: Future[GraphMessage] = (clientActorRef ? ClientActor.UnsubscribeFrom(channel)).map {
         case PubSubMediator.UnsubscribeFromAck(returnedChannel) if returnedChannel == channel =>
-          Left(jsonRpcMessage)
+          Right(jsonRpcMessage)
         case PubSubMediator.UnsubscribeFromAck(returnedChannel) =>
-          Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"PubSubMediator unsubscribe client from channel '$returnedChannel' instead of '$channel'", jsonRpcMessage.id))
+          Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"PubSubMediator unsubscribe client from channel '$returnedChannel' instead of '$channel'", jsonRpcMessage.id))
         case PubSubMediator.UnsubscribeFromNAck(returnedChannel, reason) if returnedChannel == channel =>
-          Right(PipelineError(ErrorCodes.INVALID_ACTION.id, s"Could not unsubscribe client from channel '$returnedChannel': $reason", jsonRpcMessage.id))
-        case PubSubMediator.UnsubscribeFromNAck(returnedChannel, reason) => Right(PipelineError(
+          Left(PipelineError(ErrorCodes.INVALID_ACTION.id, s"Could not unsubscribe client from channel '$returnedChannel': $reason", jsonRpcMessage.id))
+        case PubSubMediator.UnsubscribeFromNAck(returnedChannel, reason) => Left(PipelineError(
             ErrorCodes.SERVER_ERROR.id,
             s"PubSubMediator tried to unsubscribe client from channel '$returnedChannel' instead of '$channel' but could not: $reason",
             jsonRpcMessage.id
           ))
         case _ =>
-          Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "Client actor returned an unknown answer", jsonRpcMessage.id))
+          Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "Client actor returned an unknown answer", jsonRpcMessage.id))
       }
 
       Await.result(ask, duration)
 
-    case Left(jsonRpcMessage: JsonRpcResponse) =>
-      Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "UnsubscribeHandler received a 'JsonRpcResponse'", jsonRpcMessage.id))
+    case Right(jsonRpcMessage: JsonRpcResponse) =>
+      Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "UnsubscribeHandler received a 'JsonRpcResponse'", jsonRpcMessage.id))
     case graphMessage @ _ => graphMessage
   }
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandler.scala
@@ -56,9 +56,9 @@ class RollCallHandler(dbRef: => AskableActorRef) extends MessageHandler {
       } yield ()
 
     Await.ready(ask, duration).value match {
-      case Some(Success(_))                        => Left(rpcRequest)
-      case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleCreateRollCall failed : ${ex.message}", rpcRequest.getId))
-      case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleCreateRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
+      case Some(Success(_))                        => Right(rpcRequest)
+      case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(ex.code, s"handleCreateRollCall failed : ${ex.message}", rpcRequest.getId))
+      case reply                                   => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleCreateRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
     }
   }
 
@@ -76,9 +76,9 @@ class RollCallHandler(dbRef: => AskableActorRef) extends MessageHandler {
       } yield ()
 
     Await.ready(ask, duration).value match {
-      case Some(Success(_))                        => Left(rpcRequest)
-      case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleOpenRollCall failed : ${ex.message}", rpcRequest.getId))
-      case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleOpenRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
+      case Some(Success(_))                        => Right(rpcRequest)
+      case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(ex.code, s"handleOpenRollCall failed : ${ex.message}", rpcRequest.getId))
+      case reply                                   => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleOpenRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
     }
   }
 
@@ -91,9 +91,9 @@ class RollCallHandler(dbRef: => AskableActorRef) extends MessageHandler {
     } yield ()
 
     Await.ready(ask, duration).value match {
-      case Some(Success(_))                        => Left(rpcRequest)
-      case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleReOpenRollCall failed : ${ex.message}", rpcRequest.getId))
-      case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleRepenRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
+      case Some(Success(_))                        => Right(rpcRequest)
+      case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(ex.code, s"handleReOpenRollCall failed : ${ex.message}", rpcRequest.getId))
+      case reply                                   => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleRepenRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
     }
   }
 
@@ -108,8 +108,8 @@ class RollCallHandler(dbRef: => AskableActorRef) extends MessageHandler {
 
     Await.ready(combined, duration).value match {
       case Some(Success(_))                        => createAttendeeChannels(rpcRequest)
-      case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleCloseRollCall failed : ${ex.message}", rpcRequest.getId))
-      case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleCloseRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
+      case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(ex.code, s"handleCloseRollCall failed : ${ex.message}", rpcRequest.getId))
+      case reply                                   => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleCloseRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
     }
   }
 
@@ -126,9 +126,9 @@ class RollCallHandler(dbRef: => AskableActorRef) extends MessageHandler {
     val askCreateChannels = dbActor ? DbActor.CreateChannelsFromList(listAttendeeChannels)
 
     Await.ready(askCreateChannels, duration).value match {
-      case Some(Success(_))                        => Left(rpcRequest)
-      case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"handleCloseRollCall failed : ${ex.message}", rpcRequest.getId))
-      case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleCloseRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
+      case Some(Success(_))                        => Right(rpcRequest)
+      case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(ex.code, s"handleCloseRollCall failed : ${ex.message}", rpcRequest.getId))
+      case reply                                   => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleCloseRollCall failed : unexpected DbActor reply '$reply'", rpcRequest.getId))
     }
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandler.scala
@@ -58,13 +58,13 @@ class SocialMediaHandler(dbRef: => AskableActorRef) extends MessageHandler {
           duration
         )
 
-      case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(
+      case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(
           ex.code,
           s"handleAddChirp failed : ${ex.message}",
           rpcMessage.getId
         ))
 
-      case _ => Right(PipelineError(
+      case _ => Left(PipelineError(
           ErrorCodes.SERVER_ERROR.id,
           unknownAnswerDatabase,
           rpcMessage.getId
@@ -90,13 +90,13 @@ class SocialMediaHandler(dbRef: => AskableActorRef) extends MessageHandler {
           duration
         )
 
-      case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(
+      case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(
           ex.code,
           s"handleDeleteChirp failed : ${ex.message}",
           rpcMessage.getId
         ))
 
-      case _ => Right(PipelineError(
+      case _ => Left(PipelineError(
           ErrorCodes.SERVER_ERROR.id,
           unknownAnswerDatabase,
           rpcMessage.getId
@@ -106,11 +106,11 @@ class SocialMediaHandler(dbRef: => AskableActorRef) extends MessageHandler {
 
   // no need for a case handleNotifyAddChirp or handleNotifyDeleteChirp for now, since the server never receives any in theory, but could be needed later
   def handleNotifyAddChirp(rpcMessage: JsonRpcRequest): GraphMessage = {
-    Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: SocialMediaHandler should not handle NotifyAddChirp messages", rpcMessage.id))
+    Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: SocialMediaHandler should not handle NotifyAddChirp messages", rpcMessage.id))
   }
 
   def handleNotifyDeleteChirp(rpcMessage: JsonRpcRequest): GraphMessage = {
-    Right(PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: SocialMediaHandler should not handle NotifyDeleteChirp messages", rpcMessage.id))
+    Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "NOT IMPLEMENTED: SocialMediaHandler should not handle NotifyDeleteChirp messages", rpcMessage.id))
   }
 
   def handleAddReaction(rpcMessage: JsonRpcRequest): GraphMessage = {

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandler.scala
@@ -40,9 +40,9 @@ class WitnessHandler(dbRef: => AskableActorRef) extends MessageHandler {
       } yield ()
 
     Await.ready(combined, duration).value.get match {
-      case Success(_)                        => Left(rpcMessage)
-      case Failure(ex: DbActorNAckException) => Right(PipelineError(ex.code, s"handleWitnessMessage failed : ${ex.message}", rpcMessage.getId))
-      case reply                             => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleWitnessMessage failed : unknown DbActor reply $reply", rpcMessage.getId))
+      case Success(_)                        => Right(rpcMessage)
+      case Failure(ex: DbActorNAckException) => Left(PipelineError(ex.code, s"handleWitnessMessage failed : ${ex.message}", rpcMessage.getId))
+      case reply                             => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"handleWitnessMessage failed : unknown DbActor reply $reply", rpcMessage.getId))
     }
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/package.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/package.scala
@@ -4,5 +4,5 @@ import ch.epfl.pop.model.network.JsonRpcMessage
 
 package object graph {
   type JsonString = String
-  type GraphMessage = Either[JsonRpcMessage, PipelineError] // FIXME convention states that Right(_) is the success value
+  type GraphMessage = Either[PipelineError, JsonRpcMessage] // FIXME convention states that Left(_) is the success value
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/package.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/package.scala
@@ -4,5 +4,5 @@ import ch.epfl.pop.model.network.JsonRpcMessage
 
 package object graph {
   type JsonString = String
-  type GraphMessage = Either[PipelineError, JsonRpcMessage] // FIXME convention states that Left(_) is the success value
+  type GraphMessage = Either[PipelineError, JsonRpcMessage]
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/CoinValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/CoinValidator.scala
@@ -18,17 +18,17 @@ case object CoinValidator extends MessageDataContentValidator {
       case Some(message: Message) =>
         val data: PostTransaction = message.decodedData.get.asInstanceOf[PostTransaction]
         if (data.transactionId != data.transaction.transactionId) {
-          Right(validationError("incorrect transaction id"))
+          Left(validationError("incorrect transaction id"))
         } else if (!data.transaction.checkSignatures()) {
-          Right(validationError("bad signature"))
+          Left(validationError("bad signature"))
         } else {
           data.transaction.sumOutputs() match {
-            case Left(err) => Right(validationError(err.getMessage()))
-            case Right(_)  => Left(rpcMessage)
+            case Left(err) => Left(validationError(err.getMessage()))
+            case Right(_)  => Right(rpcMessage)
           }
         }
 
-      case _ => Right(validationErrorNoMessage(rpcMessage.id))
+      case _ => Left(validationErrorNoMessage(rpcMessage.id))
     }
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/CoinValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/CoinValidator.scala
@@ -42,7 +42,7 @@ case object CoinValidator extends MessageDataContentValidator {
     * @param error
     *   the error to forward in case the transaction signatures are not valid.
     * @return
-    *   : GraphMessage passes the rpcMessages to Left if successful, else right with pipeline error
+    *   : GraphMessage passes the rpcMessages to Right if successful, else Left with pipeline error
     */
   private def checkTransactionSignatures(rpcMessage: JsonRpcRequest, transaction: Transaction, error: PipelineError): GraphMessage = {
     if (transaction.checkSignatures())
@@ -59,7 +59,7 @@ case object CoinValidator extends MessageDataContentValidator {
     * @param validationError
     *   the error to forward in case the transaction's sum is not valid.
     * @return
-    *   GraphMessage passes the rpcMessages to Left if successful, else right with pipeline error
+    *   GraphMessage passes the rpcMessages to Right if successful, else Left with pipeline error
     */
   private def checkSumOutputs(rpcMessage: JsonRpcRequest, transaction: Transaction, validationError: String => PipelineError): GraphMessage = {
     transaction.sumOutputs() match {

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/ElectionValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/ElectionValidator.scala
@@ -330,7 +330,7 @@ sealed class ElectionValidator(dbActorRef: => AskableActorRef) extends MessageDa
     * @param error
     *   the error to forward in case the election has ended
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful else Right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful else Left with pipeline error
     */
   private def checkElectionNotEnded(
       rpcMessage: JsonRpcRequest,
@@ -356,7 +356,7 @@ sealed class ElectionValidator(dbActorRef: => AskableActorRef) extends MessageDa
     * @param error
     *   the error to forward in case of invalid vote(s)
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful else Right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful else Left with pipeline error
     */
   private def checkValidateVoteElection(
       rpcMessage: JsonRpcRequest,
@@ -398,7 +398,7 @@ sealed class ElectionValidator(dbActorRef: => AskableActorRef) extends MessageDa
     * @param error
     *   the error to forward in case the election hasn't started
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful else Right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful else Left with pipeline error
     */
   private def checkElectionStarted(
       rpcMessage: JsonRpcRequest,
@@ -422,7 +422,7 @@ sealed class ElectionValidator(dbActorRef: => AskableActorRef) extends MessageDa
     * @param error
     *   the error to forward in case of invalid id
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful else Right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful else Left with pipeline error
     */
   private def checkQuestionId(
       rpcMessage: JsonRpcRequest,
@@ -452,7 +452,7 @@ sealed class ElectionValidator(dbActorRef: => AskableActorRef) extends MessageDa
     * @param error
     *   the error to forward in case of incoherence between expectedHash and the computed hash from castVotes
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful else Right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful else Left with pipeline error
     */
   private def checkVoteResults(rpcMessage: JsonRpcRequest, channel: Channel, expectedHash: Hash, error: PipelineError): GraphMessage = {
     val castVotes = Await.result(channel.getLastVotes(dbActorRef), duration)

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidator.scala
@@ -80,7 +80,7 @@ object LaoValidator extends MessageDataContentValidator {
               validationError("LAO name must not be empty")
             )
           )
-        case _ => Right(validationErrorNoMessage(rpcMessage.id))
+        case _ => Left(validationErrorNoMessage(rpcMessage.id))
       }
 
     }
@@ -129,7 +129,7 @@ object LaoValidator extends MessageDataContentValidator {
             )
           )
 
-        case _ => Right(validationErrorNoMessage(rpcMessage.id))
+        case _ => Left(validationErrorNoMessage(rpcMessage.id))
       }
     }
 
@@ -168,7 +168,7 @@ object LaoValidator extends MessageDataContentValidator {
             )
           )
 
-        case _ => Right(validationErrorNoMessage(rpcMessage.id))
+        case _ => Left(validationErrorNoMessage(rpcMessage.id))
       }
 
     }
@@ -185,7 +185,7 @@ object LaoValidator extends MessageDataContentValidator {
 
           Await.ready(askLaoMessage, duration).value match {
             case Some(Success(DbActor.DbActorReadAck(None))) =>
-              Right(PipelineError(ErrorCodes.INVALID_RESOURCE.id, "validateUpdateLao failed : no CreateLao message associated found", rpcMessage.id))
+              Left(PipelineError(ErrorCodes.INVALID_RESOURCE.id, "validateUpdateLao failed : no CreateLao message associated found", rpcMessage.id))
             case Some(Success(DbActor.DbActorReadAck(Some(retrievedMessage)))) =>
               val laoCreationMessage = retrievedMessage.decodedData.get.asInstanceOf[CreateLao]
               // Calculate expected hash
@@ -221,11 +221,11 @@ object LaoValidator extends MessageDataContentValidator {
                 )
               )
 
-            case Some(Failure(ex: DbActorNAckException)) => Right(PipelineError(ex.code, s"validateUpdateLao failed : ${ex.message}", rpcMessage.getId))
-            case reply                                   => Right(PipelineError(ErrorCodes.SERVER_ERROR.id, s"validateUpdateLao failed : unexpected DbActor reply '$reply'", rpcMessage.getId))
+            case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(ex.code, s"validateUpdateLao failed : ${ex.message}", rpcMessage.getId))
+            case reply                                   => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"validateUpdateLao failed : unexpected DbActor reply '$reply'", rpcMessage.getId))
           }
 
-        case _ => Right(validationErrorNoMessage(rpcMessage.id))
+        case _ => Left(validationErrorNoMessage(rpcMessage.id))
 
       }
     }
@@ -242,12 +242,12 @@ object LaoValidator extends MessageDataContentValidator {
     * @param error
     *   the error to forward in case the channels are not equals
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
     */
   private def checkChannel(rpcMessage: JsonRpcRequest, chan1: Channel, chan2: Channel, error: PipelineError): GraphMessage = {
     if (chan1 == chan2)
-      Left(rpcMessage)
+      Right(rpcMessage)
     else
-      Right(error)
+      Left(error)
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidator.scala
@@ -242,7 +242,7 @@ object LaoValidator extends MessageDataContentValidator {
     * @param error
     *   the error to forward in case the channels are not equals
     * @return
-    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful Left with pipeline error
     */
   private def checkChannel(rpcMessage: JsonRpcRequest, chan1: Channel, chan2: Channel, error: PipelineError): GraphMessage = {
     if (chan1 == chan2)

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MeetingValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MeetingValidator.scala
@@ -40,23 +40,23 @@ sealed class MeetingValidator(dbActorRef: => AskableActorRef) extends MessageDat
         val channel: Channel = rpcMessage.getParamsChannel
 
         if (!validateTimestampStaleness(data.creation)) {
-          Right(validationError(s"stale 'creation' timestamp (${data.creation})"))
+          Left(validationError(s"stale 'creation' timestamp (${data.creation})"))
         } else if (!validateTimestampStaleness(data.start)) {
-          Right(validationError(s"stale 'start' timestamp (${data.start})"))
+          Left(validationError(s"stale 'start' timestamp (${data.start})"))
         } else if (data.end.isDefined && !validateTimestampOrder(data.creation, data.end.get)) {
-          Right(validationError(s"'end' (${data.end.get}) timestamp is smaller than 'creation' (${data.creation})"))
+          Left(validationError(s"'end' (${data.end.get}) timestamp is smaller than 'creation' (${data.creation})"))
         } else if (data.end.isDefined && !validateTimestampOrder(data.start, data.end.get)) {
-          Right(validationError(s"'end' (${data.end.get}) timestamp is smaller than 'start' (${data.start})"))
+          Left(validationError(s"'end' (${data.end.get}) timestamp is smaller than 'start' (${data.start})"))
         } else if (expectedHash != data.id) {
-          Right(validationError("unexpected id"))
+          Left(validationError("unexpected id"))
         } else if (!validateOwner(sender, channel, dbActorRef)) {
-          Right(validationError(s"invalid sender $sender"))
+          Left(validationError(s"invalid sender $sender"))
         } else if (!validateChannelType(ObjectType.LAO, channel, dbActorRef)) {
-          Right(validationError(s"trying to send an CreateMeeting message on a wrong type of channel $channel"))
+          Left(validationError(s"trying to send an CreateMeeting message on a wrong type of channel $channel"))
         } else {
-          Left(rpcMessage)
+          Right(rpcMessage)
         }
-      case _ => Right(validationErrorNoMessage(rpcMessage.id))
+      case _ => Left(validationErrorNoMessage(rpcMessage.id))
     }
   }
 
@@ -71,23 +71,23 @@ sealed class MeetingValidator(dbActorRef: => AskableActorRef) extends MessageDat
         val expectedHash: Hash = Hash.fromStrings(EVENT_HASH_PREFIX, laoId.toString, data.creation.toString, data.name)
 
         if (!validateTimestampStaleness(data.creation)) {
-          Right(validationError(s"stale 'creation' timestamp (${data.creation})"))
+          Left(validationError(s"stale 'creation' timestamp (${data.creation})"))
         } else if (!validateTimestampOrder(data.creation, data.last_modified)) {
-          Right(validationError(s"'last_modified' (${data.last_modified}) timestamp is smaller than 'creation' (${data.creation})"))
+          Left(validationError(s"'last_modified' (${data.last_modified}) timestamp is smaller than 'creation' (${data.creation})"))
         } else if (!validateTimestampStaleness(data.start)) {
-          Right(validationError(s"stale 'start' timestamp (${data.start})"))
+          Left(validationError(s"stale 'start' timestamp (${data.start})"))
         } else if (data.end.isDefined && !validateTimestampOrder(data.creation, data.end.get)) {
-          Right(validationError(s"'end' (${data.end.get}) timestamp is smaller than 'creation' (${data.creation})"))
+          Left(validationError(s"'end' (${data.end.get}) timestamp is smaller than 'creation' (${data.creation})"))
         } else if (data.end.isDefined && !validateTimestampOrder(data.start, data.end.get)) {
-          Right(validationError(s"'end' (${data.end.get}) timestamp is smaller than 'start' (${data.start})"))
+          Left(validationError(s"'end' (${data.end.get}) timestamp is smaller than 'start' (${data.start})"))
         } else if (!validateWitnessSignatures(data.modification_signatures, data.modification_id)) {
-          Right(validationError("witness key-signature pairs are not valid for the given modification_id"))
+          Left(validationError("witness key-signature pairs are not valid for the given modification_id"))
         } else if (expectedHash != data.id) {
-          Right(validationError("unexpected id"))
+          Left(validationError("unexpected id"))
         } else {
-          Left(rpcMessage)
+          Right(rpcMessage)
         }
-      case _ => Right(validationErrorNoMessage(rpcMessage.id))
+      case _ => Left(validationErrorNoMessage(rpcMessage.id))
     }
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageDataContentValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageDataContentValidator.scala
@@ -141,7 +141,7 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
     * @param error
     *   the error to throw if the chirp do not exist
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful Left with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful Left with pipeline error
     */
   def checkIdExistence(rpcMessage: JsonRpcRequest, id: Option[Hash], channel: Channel, dbActor: AskableActorRef, error: PipelineError): GraphMessage = {
     id match {

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageDataContentValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageDataContentValidator.scala
@@ -29,9 +29,9 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
   // Same as validateTimestampStaleness except that it returns a GraphMessage
   def checkTimestampStaleness(rpcMessage: JsonRpcRequest, timestamp: Timestamp, error: PipelineError): GraphMessage = {
     if (validateTimestampStaleness(timestamp))
-      Left(rpcMessage)
+      Right(rpcMessage)
     else
-      Right(error)
+      Left(error)
   }
 
   /** Check whether timestamp <first> is not older than timestamp <second>
@@ -53,9 +53,9 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
       error: PipelineError
   ): GraphMessage = {
     if (validateTimestampOrder(first, second))
-      Left(rpcMessage)
+      Right(rpcMessage)
     else
-      Right(error)
+      Left(error)
   }
 
   /** Checks if the id corresponds to the expected id
@@ -69,13 +69,13 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
     * @param error
     *   the error to forward in case the id is not the same as the expected id
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
     */
   def checkId(rpcMessage: JsonRpcRequest, expectedId: Hash, id: Hash, error: PipelineError): GraphMessage = {
     if (expectedId == id)
-      Left(rpcMessage)
+      Right(rpcMessage)
     else
-      Right(error)
+      Left(error)
   }
 
   /** Check if all witnesses are distinct
@@ -87,13 +87,13 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
     * @param error
     *   the error to forward in case the witnesses are not all distinct
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
     */
   def checkWitnesses(rpcMessage: JsonRpcRequest, witnesses: List[PublicKey], error: PipelineError): GraphMessage = {
     if (validateWitnesses(witnesses))
-      Left(rpcMessage)
+      Right(rpcMessage)
     else
-      Right(error)
+      Left(error)
   }
 
   /** Check if some String match the pattern
@@ -107,13 +107,13 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
     * @param error
     *   the error to forward in case the name doesn't match the pattern
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
     */
   def checkStringPattern(rpcMessage: JsonRpcRequest, str: String, pattern: Regex, error: PipelineError): GraphMessage = {
     if (pattern.matches(str))
-      Left(rpcMessage)
+      Right(rpcMessage)
     else
-      Right(error)
+      Left(error)
   }
 
   /** Checks witnesses key signature pairs for given modification id
@@ -127,7 +127,7 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
     * @param error
     *   the error to forward in case of invalid modifications
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
     */
   def checkWitnessesSignatures(
       rpcMessage: JsonRpcRequest,
@@ -136,9 +136,9 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
       error: PipelineError
   ): GraphMessage = {
     if (validateWitnessSignatures(witnessesKeyPairs, id))
-      Left(rpcMessage)
+      Right(rpcMessage)
     else
-      Right(error)
+      Left(error)
   }
 
   /** Check whether a list of <witnesses> public keys are valid or not

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageDataContentValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageDataContentValidator.scala
@@ -81,7 +81,7 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
     * @param error
     *   the error to forward in case the id is not the same as the expected id
     * @return
-    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful Left with pipeline error
     */
   def checkId(rpcMessage: JsonRpcRequest, expectedId: Hash, id: Hash, error: PipelineError): GraphMessage = {
     if (expectedId == id)
@@ -99,7 +99,7 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
     * @param error
     *   the error to forward in case the witnesses are not all distinct
     * @return
-    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful Left with pipeline error
     */
   def checkWitnesses(rpcMessage: JsonRpcRequest, witnesses: List[PublicKey], error: PipelineError): GraphMessage = {
     if (validateWitnesses(witnesses))
@@ -119,7 +119,7 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
     * @param error
     *   the error to forward in case the name doesn't match the pattern
     * @return
-    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful Left with pipeline error
     */
   def checkStringPattern(rpcMessage: JsonRpcRequest, str: String, pattern: Regex, error: PipelineError): GraphMessage = {
     if (pattern.matches(str))
@@ -141,7 +141,7 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
     * @param error
     *   the error to throw if the chirp do not exist
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Left if successful Left with pipeline error
     */
   def checkIdExistence(rpcMessage: JsonRpcRequest, id: Option[Hash], channel: Channel, dbActor: AskableActorRef, error: PipelineError): GraphMessage = {
     id match {
@@ -168,7 +168,7 @@ trait MessageDataContentValidator extends ContentValidator with AskPatternConsta
     * @param error
     *   the error to forward in case of invalid modifications
     * @return
-    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful Left with pipeline error
     */
   def checkWitnessesSignatures(
       rpcMessage: JsonRpcRequest,

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
@@ -36,10 +36,10 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
     * @param checks
     *   checks which return a GraphMessage
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
     */
   def runChecks(checks: GraphMessage*): GraphMessage = {
-    if (checks.head.isLeft && !checks.tail.isEmpty)
+    if (checks.head.isRight && !checks.tail.isEmpty)
       runChecks(checks.tail: _*)
     else
       checks.head
@@ -51,13 +51,13 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
     val expectedId: Hash = Hash.fromStrings(message.data.toString, message.signature.toString)
 
     if (message.message_id != expectedId) {
-      Right(validationError("Invalid message_id", "MessageValidator", rpcMessage.id))
+      Left(validationError("Invalid message_id", "MessageValidator", rpcMessage.id))
     } else if (!message.signature.verify(message.sender, message.data)) {
-      Right(validationError("Invalid sender signature", "MessageValidator", rpcMessage.id))
+      Left(validationError("Invalid sender signature", "MessageValidator", rpcMessage.id))
     } else if (!message.witness_signatures.forall(ws => ws.verify(message.message_id))) {
-      Right(validationError("Invalid witness signature", "MessageValidator", rpcMessage.id))
+      Left(validationError("Invalid witness signature", "MessageValidator", rpcMessage.id))
     } else {
-      Left(rpcMessage)
+      Right(rpcMessage)
     }
   }
 
@@ -87,9 +87,9 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
       error: PipelineError
   ): GraphMessage = {
     if (validateAttendee(sender, channel, dbActor))
-      Left(rpcMessage)
+      Right(rpcMessage)
     else
-      Right(error)
+      Left(error)
   }
 
   /** checks whether the sender of the JsonRpcRequest is the LAO owner
@@ -118,9 +118,9 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
       error: PipelineError
   ): GraphMessage = {
     if (validateOwner(sender, channel, dbActor))
-      Left(rpcMessage)
+      Right(rpcMessage)
     else
-      Right(error)
+      Left(error)
   }
 
   /** checks whether the channel of the JsonRpcRequest is of the given type
@@ -153,9 +153,9 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
       error: PipelineError
   ): GraphMessage = {
     if (validateChannelType(channelObjectType, channel, dbActor))
-      Left(rpcMessage)
+      Right(rpcMessage)
     else
-      Right(error)
+      Left(error)
   }
 
   /** Checks if the msg senderPK is the expected one
@@ -169,7 +169,7 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
     * @param error
     *   the error to forward in case the senderPK doesn't match the expected one
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
     */
   def checkMsgSenderKey(
       rpcMessage: JsonRpcRequest,
@@ -178,9 +178,9 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
       error: PipelineError
   ): GraphMessage = {
     if (expectedKey == msgSenderKey)
-      Left(rpcMessage)
+      Right(rpcMessage)
     else
-      Right(error)
+      Left(error)
   }
 
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidator.scala
@@ -36,7 +36,7 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
     * @param checks
     *   checks which return a GraphMessage
     * @return
-    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful Left with pipeline error
     */
   def runChecks(checks: GraphMessage*): GraphMessage = {
     if (checks.head.isRight && !checks.tail.isEmpty)
@@ -169,7 +169,7 @@ object MessageValidator extends ContentValidator with AskPatternConstants {
     * @param error
     *   the error to forward in case the senderPK doesn't match the expected one
     * @return
-    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful Left with pipeline error
     */
   def checkMsgSenderKey(
       rpcMessage: JsonRpcRequest,

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/ParamsValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/ParamsValidator.scala
@@ -9,9 +9,9 @@ object ParamsValidator extends MethodContentValidator {
 
   private def validateGeneralParams(rpcMessage: JsonRpcRequest): GraphMessage = {
     if (!validateChannel(rpcMessage.getParamsChannel)) {
-      Right(ParamsValidator.validationError("Channel validation failed", rpcMessage.id))
+      Left(ParamsValidator.validationError("Channel validation failed", rpcMessage.id))
     } else {
-      Left(rpcMessage)
+      Right(rpcMessage)
     }
   }
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
@@ -103,7 +103,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
     * @param rpcMessage
     *   rpc message to validate
     * @return
-    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful Left with pipeline error
     */
   def validateOpenRollCall(rpcMessage: JsonRpcRequest, validatorName: String = "OpenRollCall"): GraphMessage = {
     def validationError(reason: String): PipelineError = super.validationError(reason, validatorName, rpcMessage.id)
@@ -150,7 +150,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
     * @param error
     *   the error to forward in case the opens id does not correspond to the expected id
     * @return
-    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful Left with pipeline error
     */
   private def validateOpens(rpcMessage: JsonRpcRequest, laoId: Hash, opens: Hash, error: PipelineError): GraphMessage = {
     val rollCallData: Option[RollCallData] = getRollCallData(laoId)
@@ -169,7 +169,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
     * @param rpcMessage
     *   rpc message to validate
     * @return
-    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful Left with pipeline error
     */
   def validateReopenRollCall(rpcMessage: JsonRpcRequest): GraphMessage = {
     validateOpenRollCall(rpcMessage, "ReopenRollCall")
@@ -227,7 +227,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
     * @param error
     *   the error to forward in case the closes id does not correspond to the expected id
     * @return
-    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful Left with pipeline error
     */
   private def validateCloses(rpcMessage: JsonRpcRequest, laoId: Hash, closes: Hash, error: PipelineError): GraphMessage = {
     val rollCallData: Option[RollCallData] = getRollCallData(laoId)
@@ -252,7 +252,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
     * @param error
     *   the error to forward in case the size is not as expected
     * @return
-    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful Left with pipeline error
     */
   private def checkAttendeeSize(rpcMessage: JsonRpcRequest, size: Int, expectedSize: Int, error: PipelineError): GraphMessage = {
     if (size == expectedSize)

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidator.scala
@@ -94,7 +94,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
             validationError(s"trying to send a CreateRollCall message on a wrong type of channel $channel")
           )
         )
-      case _ => Right(validationErrorNoMessage(rpcMessage.id))
+      case _ => Left(validationErrorNoMessage(rpcMessage.id))
     }
   }
 
@@ -103,7 +103,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
     * @param rpcMessage
     *   rpc message to validate
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
     */
   def validateOpenRollCall(rpcMessage: JsonRpcRequest, validatorName: String = "OpenRollCall"): GraphMessage = {
     def validationError(reason: String): PipelineError = super.validationError(reason, validatorName, rpcMessage.id)
@@ -135,7 +135,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
           ),
           validateOpens(rpcMessage, laoId, data.opens, validationError("unexpected id 'opens'"))
         )
-      case _ => Right(validationErrorNoMessage(rpcMessage.id))
+      case _ => Left(validationErrorNoMessage(rpcMessage.id))
     }
   }
 
@@ -150,17 +150,17 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
     * @param error
     *   the error to forward in case the opens id does not correspond to the expected id
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
     */
   private def validateOpens(rpcMessage: JsonRpcRequest, laoId: Hash, opens: Hash, error: PipelineError): GraphMessage = {
     val rollCallData: Option[RollCallData] = getRollCallData(laoId)
     rollCallData match {
       case Some(data) =>
         if ((data.state == CREATE || data.state == CLOSE) && data.updateId == opens)
-          Left(rpcMessage)
+          Right(rpcMessage)
         else
-          Right(error)
-      case _ => Right(error)
+          Left(error)
+      case _ => Left(error)
     }
   }
 
@@ -169,7 +169,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
     * @param rpcMessage
     *   rpc message to validate
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
     */
   def validateReopenRollCall(rpcMessage: JsonRpcRequest): GraphMessage = {
     validateOpenRollCall(rpcMessage, "ReopenRollCall")
@@ -212,7 +212,7 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
             validationError(s"trying to send a CloseRollCall message on a wrong type of channel $channel")
           )
         )
-      case _ => Right(validationErrorNoMessage(rpcMessage.id))
+      case _ => Left(validationErrorNoMessage(rpcMessage.id))
     }
   }
 
@@ -227,17 +227,17 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
     * @param error
     *   the error to forward in case the closes id does not correspond to the expected id
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
     */
   private def validateCloses(rpcMessage: JsonRpcRequest, laoId: Hash, closes: Hash, error: PipelineError): GraphMessage = {
     val rollCallData: Option[RollCallData] = getRollCallData(laoId)
     rollCallData match {
       case Some(data) =>
         if ((data.state == OPEN || data.state == REOPEN) && data.updateId == closes)
-          Left(rpcMessage)
+          Right(rpcMessage)
         else
-          Right(error)
-      case _ => Right(error)
+          Left(error)
+      case _ => Left(error)
     }
   }
 
@@ -252,12 +252,12 @@ sealed class RollCallValidator(dbActorRef: => AskableActorRef) extends MessageDa
     * @param error
     *   the error to forward in case the size is not as expected
     * @return
-    *   GraphMessage: passes the rpcMessages to Left if successful right with pipeline error
+    *   GraphMessage: passes the rpcMessages to Right if successful right with pipeline error
     */
   private def checkAttendeeSize(rpcMessage: JsonRpcRequest, size: Int, expectedSize: Int, error: PipelineError): GraphMessage = {
     if (size == expectedSize)
-      Left(rpcMessage)
+      Right(rpcMessage)
     else
-      Right(error)
+      Left(error)
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RpcValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/RpcValidator.scala
@@ -8,9 +8,9 @@ object RpcValidator extends ContentValidator {
 
   private def validateGeneralRpc(rpcMessage: JsonRpcMessage, validationErrorFunction: String => PipelineError): GraphMessage = {
     if (rpcMessage.jsonrpc != JSON_RPC_VERSION) {
-      Right(validationErrorFunction(s"json-rpc version should be '$JSON_RPC_VERSION' but is ${rpcMessage.jsonrpc}"))
+      Left(validationErrorFunction(s"json-rpc version should be '$JSON_RPC_VERSION' but is ${rpcMessage.jsonrpc}"))
     } else {
-      Left(rpcMessage)
+      Right(rpcMessage)
     }
   }
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/SocialMediaValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/SocialMediaValidator.scala
@@ -49,27 +49,27 @@ sealed class SocialMediaValidator(dbActorRef: => AskableActorRef) extends Messag
         val channel: Channel = rpcMessage.getParamsChannel
 
         if (!validateTimestampStaleness(data.timestamp)) {
-          Right(validationError(s"stale timestamp (${data.timestamp})"))
+          Left(validationError(s"stale timestamp (${data.timestamp})"))
         } else if (!validateChannelType(ObjectType.CHIRP, channel, dbActorRef)) {
-          Right(validationError(s"trying to add a Chirp on a wrong type of channel $channel"))
+          Left(validationError(s"trying to add a Chirp on a wrong type of channel $channel"))
         } else if (!validateAttendee(sender, channel, dbActorRef)) {
-          Right(validationError(s"Sender $sender has an invalid PoP token."))
+          Left(validationError(s"Sender $sender has an invalid PoP token."))
         } else if (channel.extractChildChannel.base64Data != sender.base64Data) {
-          Right(validationError(s"Sender $sender has an invalid PoP token - doesn't own the channel."))
+          Left(validationError(s"Sender $sender has an invalid PoP token - doesn't own the channel."))
         } else if (data.text.length > CHIRP_TEXT_LENGTH) {
-          Right(validationError(s"Text is too long (over 300 characters)."))
+          Left(validationError(s"Text is too long (over 300 characters)."))
         }
         // FIXME: validate parent ID: check with ChannelData object
         else {
-          Left(rpcMessage)
+          Right(rpcMessage)
         }
-      case _ => Right(validationErrorNoMessage(rpcMessage.id))
+      case _ => Left(validationErrorNoMessage(rpcMessage.id))
     }
   }
 
   // no need for validation for now, as the server is not supposed to receive the broadcasts
   def validateNotifyAddChirp(rpcMessage: JsonRpcRequest): GraphMessage = {
-    Left(rpcMessage)
+    Right(rpcMessage)
   }
 
   def validateDeleteChirp(rpcMessage: JsonRpcRequest): GraphMessage = {
@@ -85,23 +85,23 @@ sealed class SocialMediaValidator(dbActorRef: => AskableActorRef) extends Messag
         val channel: Channel = rpcMessage.getParamsChannel
 
         if (!validateTimestampStaleness(data.timestamp)) {
-          Right(validationError(s"stale timestamp (${data.timestamp})"))
+          Left(validationError(s"stale timestamp (${data.timestamp})"))
         } else if (!validateChannelType(ObjectType.CHIRP, channel, dbActorRef)) {
-          Right(validationError(s"trying to delete a Chirp on a wrong type of channel $channel"))
+          Left(validationError(s"trying to delete a Chirp on a wrong type of channel $channel"))
         } else if (!validateAttendee(sender, channel, dbActorRef)) {
-          Right(validationError(s"Sender $sender has an invalid PoP token."))
+          Left(validationError(s"Sender $sender has an invalid PoP token."))
         } else if (channel.extractChildChannel.base64Data != sender.base64Data) {
-          Right(validationError(s"Sender $sender has an invalid PoP token - doesn't own the channel."))
+          Left(validationError(s"Sender $sender has an invalid PoP token - doesn't own the channel."))
         } else {
-          Left(rpcMessage)
+          Right(rpcMessage)
         }
-      case _ => Right(validationErrorNoMessage(rpcMessage.id))
+      case _ => Left(validationErrorNoMessage(rpcMessage.id))
     }
   }
 
   // no need for validation for now, as the server is not supposed to receive the broadcasts
   def validateNotifyDeleteChirp(rpcMessage: JsonRpcRequest): GraphMessage = {
-    Left(rpcMessage)
+    Right(rpcMessage)
   }
 
   def validateAddReaction(rpcMessage: JsonRpcRequest): GraphMessage = {
@@ -115,15 +115,15 @@ sealed class SocialMediaValidator(dbActorRef: => AskableActorRef) extends Messag
         val channel: Channel = rpcMessage.getParamsChannel
 
         if (!validateTimestampStaleness(data.timestamp)) {
-          Right(validationError(s"stale timestamp (${data.timestamp})"))
+          Left(validationError(s"stale timestamp (${data.timestamp})"))
         } else if (!validateChannelType(ObjectType.REACTION, channel, dbActorRef)) {
-          Right(validationError(s"trying to delete a reaction on a wrong type of channel $channel"))
+          Left(validationError(s"trying to delete a reaction on a wrong type of channel $channel"))
         } else if (!validateAttendee(sender, channel, dbActorRef)) {
-          Right(validationError(s"Sender $sender has an invalid PoP token."))
+          Left(validationError(s"Sender $sender has an invalid PoP token."))
         } else {
-          Left(rpcMessage)
+          Right(rpcMessage)
         }
-      case _ => Right(validationErrorNoMessage(rpcMessage.id))
+      case _ => Left(validationErrorNoMessage(rpcMessage.id))
     }
   }
 
@@ -138,15 +138,15 @@ sealed class SocialMediaValidator(dbActorRef: => AskableActorRef) extends Messag
         val channel: Channel = rpcMessage.getParamsChannel
 
         if (!validateTimestampStaleness(data.timestamp)) {
-          Right(validationError(s"stale timestamp (${data.timestamp})"))
+          Left(validationError(s"stale timestamp (${data.timestamp})"))
         } else if (!validateChannelType(ObjectType.REACTION, channel, dbActorRef)) {
-          Right(validationError(s"trying to delete a reaction on a wrong type of channel $channel"))
+          Left(validationError(s"trying to delete a reaction on a wrong type of channel $channel"))
         } else if (!validateAttendee(sender, channel, dbActorRef)) {
-          Right(validationError(s"Sender $sender has an invalid PoP token."))
+          Left(validationError(s"Sender $sender has an invalid PoP token."))
         } else {
-          Left(rpcMessage)
+          Right(rpcMessage)
         }
-      case _ => Right(validationErrorNoMessage(rpcMessage.id))
+      case _ => Left(validationErrorNoMessage(rpcMessage.id))
     }
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidator.scala
@@ -3,7 +3,7 @@ package ch.epfl.pop.pubsub.graph.validators
 import akka.pattern.AskableActorRef
 import ch.epfl.pop.model.network.method.message.data.witness.WitnessMessage
 import ch.epfl.pop.model.network.{JsonRpcMessage, JsonRpcRequest}
-import ch.epfl.pop.model.objects.{Channel, Hash, PublicKey, WitnessSignaturePair}
+import ch.epfl.pop.model.objects.{WitnessSignaturePair}
 import ch.epfl.pop.pubsub.graph.validators.MessageValidator._
 import ch.epfl.pop.pubsub.graph.{GraphMessage, PipelineError}
 import ch.epfl.pop.storage.DbActor

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidator.scala
@@ -16,57 +16,19 @@ object WitnessValidator {
 }
 
 sealed class WitnessValidator(dbActorRef: => AskableActorRef) extends MessageDataContentValidator {
-  type TestChange = Either[PipelineError, JsonRpcMessage]
-
-  def bindToPipe[T](rpcMessage: JsonRpcMessage, opt: Option[T], pipelineError: PipelineError): TestChange = {
+  def bindToPipe[T](rpcMessage: JsonRpcMessage, opt: Option[T], pipelineError: PipelineError): GraphMessage = {
     if (opt.isEmpty) Left(pipelineError) else Right(rpcMessage)
   }
 
-  def revert(graphMessage: GraphMessage): TestChange = {
-    graphMessage match {
-      case Left(message) => Right(message)
-      case Right(err)    => Left(err)
-    }
-  }
-
-  def undoRevert(testChange: TestChange): GraphMessage = {
-    testChange match {
-      case Left(err) => Right(err)
-      case Right(x)  => Left(x)
-    }
-  }
-
-  def checkWitnessesSignaturesTest(
-      rpcMessage: JsonRpcRequest,
-      witnessesKeyPairs: List[WitnessSignaturePair],
-      id: Hash,
-      error: PipelineError
-  ): TestChange = {
-    revert(checkWitnessesSignatures(rpcMessage, witnessesKeyPairs, id, error))
-  }
-
-  def checkOwnerTest(
-      rpcMessage: JsonRpcRequest,
-      sender: PublicKey,
-      channel: Channel,
-      dbActor: AskableActorRef = DbActor.getInstance,
-      error: PipelineError
-  ): TestChange = {
-    revert(checkOwner(rpcMessage, sender, channel, dbActor, error))
-  }
   def validateWitnessMessage(rpcMessage: JsonRpcRequest): GraphMessage = {
-    undoRevert(validateWitnessMessageTest(rpcMessage))
-  }
-
-  def validateWitnessMessageTest(rpcMessage: JsonRpcRequest): TestChange = {
     def validationError(reason: String): PipelineError = super.validationError(reason, "WitnessMessage", rpcMessage.id)
 
     for {
       _ <- bindToPipe(rpcMessage, rpcMessage.getParamsMessage, validationErrorNoMessage(rpcMessage.id))
       (data, _, sender, channel) = extractData[WitnessMessage](rpcMessage)
       witnessSignaturePair = WitnessSignaturePair(sender, data.signature)
-      _ <- checkWitnessesSignaturesTest(rpcMessage, List(witnessSignaturePair), data.message_id, validationError("verification of the signature over the message id failed"))
-      result <- checkOwnerTest(rpcMessage, sender, channel, dbActorRef, validationError(s"invalid sender $sender"))
+      _ <- checkWitnessesSignatures(rpcMessage, List(witnessSignaturePair), data.message_id, validationError("verification of the signature over the message id failed"))
+      result <- checkOwner(rpcMessage, sender, channel, dbActorRef, validationError(s"invalid sender $sender"))
     } yield result
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidator.scala
@@ -27,7 +27,14 @@ sealed class WitnessValidator(dbActorRef: => AskableActorRef) extends MessageDat
       _ <- bindToPipe(rpcMessage, rpcMessage.getParamsMessage, validationErrorNoMessage(rpcMessage.id))
       (data, _, sender, channel) = extractData[WitnessMessage](rpcMessage)
       witnessSignaturePair = WitnessSignaturePair(sender, data.signature)
-      _ <- checkWitnessesSignatures(rpcMessage, List(witnessSignaturePair), data.message_id, validationError("verification of the signature over the message id failed"))
+      _ <- checkWitnessesSignatures(
+        rpcMessage,
+        List(witnessSignaturePair),
+        data.message_id,
+        validationError(
+          "verification of the signature over the message id failed"
+        )
+      )
       result <- checkOwner(rpcMessage, sender, channel, dbActorRef, validationError(s"invalid sender $sender"))
     } yield result
   }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/MessageRegistrySuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/MessageRegistrySuite.scala
@@ -21,7 +21,7 @@ class MessageRegistrySuite extends FunSuite with Matchers {
 
   def unitSchemaVerifier(s: JsonString): Try[Unit] = Success((): Unit)
   def unitBuilder(s: JsonString): MessageData = MessageDataInstance()
-  def unitValidator(r: JsonRpcRequest): GraphMessage = Left(r)
+  def unitValidator(r: JsonRpcRequest): GraphMessage = Right(r)
   def unitHandler(r: JsonRpcRequest): GraphMessage = unitValidator(r)
 
   val register: Map[(ObjectType, ActionType), RegisterEntry] = Map(
@@ -32,15 +32,15 @@ class MessageRegistrySuite extends FunSuite with Matchers {
   val registry: MessageRegistry = new MessageRegistry(register)
 
   test("A custom MessageRegistry may be injected in the graph") {
-    val gm = Left(JsonRpcRequest.buildFromJson("""{"jsonrpc":"2.0","method":"publish","params":{"message":{"message_id":"f1jTxH8TU2UGUBnikGU3wRTHjhOmIEQVmxZBK55QpsE=","sender":"to_klZLtiHV446Fv98OLNdNmi-EP5OaTtbBkotTYLic=","signature":"2VDJCWg11eNPUvZOnvq5YhqqIKLBcik45n-6o87aUKefmiywagivzD4o_YmjWHzYcb9qg-OgDBZbBNWSUgJICA==","data":"eyJjcmVhdGlvbiI6MTYzMTg4NzQ5NiwiaWQiOiJ4aWdzV0ZlUG1veGxkd2txMUt1b0wzT1ZhODl4amdYalRPZEJnSldjR1drPSIsIm5hbWUiOiJoZ2dnZ2dnIiwib3JnYW5pemVyIjoidG9fa2xaTHRpSFY0NDZGdjk4T0xOZE5taS1FUDVPYVR0YkJrb3RUWUxpYz0iLCJ3aXRuZXNzZXMiOltdLCJvYmplY3QiOiJsYW8iLCJhY3Rpb24iOiJjcmVhdGUifQ==","witness_signatures":[]},"channel":"/root"},"id":1}"""))
+    val gm = Right(JsonRpcRequest.buildFromJson("""{"jsonrpc":"2.0","method":"publish","params":{"message":{"message_id":"f1jTxH8TU2UGUBnikGU3wRTHjhOmIEQVmxZBK55QpsE=","sender":"to_klZLtiHV446Fv98OLNdNmi-EP5OaTtbBkotTYLic=","signature":"2VDJCWg11eNPUvZOnvq5YhqqIKLBcik45n-6o87aUKefmiywagivzD4o_YmjWHzYcb9qg-OgDBZbBNWSUgJICA==","data":"eyJjcmVhdGlvbiI6MTYzMTg4NzQ5NiwiaWQiOiJ4aWdzV0ZlUG1veGxkd2txMUt1b0wzT1ZhODl4amdYalRPZEJnSldjR1drPSIsIm5hbWUiOiJoZ2dnZ2dnIiwib3JnYW5pemVyIjoidG9fa2xaTHRpSFY0NDZGdjk4T0xOZE5taS1FUDVPYVR0YkJrb3RUWUxpYz0iLCJ3aXRuZXNzZXMiOltdLCJvYmplY3QiOiJsYW8iLCJhY3Rpb24iOiJjcmVhdGUifQ==","witness_signatures":[]},"channel":"/root"},"id":1}"""))
 
     val res = MessageDecoder.parseData(gm, registry)
 
     res shouldBe a[GraphMessage]
-    res.isLeft should be(true)
+    res.isRight should be(true)
 
     res match {
-      case Left(rpcMessage) =>
+      case Right(rpcMessage) =>
         rpcMessage shouldBe a[JsonRpcRequest]
 
         // takes the "left" of the either
@@ -50,7 +50,7 @@ class MessageRegistrySuite extends FunSuite with Matchers {
         val messageData = rpc.getDecodedData.get
         messageData._object should equal(MessageDataInstance()._object)
         messageData.action should equal(MessageDataInstance().action)
-      case _ => fail("resulting graph message is not 'Left'")
+      case _ => fail("resulting graph message is not 'Right'")
     }
   }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/AnswerGeneratorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/AnswerGeneratorSuite.scala
@@ -157,8 +157,8 @@ class AnswerGeneratorSuite extends TestKit(ActorSystem("Test")) with FunSuiteLik
       optId
     )
     val gm = AnswerGenerator.generateAnswer(Left(error))
-    gm shouldBe a[Right[JsonRpcResponse, _]]
-    val msg = gm.swap.toOption
+    gm shouldBe a[Right[_, JsonRpcResponse]]
+    val msg = gm.toOption
     msg.isDefined should be(true)
     msg.get.asInstanceOf[JsonRpcResponse].jsonrpc should be(RpcValidator.JSON_RPC_VERSION)
     msg.get.asInstanceOf[JsonRpcResponse].id should be(optId)

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/AnswerGeneratorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/AnswerGeneratorSuite.scala
@@ -77,8 +77,8 @@ class AnswerGeneratorSuite extends TestKit(ActorSystem("Test")) with FunSuiteLik
   test("Publish: correct response test") {
 
     val rpcPublishReq = getJsonRPC(pathPublishJson)
-    val message: GraphMessage = AnswerGenerator.generateAnswer(Left(rpcPublishReq))
-    val expected: GraphMessage = Left(JsonRpcResponse(
+    val message: GraphMessage = AnswerGenerator.generateAnswer(Right(rpcPublishReq))
+    val expected: GraphMessage = Right(JsonRpcResponse(
       RpcValidator.JSON_RPC_VERSION,
       Some(new ResultObject(0)),
       None,
@@ -92,11 +92,11 @@ class AnswerGeneratorSuite extends TestKit(ActorSystem("Test")) with FunSuiteLik
   test("Catchup: correct response test for Nil Messages") {
 
     lazy val dbActorRef = mockDbWithMessages(Nil)
-    val message: GraphMessage = new AnswerGenerator(dbActorRef).generateAnswer(Left(rpcCatchupReq))
+    val message: GraphMessage = new AnswerGenerator(dbActorRef).generateAnswer(Right(rpcCatchupReq))
 
     def resultObject: ResultObject = new ResultObject(Nil)
 
-    val expected = Left(JsonRpcResponse(
+    val expected = Right(JsonRpcResponse(
       RpcValidator.JSON_RPC_VERSION,
       Some(resultObject),
       None,
@@ -111,11 +111,11 @@ class AnswerGeneratorSuite extends TestKit(ActorSystem("Test")) with FunSuiteLik
 
     val messages = MessageExample.MESSAGE :: Nil
     lazy val dbActorRef = mockDbWithMessages(messages)
-    val gmsg: GraphMessage = new AnswerGenerator(dbActorRef).generateAnswer(Left(rpcCatchupReq))
+    val gmsg: GraphMessage = new AnswerGenerator(dbActorRef).generateAnswer(Right(rpcCatchupReq))
 
     def resultObject: ResultObject = new ResultObject(messages)
 
-    val expected = Left(JsonRpcResponse(
+    val expected = Right(JsonRpcResponse(
       RpcValidator.JSON_RPC_VERSION,
       Some(resultObject),
       None,
@@ -131,8 +131,8 @@ class AnswerGeneratorSuite extends TestKit(ActorSystem("Test")) with FunSuiteLik
     lazy val dbActorRef =
       mockDbWithNack(ErrorCodes.INVALID_RESOURCE.id, "error (mock)")
 
-    val gmsg: GraphMessage = new AnswerGenerator(dbActorRef).generateAnswer(Left(rpcCatchupReq))
-    val expected = Right(PipelineError(ErrorCodes.INVALID_RESOURCE.id, "AnswerGenerator failed : error (mock)", rpcCatchupReq.id))
+    val gmsg: GraphMessage = new AnswerGenerator(dbActorRef).generateAnswer(Right(rpcCatchupReq))
+    val expected = Left(PipelineError(ErrorCodes.INVALID_RESOURCE.id, "AnswerGenerator failed : error (mock)", rpcCatchupReq.id))
 
     gmsg should be(expected)
     system.stop(dbActorRef.actorRef)
@@ -141,14 +141,14 @@ class AnswerGeneratorSuite extends TestKit(ActorSystem("Test")) with FunSuiteLik
   test("Broadcast: answer error on broadcast") {
 
     val rpcBroadcastReq = getJsonRPC(pathBroadcastJson)
-    val message: GraphMessage = AnswerGenerator.generateAnswer(Left(rpcBroadcastReq))
+    val message: GraphMessage = AnswerGenerator.generateAnswer(Right(rpcBroadcastReq))
 
-    message shouldBe a[Right[_, PipelineError]]
-    message.toOption.isDefined should be(true)
-    message.toOption.get.code should be(ErrorCodes.SERVER_ERROR.id)
+    message shouldBe a[Left[PipelineError, _]]
+    message.isLeft should be(true)
+    message.swap.toOption.get.code should be(ErrorCodes.SERVER_ERROR.id)
   }
 
-  test("Convert Right Pipeline messages into Error Messages test") {
+  test("Convert Left Pipeline messages into Error Messages test") {
 
     val optId = Option(1)
     val error = PipelineError(
@@ -156,8 +156,8 @@ class AnswerGeneratorSuite extends TestKit(ActorSystem("Test")) with FunSuiteLik
       "Server received a Broadcast message which should never happen (broadcast messages are only emitted by server)",
       optId
     )
-    val gm = AnswerGenerator.generateAnswer(Right(error))
-    gm shouldBe a[Left[JsonRpcResponse, _]]
+    val gm = AnswerGenerator.generateAnswer(Left(error))
+    gm shouldBe a[Right[JsonRpcResponse, _]]
     val msg = gm.swap.toOption
     msg.isDefined should be(true)
     msg.get.asInstanceOf[JsonRpcResponse].jsonrpc should be(RpcValidator.JSON_RPC_VERSION)

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/CoinHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/CoinHandlerSuite.scala
@@ -29,7 +29,7 @@ class CoinHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System")) wit
     val rc = CoinHandler
     val request = postTransaction
 
-    rc.handlePostTransaction(request) should equal(Left(request))
+    rc.handlePostTransaction(request) should equal(Right(request))
   }
 
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandlerTest.scala
@@ -40,7 +40,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
   private final val PUBLIC_KEY: PublicKey = PublicKey(Base64Data("jsNj23IHALvppqV1xQfP71_3IyAHzivxiCz236_zzQc="))
   private final val PRIVATE_KEY: PrivateKey = PrivateKey(Base64Data("qRfms3wzSLkxAeBz6UtwA-L1qP0h8D9XI1FSvY68t7Y="))
   private final val PK_OWNER: PublicKey = PublicKey(Base64Data.encode("wrongOwner"))
-  private final val laoDataRight: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
+  private final val laoDataLeft: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
 
   private final val channelDataWithSetupAndOpenAndCastMessage: ChannelData = ChannelData(ObjectType.ELECTION, List(DATA_CAST_VOTE_MESSAGE, DATA_SET_UP_OPEN_BALLOT, DATA_OPEN_MESSAGE))
   private final val messages: List[Message] = List(MESSAGE_CAST_VOTE_ELECTION_WORKING, MESSAGE_SETUPELECTION_OPEN_BALLOT_WORKING, MESSAGE_OPEN_ELECTION_WORKING, MESSAGE_END_ELECTION_WORKING)
@@ -137,7 +137,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
 
         case DbActor.ReadLaoData(_) =>
           system.log.info("Responding with a Ack")
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
 
         case DbActor.ReadElectionData(_) =>
           system.log.info("Responding with a Ack")
@@ -205,7 +205,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
     val rc = new ElectionHandler(mockedDB)
     val request = SetupElectionMessages.setupElection
 
-    rc.handleSetupElection(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleSetupElection(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -215,7 +215,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
     val rc = new ElectionHandler(mockedDB)
     val request = SetupElectionMessages.setupElection
 
-    rc.handleSetupElection(request) should equal(Left(request))
+    rc.handleSetupElection(request) should equal(Right(request))
 
     system.stop(mockedDB.actorRef)
   }
@@ -225,7 +225,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
     val rc = new ElectionHandler(mockedDB)
     val request = SetupElectionMessages.setupElectionSecretBallot
 
-    rc.handleSetupElection(request) should equal(Left(request))
+    rc.handleSetupElection(request) should equal(Right(request))
 
     system.stop(mockedDB.actorRef)
   }
@@ -235,7 +235,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
     val rc = new ElectionHandler(mockedDB)
     val request = SetupElectionMessages.setupElectionSecretBallot
 
-    rc.handleSetupElection(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleSetupElection(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -245,7 +245,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
     val rc = new ElectionHandler(mockedDB)
     val request = OpenElectionMessages.openElection
 
-    rc.handleOpenElection(request) should equal(Left(request))
+    rc.handleOpenElection(request) should equal(Right(request))
 
     system.stop(mockedDB.actorRef)
   }
@@ -255,7 +255,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
     val rc = new ElectionHandler(mockedDB)
     val request = OpenElectionMessages.openElection
 
-    rc.handleOpenElection(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleOpenElection(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -265,7 +265,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
     val rc = new ElectionHandler(mockedDB)
     val request = OpenElectionMessages.openElection
 
-    rc.handleOpenElection(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleOpenElection(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -275,7 +275,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
     val rc = new ElectionHandler(mockedDB)
     val request = CastVoteElectionMessages.castVoteElection
 
-    rc.handleCastVoteElection(request) should equal(Left(request))
+    rc.handleCastVoteElection(request) should equal(Right(request))
 
     system.stop(mockedDB.actorRef)
   }
@@ -285,7 +285,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
     val rc = new ElectionHandler(mockedDB)
     val request = CastVoteElectionMessages.castVoteElection
 
-    rc.handleCastVoteElection(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleCastVoteElection(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -295,7 +295,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
     val rc = new ElectionHandler(mockedDB)
     val request = EndElectionMessages.endElection
 
-    rc.handleEndElection(request) should equal(Left(request))
+    rc.handleEndElection(request) should equal(Right(request))
 
     system.stop(mockedDB.actorRef)
   }*/
@@ -305,7 +305,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
     val rc = new ElectionHandler(mockedDB)
     val request = EndElectionMessages.endElection
 
-    rc.handleOpenElection(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleOpenElection(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -315,7 +315,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
     val rc = new ElectionHandler(mockedDB)
     val request = EndElectionMessages.endElection
 
-    rc.handleEndElection(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleEndElection(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -325,7 +325,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
     val rc = new ElectionHandler(mockedDB)
     val request = KeyElectionMessages.keyElection
 
-    rc.handleKeyElection(request) should equal(Left(request))
+    rc.handleKeyElection(request) should equal(Right(request))
 
     system.stop(mockedDB.actorRef)
   }
@@ -335,7 +335,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
     val rc = new ElectionHandler(mockedDB)
     val request = KeyElectionMessages.keyElection
 
-    rc.handleKeyElection(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleKeyElection(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ElectionHandlerTest.scala
@@ -40,7 +40,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
   private final val PUBLIC_KEY: PublicKey = PublicKey(Base64Data("jsNj23IHALvppqV1xQfP71_3IyAHzivxiCz236_zzQc="))
   private final val PRIVATE_KEY: PrivateKey = PrivateKey(Base64Data("qRfms3wzSLkxAeBz6UtwA-L1qP0h8D9XI1FSvY68t7Y="))
   private final val PK_OWNER: PublicKey = PublicKey(Base64Data.encode("wrongOwner"))
-  private final val laoDataLeft: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
+  private final val laoDataRight: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
 
   private final val channelDataWithSetupAndOpenAndCastMessage: ChannelData = ChannelData(ObjectType.ELECTION, List(DATA_CAST_VOTE_MESSAGE, DATA_SET_UP_OPEN_BALLOT, DATA_OPEN_MESSAGE))
   private final val messages: List[Message] = List(MESSAGE_CAST_VOTE_ELECTION_WORKING, MESSAGE_SETUPELECTION_OPEN_BALLOT_WORKING, MESSAGE_OPEN_ELECTION_WORKING, MESSAGE_END_ELECTION_WORKING)
@@ -137,7 +137,7 @@ class ElectionHandlerTest extends TestKit(ActorSystem("Election-DB-System")) wit
 
         case DbActor.ReadLaoData(_) =>
           system.log.info("Responding with a Ack")
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
 
         case DbActor.ReadElectionData(_) =>
           system.log.info("Responding with a Ack")

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandlerTest.scala
@@ -93,7 +93,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     val mockedDB = mockDbWithNack
     val rc = new RollCallHandler(mockedDB)
     val request = CreateRollCallMessages.createRollCall
-    rc.handleCreateRollCall(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleCreateRollCall(request) shouldBe an[Left[PipelineError, _]]
     system.stop(mockedDB.actorRef)
   }
 
@@ -101,7 +101,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     val mockedDB = mockDbRollCallNotCreated
     val rc = new RollCallHandler(mockedDB)
     val request = CreateRollCallMessages.createRollCall
-    rc.handleCreateRollCall(request) should matchPattern { case Left(_) => }
+    rc.handleCreateRollCall(request) should matchPattern { case Right(_) => }
     system.stop(mockedDB.actorRef)
   }
 
@@ -109,7 +109,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     val mockedDB = mockDbRollCallAlreadyCreated
     val rc = new RollCallHandler(mockedDB)
     val request = CreateRollCallMessages.createRollCall
-    rc.handleCreateRollCall(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleCreateRollCall(request) shouldBe an[Left[PipelineError, _]]
     system.stop(mockedDB.actorRef)
   }
 
@@ -117,7 +117,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     val mockedDB = mockDbRollCallNotCreated
     val rc = new RollCallHandler(mockedDB)
     val request = OpenRollCallMessages.openRollCall
-    rc.handleOpenRollCall(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleOpenRollCall(request) shouldBe an[Left[PipelineError, _]]
     system.stop(mockedDB.actorRef)
   }
 
@@ -125,7 +125,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     val mockedDB = mockDbRollCallAlreadyCreated
     val rc = new RollCallHandler(mockedDB)
     val request = OpenRollCallMessages.openRollCall
-    rc.handleOpenRollCall(request) should matchPattern { case Left(_) => }
+    rc.handleOpenRollCall(request) should matchPattern { case Right(_) => }
     system.stop(mockedDB.actorRef)
   }
 
@@ -133,7 +133,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     val mockedDB = mockDbWithNack
     val rc = new RollCallHandler(mockedDB)
     val request = OpenRollCallMessages.openRollCall
-    rc.handleOpenRollCall(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleOpenRollCall(request) shouldBe an[Left[PipelineError, _]]
     system.stop(mockedDB.actorRef)
   }
 
@@ -141,7 +141,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     val mockedDB = mockDbRollCallAlreadyCreated
     val rc = new RollCallHandler(mockedDB)
     val request = ReopenRollCallMessages.reopenRollCall
-    rc.handleReopenRollCall(request) should matchPattern { case Left(_) => }
+    rc.handleReopenRollCall(request) should matchPattern { case Right(_) => }
     system.stop(mockedDB.actorRef)
   }
 
@@ -149,7 +149,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     val mockedDB = mockDbWithNack
     val rc = new RollCallHandler(mockedDB)
     val request = ReopenRollCallMessages.reopenRollCall
-    rc.handleReopenRollCall(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleReopenRollCall(request) shouldBe an[Left[PipelineError, _]]
     system.stop(mockedDB.actorRef)
   }
 
@@ -157,7 +157,7 @@ class RollCallHandlerTest extends TestKit(ActorSystem("RollCall-DB-System")) wit
     val mockedDB = mockDbWithNack
     val rc = new RollCallHandler(mockedDB)
     val request = CloseRollCallMessages.closeRollCall
-    rc.handleCloseRollCall(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleCloseRollCall(request) shouldBe an[Left[PipelineError, _]]
     system.stop(mockedDB.actorRef)
   }
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandlerSuite.scala
@@ -133,7 +133,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
     val rc = new SocialMediaHandler(mockedDB)
     val request = AddReactionMessages.addReaction
 
-    rc.handleAddReaction(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleAddReaction(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -143,7 +143,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
     val rc = new SocialMediaHandler(mockedDB)
     val request = AddReactionMessages.addReaction
 
-    rc.handleAddReaction(request) should equal(Left(request))
+    rc.handleAddReaction(request) should equal(Right(request))
 
     system.stop(mockedDB.actorRef)
   }
@@ -153,7 +153,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
     val rc = new SocialMediaHandler(mockedDB)
     val request = DeleteReactionMessages.deleteReaction
 
-    rc.handleDeleteReaction(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleDeleteReaction(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -163,7 +163,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
     val rc = new SocialMediaHandler(mockedDB)
     val request = DeleteReactionMessages.deleteReaction
 
-    rc.handleDeleteReaction(request) should equal(Left(request))
+    rc.handleDeleteReaction(request) should equal(Right(request))
 
     system.stop(mockedDB.actorRef)
   }
@@ -173,7 +173,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
     val rc = new SocialMediaHandler(mockedDB)
     val request = AddChirpMessages.addChirp
 
-    rc.handleAddChirp(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleAddChirp(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -183,7 +183,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
     val rc = new SocialMediaHandler(mockedDB)
     val request = AddChirpMessages.addChirp
 
-    rc.handleAddChirp(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleAddChirp(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -193,7 +193,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
     val rc = new SocialMediaHandler(mockedDB)
     val request = AddChirpMessages.addChirp
 
-    rc.handleAddChirp(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleAddChirp(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -203,7 +203,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
     val rc = new SocialMediaHandler(mockedDB)
     val request = AddChirpMessages.addChirp
 
-    rc.handleAddChirp(request) should equal(Left(request))
+    rc.handleAddChirp(request) should equal(Right(request))
 
     system.stop(mockedDB.actorRef)
   }
@@ -213,7 +213,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
     val rc = new SocialMediaHandler(mockedDB)
     val request = AddChirpMessages.addChirp
 
-    rc.handleAddChirp(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleAddChirp(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -223,7 +223,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
     val rc = new SocialMediaHandler(mockedDB)
     val request = DeleteChirpMessages.deleteChirp
 
-    rc.handleDeleteChirp(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleDeleteChirp(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -233,7 +233,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
     val rc = new SocialMediaHandler(mockedDB)
     val request = DeleteChirpMessages.deleteChirp
 
-    rc.handleDeleteChirp(request) should equal(Left(request))
+    rc.handleDeleteChirp(request) should equal(Right(request))
 
     system.stop(mockedDB.actorRef)
   }
@@ -243,7 +243,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
     val rc = new SocialMediaHandler(mockedDB)
     val request = DeleteChirpMessages.deleteChirp
 
-    rc.handleDeleteChirp(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleDeleteChirp(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -253,7 +253,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
     val rc = new SocialMediaHandler(mockedDB)
     val request = DeleteChirpMessages.deleteChirp
 
-    rc.handleDeleteChirp(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleDeleteChirp(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -263,7 +263,7 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
     val rc = new SocialMediaHandler(mockedDB)
     val request = DeleteChirpMessages.deleteChirp
 
-    rc.handleDeleteChirp(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleDeleteChirp(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandlerTest.scala
@@ -98,7 +98,7 @@ class WitnessHandlerTest extends TestKit(ActorSystem("Witness-DB-System")) with 
     val rc = new WitnessHandler(mockedDB)
     val request = WitnessMessages.witnessMessage
 
-    rc.handleWitnessMessage(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleWitnessMessage(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }
@@ -108,7 +108,7 @@ class WitnessHandlerTest extends TestKit(ActorSystem("Witness-DB-System")) with 
     val rc = new WitnessHandler(mockedDB)
     val request = WitnessMessages.witnessMessage
 
-    rc.handleWitnessMessage(request) should equal(Left(request))
+    rc.handleWitnessMessage(request) should equal(Right(request))
 
     system.stop(mockedDB.actorRef)
   }
@@ -118,7 +118,7 @@ class WitnessHandlerTest extends TestKit(ActorSystem("Witness-DB-System")) with 
     val rc = new WitnessHandler(mockedDB)
     val request = WitnessMessages.witnessMessage
 
-    rc.handleWitnessMessage(request) shouldBe an[Right[PipelineError, _]]
+    rc.handleWitnessMessage(request) shouldBe an[Left[PipelineError, _]]
 
     system.stop(mockedDB.actorRef)
   }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/CoinValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/CoinValidatorSuite.scala
@@ -40,42 +40,42 @@ class CoinValidatorSuite extends TestKit(ActorSystem("coinValidatorTestActorSyst
 
   test("Posting a transaction works as intended") {
     val message: GraphMessage = CoinValidator.validatePostTransaction(postTransaction)
-    message should equal(Left(postTransaction))
+    message should equal(Right(postTransaction))
   }
 
   test("Posting a coinbase transaction works as intended") {
     val postTransaction = postTransactionCoinbase
     val message: GraphMessage = CoinValidator.validatePostTransaction(postTransaction)
-    message should equal(Left(postTransaction))
+    message should equal(Right(postTransaction))
   }
 
   test("Posting a large transaction works as intended") {
     val postTransaction = postTransactionMaxAmount
     val message: GraphMessage = CoinValidator.validatePostTransaction(postTransaction)
-    message should equal(Left(postTransaction))
+    message should equal(Right(postTransaction))
   }
 
   test("Posting a transaction with a zero amount succeeds") {
     val postTransaction = postTransactionZeroAmount
     val message: GraphMessage = CoinValidator.validatePostTransaction(postTransaction)
-    message should equal(Left(postTransaction))
+    message should equal(Right(postTransaction))
   }
 
   test("Posting a transaction with an incorrect ID does not work") {
     val postTransaction = postTransactionWrongTransactionId
     val message: GraphMessage = CoinValidator.validatePostTransaction(postTransaction)
-    message shouldEqual Right(PipelineError(-4, "PostTransaction content validation failed: incorrect transaction id", Some(1)))
+    message shouldEqual Left(PipelineError(-4, "PostTransaction content validation failed: incorrect transaction id", Some(1)))
   }
 
   test("Posting a transaction with an incorrect signature does not work") {
     val postTransaction = postTransactionBadSignature
     val message: GraphMessage = CoinValidator.validatePostTransaction(postTransaction)
-    message shouldEqual Right(PipelineError(-4, "PostTransaction content validation failed: bad signature", Some(1)))
+    message shouldEqual Left(PipelineError(-4, "PostTransaction content validation failed: bad signature", Some(1)))
   }
 
   test("Posting a transaction with an arithmetic overflow does not work") {
     val postTransaction = postTransactionOverflowSum
     val message: GraphMessage = CoinValidator.validatePostTransaction(postTransaction)
-    message shouldEqual Right(PipelineError(-4, "PostTransaction content validation failed: uint53 addition overflow", Some(1)))
+    message shouldEqual Left(PipelineError(-4, "PostTransaction content validation failed: uint53 addition overflow", Some(1)))
   }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/ElectionValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/ElectionValidatorSuite.scala
@@ -51,12 +51,12 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
   private final val PUBLIC_KEY: PublicKey = PublicKey(Base64Data("jsNj23IHALvppqV1xQfP71_3IyAHzivxiCz236_zzQc="))
   private final val PRIVATE_KEY: PrivateKey = PrivateKey(Base64Data("qRfms3wzSLkxAeBz6UtwA-L1qP0h8D9XI1FSvY68t7Y="))
   private final val PK_WRONG: PublicKey = PublicKey(Base64Data.encode("wrongOwner"))
-  private final val laoDataRight: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
+  private final val laoDataLeft: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
   private final val laoDataWrong: LaoData = LaoData(PK_WRONG, List(PK_WRONG), PRIVATE_KEY, PUBLIC_KEY, List.empty)
-  private final val channelDataRightSetup: ChannelData = ChannelData(ObjectType.LAO, List.empty)
+  private final val channelDataLeftSetup: ChannelData = ChannelData(ObjectType.LAO, List.empty)
   private final val channelDataWrongSetup: ChannelData = ChannelData(ObjectType.ELECTION, List.empty)
 
-  private final val channelDataRightElection: ChannelData = ChannelData(ObjectType.ELECTION, List.empty)
+  private final val channelDataLeftElection: ChannelData = ChannelData(ObjectType.ELECTION, List.empty)
   private final val channelDataWrongElection: ChannelData = ChannelData(ObjectType.LAO, List.empty)
 
   private final val channelDataWithSetupAndOpenAndCastMessage: ChannelData = ChannelData(ObjectType.ELECTION, List(DATA_CAST_VOTE_MESSAGE, DATA_SET_UP_OPEN_BALLOT, DATA_OPEN_MESSAGE))
@@ -73,9 +73,9 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRightSetup)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeftSetup)
       }
     })
     system.actorOf(dbActorMock)
@@ -87,7 +87,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
         case DbActor.ReadLaoData(_) =>
           sender() ! DbActor.DbActorReadLaoDataAck(laoDataWrong)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRightSetup)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeftSetup)
       }
     })
     system.actorOf(dbActorMock)
@@ -97,7 +97,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWrongSetup)
       }
@@ -109,9 +109,9 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRightElection)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeftElection)
         case DbActor.Catchup(_) =>
           sender() ! DbActor.DbActorCatchupAck(messages)
       }
@@ -125,7 +125,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
         case DbActor.ReadLaoData(_) =>
           sender() ! DbActor.DbActorReadLaoDataAck(laoDataWrong)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRightElection)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeftElection)
       }
     })
     system.actorOf(dbActorMock)
@@ -135,7 +135,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWrongElection)
       }
@@ -147,7 +147,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWithSetupAndOpenAndCastMessage)
         case DbActor.ReadElectionData(_) =>
@@ -191,7 +191,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWrongChannelCastVote)
         case DbActor.ReadElectionData(_) =>
@@ -213,7 +213,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWithSetupAndCastMessage)
         case DbActor.ReadElectionData(_) =>
@@ -235,7 +235,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWithEndElectionMessage)
         case DbActor.ReadElectionData(_) =>
@@ -260,7 +260,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWorkingSetup
     println(dbActorRef)
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateSetupElection(SETUP_ELECTION_RPC)
-    message should equal(Left(SETUP_ELECTION_RPC))
+    message should equal(Right(SETUP_ELECTION_RPC))
     system.stop(dbActorRef.actorRef)
   }
 
@@ -268,8 +268,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateSetupElection(SETUP_ELECTION_WRONG_TIMESTAMP_RPC)
     val messageStandardActor = ElectionValidator.validateSetupElection(SETUP_ELECTION_WRONG_TIMESTAMP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -277,8 +277,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateSetupElection(SETUP_ELECTION_WRONG_TIMESTAMP_ORDER_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateSetupElection(SETUP_ELECTION_WRONG_TIMESTAMP_ORDER_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -286,8 +286,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateSetupElection(SETUP_ELECTION_WRONG_TIMESTAMP_ORDER_RPC2)
     val messageStandardActor: GraphMessage = ElectionValidator.validateSetupElection(SETUP_ELECTION_WRONG_TIMESTAMP_ORDER_RPC2)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -295,8 +295,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWrongTokenSetup
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateSetupElection(SETUP_ELECTION_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateSetupElection(SETUP_ELECTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -304,8 +304,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWrongChannelSetup
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateSetupElection(SETUP_ELECTION_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateSetupElection(SETUP_ELECTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -313,15 +313,15 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateSetupElection(SETUP_ELECTION_WRONG_ID_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateSetupElection(SETUP_ELECTION_WRONG_ID_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Setting up an election with invalid question id fails") {
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateSetupElection(SETUP_ELECTION_WRONG_QUESTION_ID_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -329,8 +329,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateSetupElection(SETUP_ELECTION_WRONG_OWNER_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateSetupElection(SETUP_ELECTION_WRONG_OWNER_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -338,8 +338,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateSetupElection(RPC_NO_PARAMS)
     val messageStandardActor: GraphMessage = ElectionValidator.validateSetupElection(RPC_NO_PARAMS)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -347,42 +347,42 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
   test("KeyElection works as intended") {
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateKeyElection(KEY_ELECTION_RPC)
-    message should equal(Left(KEY_ELECTION_RPC))
+    message should equal(Right(KEY_ELECTION_RPC))
     system.stop(dbActorRef.actorRef)
   }
 
   test("KeyElection fails with invalid election id") {
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateKeyElection(KEY_ELECTION_WRONG_ID_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("KeyElection fails with wrong sender") {
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateKeyElection(KEY_ELECTION_WRONG_OWNER_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("KeyElection fails with invalid PoP token") {
     val dbActorRef = mockDbWrongTokenSetup
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateKeyElection(KEY_ELECTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("KeyElection fails with wrong channel") {
     val dbActorRef = mockDbWrongChannel
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateKeyElection(KEY_ELECTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("KeyElection without Params does not work in validateKeyElection") {
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateKeyElection(RPC_NO_PARAMS)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -390,7 +390,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
   test("Open up an election works as intended") {
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateOpenElection(OPEN_ELECTION_RPC)
-    message should equal(Left(OPEN_ELECTION_RPC))
+    message should equal(Right(OPEN_ELECTION_RPC))
     system.stop(dbActorRef.actorRef)
   }
 
@@ -398,7 +398,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateOpenElection(OPEN_ELECTION_WRONG_TIMESTAMP_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateOpenElection(OPEN_ELECTION_WRONG_TIMESTAMP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -406,8 +406,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWrongToken
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateOpenElection(OPEN_ELECTION_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateOpenElection(OPEN_ELECTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -415,8 +415,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWrongChannel
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateOpenElection(OPEN_ELECTION_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateOpenElection(OPEN_ELECTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -424,8 +424,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateOpenElection(OPEN_ELECTION_WRONG_ID_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateOpenElection(OPEN_ELECTION_WRONG_ID_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -433,8 +433,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateOpenElection(OPEN_ELECTION_WRONG_LAO_ID_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateOpenElection(OPEN_ELECTION_WRONG_LAO_ID_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -442,8 +442,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateOpenElection(OPEN_ELECTION_WRONG_OWNER_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateOpenElection(OPEN_ELECTION_WRONG_OWNER_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -451,8 +451,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateOpenElection(RPC_NO_PARAMS)
     val messageStandardActor: GraphMessage = ElectionValidator.validateOpenElection(RPC_NO_PARAMS)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -460,91 +460,91 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
   test("Casting a vote works as intended") {
     val dbActorRef = mockDbCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateCastVoteElection(CAST_VOTE_ELECTION_RPC)
-    message should equal(Left(CAST_VOTE_ELECTION_RPC))
+    message should equal(Right(CAST_VOTE_ELECTION_RPC))
     system.stop(dbActorRef.actorRef)
   }
 
   test("Casting a vote with invalid Timestamp fails") {
     val dbActorRef = mockDbCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateCastVoteElection(CAST_VOTE_ELECTION_WRONG_TIMESTAMP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Casting a vote without valid PoP token fails") {
     val dbActorRef = mockDbWrongTokenCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateCastVoteElection(CAST_VOTE_ELECTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Casting a vote on wrong type of channel fails") {
     val dbActorRef = mockDbWrongChannelCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateCastVoteElection(CAST_VOTE_ELECTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Casting a vote with invalid id fails") {
     val dbActorRef = mockDbCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateCastVoteElection(CAST_VOTE_ELECTION_WRONG_ID_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Casting a vote with invalid lao id fails") {
     val dbActorRef = mockDbCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateCastVoteElection(CAST_VOTE_ELECTION_WRONG_LAO_ID_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Casting a vote with wrong sender fails") {
     val dbActorRef = mockDbCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateCastVoteElection(CAST_VOTE_ELECTION_WRONG_OWNER_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Casting a vote without Params does not work in validateCastVoteElection") {
     val dbActorRef = mockDbCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateCastVoteElection(RPC_NO_PARAMS)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Casting an invalid vote should fail") {
     val dbActorRef = mockDbCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateCastVoteElection(CAST_VOTE_ELECTION_INVALID_VOTE_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Casting an invalid ballot should fail") {
     val dbActorRef = mockDbCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateCastVoteElection(CAST_VOTE_ELECTION_INVALID_BALLOT_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Casting an invalid vote id should fail") {
     val dbActorRef = mockDbCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateCastVoteElection(CAST_VOTE_ELECTION_INVALID_VOTE_ID_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Casting a vote if election is not open should fail") {
     val dbActorRef = mockDbMissingOpenElectionMessage
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateCastVoteElection(CAST_VOTE_ELECTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Casting a vote in an election that was ended should fail") {
     val dbActorRef = mockDbWithEndElectionMessage
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateCastVoteElection(CAST_VOTE_ELECTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -553,7 +553,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateEndElection(END_ELECTION_RPC)
     system.log.info("Responding with a Ack")
-    message should equal(Left(END_ELECTION_RPC))
+    message should equal(Right(END_ELECTION_RPC))
     system.stop(dbActorRef.actorRef)
   }
 
@@ -561,8 +561,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateEndElection(END_ELECTION_WRONG_TIMESTAMP_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateEndElection(END_ELECTION_WRONG_TIMESTAMP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -570,8 +570,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWrongTokenCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateEndElection(END_ELECTION_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateEndElection(END_ELECTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -579,8 +579,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWrongChannelCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateEndElection(END_ELECTION_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateEndElection(END_ELECTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -588,8 +588,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateEndElection(END_ELECTION_WRONG_ID_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateEndElection(END_ELECTION_WRONG_ID_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -597,8 +597,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateEndElection(END_ELECTION_WRONG_LAO_ID_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateEndElection(END_ELECTION_WRONG_LAO_ID_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -606,8 +606,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbCastVote
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateEndElection(END_ELECTION_WRONG_OWNER_RPC)
     val messageStandardActor: GraphMessage = ElectionValidator.validateEndElection(END_ELECTION_WRONG_OWNER_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -615,8 +615,8 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new ElectionValidator(dbActorRef).validateEndElection(RPC_NO_PARAMS)
     val messageStandardActor: GraphMessage = ElectionValidator.validateEndElection(RPC_NO_PARAMS)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/ElectionValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/ElectionValidatorSuite.scala
@@ -51,12 +51,12 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
   private final val PUBLIC_KEY: PublicKey = PublicKey(Base64Data("jsNj23IHALvppqV1xQfP71_3IyAHzivxiCz236_zzQc="))
   private final val PRIVATE_KEY: PrivateKey = PrivateKey(Base64Data("qRfms3wzSLkxAeBz6UtwA-L1qP0h8D9XI1FSvY68t7Y="))
   private final val PK_WRONG: PublicKey = PublicKey(Base64Data.encode("wrongOwner"))
-  private final val laoDataLeft: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
+  private final val laoDataRight: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
   private final val laoDataWrong: LaoData = LaoData(PK_WRONG, List(PK_WRONG), PRIVATE_KEY, PUBLIC_KEY, List.empty)
-  private final val channelDataLeftSetup: ChannelData = ChannelData(ObjectType.LAO, List.empty)
+  private final val channelDataRightSetup: ChannelData = ChannelData(ObjectType.LAO, List.empty)
   private final val channelDataWrongSetup: ChannelData = ChannelData(ObjectType.ELECTION, List.empty)
 
-  private final val channelDataLeftElection: ChannelData = ChannelData(ObjectType.ELECTION, List.empty)
+  private final val channelDataRightElection: ChannelData = ChannelData(ObjectType.ELECTION, List.empty)
   private final val channelDataWrongElection: ChannelData = ChannelData(ObjectType.LAO, List.empty)
 
   private final val channelDataWithSetupAndOpenAndCastMessage: ChannelData = ChannelData(ObjectType.ELECTION, List(DATA_CAST_VOTE_MESSAGE, DATA_SET_UP_OPEN_BALLOT, DATA_OPEN_MESSAGE))
@@ -73,9 +73,9 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeftSetup)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRightSetup)
       }
     })
     system.actorOf(dbActorMock)
@@ -87,7 +87,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
         case DbActor.ReadLaoData(_) =>
           sender() ! DbActor.DbActorReadLaoDataAck(laoDataWrong)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeftSetup)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRightSetup)
       }
     })
     system.actorOf(dbActorMock)
@@ -97,7 +97,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWrongSetup)
       }
@@ -109,9 +109,9 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeftElection)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRightElection)
         case DbActor.Catchup(_) =>
           sender() ! DbActor.DbActorCatchupAck(messages)
       }
@@ -125,7 +125,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
         case DbActor.ReadLaoData(_) =>
           sender() ! DbActor.DbActorReadLaoDataAck(laoDataWrong)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeftElection)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRightElection)
       }
     })
     system.actorOf(dbActorMock)
@@ -135,7 +135,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWrongElection)
       }
@@ -147,7 +147,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWithSetupAndOpenAndCastMessage)
         case DbActor.ReadElectionData(_) =>
@@ -191,7 +191,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWrongChannelCastVote)
         case DbActor.ReadElectionData(_) =>
@@ -213,7 +213,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWithSetupAndCastMessage)
         case DbActor.ReadElectionData(_) =>
@@ -235,7 +235,7 @@ class ElectionValidatorSuite extends TestKit(ActorSystem("electionValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWithEndElectionMessage)
         case DbActor.ReadElectionData(_) =>

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/Lao/CreateLaoContentSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/Lao/CreateLaoContentSuite.scala
@@ -15,15 +15,15 @@ class CreateLaoContentSuite extends FlatSpec with Matchers with Inside with Give
   /** Decodes data before passing it to the test * */
   def withCreateLaoFixture(createLaoData: Message)(testCode: GraphMessage => Any): Unit = {
     // Raw encoded data data
-    val message = Left(CreateLaoExamples.getJsonRequestFromMessage(createLaoData))
+    val message = Right(CreateLaoExamples.getJsonRequestFromMessage(createLaoData))
     // Decode data
     val decoded = MessageDecoder.parseData(message, MessageRegistry.apply())
     decoded match {
-      case Left(r: JsonRpcRequest) =>
+      case Right(r: JsonRpcRequest) =>
         r.getDecodedDataHeader should equal((ObjectType.LAO, ActionType.CREATE))
         testCode(decoded)
-      case Left(m) => fail(f"Decoder decoded to bad type: <$m> expected type is JsonRpcRequestCreateLao")
-      case Right(_) =>
+      case Right(m) => fail(f"Decoder decoded to bad type: <$m> expected type is JsonRpcRequestCreateLao")
+      case Left(_) =>
         fail("Message could not be decoded/parsed")
     }
   }
@@ -34,14 +34,14 @@ class CreateLaoContentSuite extends FlatSpec with Matchers with Inside with Give
     (message) => {
       When("validated")
       inside(message) {
-        case Left(rpcRequest: JsonRpcRequest) =>
+        case Right(rpcRequest: JsonRpcRequest) =>
           val registry: MessageRegistry = MessageRegistry.apply()
           val validationResult = Validator.validateMessageDataContent(rpcRequest, registry)
           inside(validationResult) {
-            case Left(msg) =>
+            case Right(msg) =>
               Then("the validation succeeds")
               msg shouldBe a[JsonRpcRequest]
-            case _ @Right(_) => fail("fails to validate CreateLao data content")
+            case _ @Left(_) => fail("fails to validate CreateLao data content")
             case _           => fail(s"validated message <$validationResult> is of unexpected type")
           }
           And("the message has the same content after validation")

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/Lao/CreateLaoContentSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/Lao/CreateLaoContentSuite.scala
@@ -42,7 +42,7 @@ class CreateLaoContentSuite extends FlatSpec with Matchers with Inside with Give
               Then("the validation succeeds")
               msg shouldBe a[JsonRpcRequest]
             case _ @Left(_) => fail("fails to validate CreateLao data content")
-            case _           => fail(s"validated message <$validationResult> is of unexpected type")
+            case _          => fail(s"validated message <$validationResult> is of unexpected type")
           }
           And("the message has the same content after validation")
           validationResult should equal(message)

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/Lao/CreateLaoDecoderSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/Lao/CreateLaoDecoderSuite.scala
@@ -63,7 +63,7 @@ class CreateLaoDecoderSuite extends FlatSpec with Matchers with Inside with Give
           laoData.id shouldNot be(null)
           noException shouldBe thrownBy(laoData.id.base64Data.decodeToString())
         case Left(_) => fail(s"The message data format should succeed with a Right[JsonRpcRequestCreateLao] but was <$parsed>")
-        case _        => fail(s"The message data format format yielded an unexpected result <$parsed>")
+        case _       => fail(s"The message data format format yielded an unexpected result <$parsed>")
       }
     }
 
@@ -81,7 +81,7 @@ class CreateLaoDecoderSuite extends FlatSpec with Matchers with Inside with Give
           And("report a correct error code")
           e.code should equal(ErrorCodes.INVALID_DATA.id)
         case Right(_) => fail(s"parsed message should fail with Left[PipelineError] but was a Right: <$parsed>")
-        case _       => fail(s"parsed message <$parsed> resulted with an unexpected type")
+        case _        => fail(s"parsed message <$parsed> resulted with an unexpected type")
       }
     }
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/Lao/CreateLaoDecoderSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/Lao/CreateLaoDecoderSuite.scala
@@ -15,7 +15,7 @@ class CreateLaoDecoderSuite extends FlatSpec with Matchers with Inside with Give
 
   def withCreateLaoFixiture(msg: Message)(testCode: (GraphMessage, Message) => Any): Unit = {
     val jsonReq = CreateLaoExamples.getJsonRequestFromMessage(msg)
-    testCode(Left(jsonReq), msg)
+    testCode(Right(jsonReq), msg)
   }
 
   def testGoodFormat: (GraphMessage, Message) => Assertion =
@@ -29,7 +29,7 @@ class CreateLaoDecoderSuite extends FlatSpec with Matchers with Inside with Give
 
       Then("it should be of type JsonRpcRequest")
       inside(parsed) {
-        case Left(createJsonRpc: JsonRpcRequest) =>
+        case Right(createJsonRpc: JsonRpcRequest) =>
           And("it should be of type create lao")
           createJsonRpc.getDecodedDataHeader should equal((ObjectType.LAO, ActionType.CREATE))
 
@@ -62,7 +62,7 @@ class CreateLaoDecoderSuite extends FlatSpec with Matchers with Inside with Give
           And("the id is not null")
           laoData.id shouldNot be(null)
           noException shouldBe thrownBy(laoData.id.base64Data.decodeToString())
-        case Right(_) => fail(s"The message data format should succeed with a Left[JsonRpcRequestCreateLao] but was <$parsed>")
+        case Left(_) => fail(s"The message data format should succeed with a Right[JsonRpcRequestCreateLao] but was <$parsed>")
         case _        => fail(s"The message data format format yielded an unexpected result <$parsed>")
       }
     }
@@ -74,13 +74,13 @@ class CreateLaoDecoderSuite extends FlatSpec with Matchers with Inside with Give
       When("the request is parsed")
       val parsed = MessageDecoder.parseData(gm, MessageRegistry.apply())
 
-      Then("it should fail with the correct type Right[PipelineError]")
+      Then("it should fail with the correct type Left[PipelineError]")
       inside(parsed) {
-        case Right(e) =>
+        case Left(e) =>
           e shouldBe a[PipelineError]
           And("report a correct error code")
           e.code should equal(ErrorCodes.INVALID_DATA.id)
-        case Left(_) => fail(s"parsed message should fail with Right[PipelineError] but was a Left: <$parsed>")
+        case Right(_) => fail(s"parsed message should fail with Left[PipelineError] but was a Right: <$parsed>")
         case _       => fail(s"parsed message <$parsed> resulted with an unexpected type")
       }
     }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/LaoValidatorSuite.scala
@@ -44,77 +44,77 @@ class LaoValidatorSuite extends TestKit(ActorSystem("laoValidatorTestActorSystem
 
   test("LAO creation works as intended") {
     val message: GraphMessage = LaoValidator.validateCreateLao(CREATE_LAO_RPC)
-    message should equal(Left(CREATE_LAO_RPC))
+    message should equal(Right(CREATE_LAO_RPC))
   }
 
   test("LAO creation fails with wrong channel") {
     val message: GraphMessage = LaoValidator.validateCreateLao(CREATE_LAO_WRONG_CHANNEL_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
   }
 
   test("LAO creation fails with stale Timestamp") {
     val message: GraphMessage = LaoValidator.validateCreateLao(CREATE_LAO_WRONG_TIMESTAMP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
   }
 
   test("LAO creation fails with duplicate witnesses") {
     val message: GraphMessage = LaoValidator.validateCreateLao(CREATE_LAO_WRONG_WITNESSES_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
   }
 
   test("LAO creation fails with wrong id") {
     val message: GraphMessage = LaoValidator.validateCreateLao(CREATE_LAO_WRONG_ID_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
   }
 
   test("LAO creation fails with wrong sender") {
     val message: GraphMessage = LaoValidator.validateCreateLao(CREATE_LAO_WRONG_SENDER_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
   }
 
   test("LAO creation fails with empty name") {
     val message: GraphMessage = LaoValidator.validateCreateLao(CREATE_LAO_EMPTY_NAME_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
   }
 
   test("LAO creation fails without ParamsWithMessage") {
     val message: GraphMessage = LaoValidator.validateCreateLao(RPC_NO_PARAMS)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
   }
 
   // GreetLao tests
   test("LAO greeting works as intended") {
     val message: GraphMessage = LaoValidator.validateGreetLao(GREET_LAO_RPC)
-    message should equal(Left(GREET_LAO_RPC))
+    message should equal(Right(GREET_LAO_RPC))
   }
 
   test("LAO greeting fails with wrong lao id") {
     val message: GraphMessage = LaoValidator.validateGreetLao(GREET_LAO_WRONG_LAO_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
   }
 
   test("LAO greeting fails with wrong frontend") {
     val message: GraphMessage = LaoValidator.validateGreetLao(GREET_LAO_WRONG_FRONTEND_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
   }
 
   test("LAO greeting fails with wrong address") {
     val message: GraphMessage = LaoValidator.validateGreetLao(GREET_LAO_WRONG_ADDRESS_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
   }
 
   test("LAO greeting fails with wrong sender") {
     val message: GraphMessage = LaoValidator.validateGreetLao(GREET_LAO_WRONG_SENDER_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
   }
 
   test("LAO greeting fails with wrong channel") {
     val message: GraphMessage = LaoValidator.validateGreetLao(GREET_LAO_WRONG_CHANNEL_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
   }
 
   test("LAO greeting fails without ParamsWithMessage") {
     val message: GraphMessage = LaoValidator.validateCreateLao(RPC_NO_PARAMS)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
   }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/MeetingValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/MeetingValidatorSuite.scala
@@ -51,21 +51,21 @@ class MeetingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
   private final val PUBLIC_KEY: PublicKey = PublicKey(Base64Data("jsNj23IHALvppqV1xQfP71_3IyAHzivxiCz236_zzQc="))
   private final val PRIVATE_KEY: PrivateKey = PrivateKey(Base64Data("qRfms3wzSLkxAeBz6UtwA-L1qP0h8D9XI1FSvY68t7Y="))
   private final val PK_OWNER: PublicKey = PublicKey(Base64Data.encode("wrongOwner"))
-  private final val laoDataLeft: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
+  private final val laoDataRight: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
   private final val laoDataWrong: LaoData = LaoData(PK_OWNER, List(PK_OWNER), PRIVATE_KEY, PUBLIC_KEY, List.empty)
-  private final val channelDataLeftSetup: ChannelData = ChannelData(ObjectType.LAO, List.empty)
+  private final val channelDataRightSetup: ChannelData = ChannelData(ObjectType.LAO, List.empty)
   private final val channelDataWrongSetup: ChannelData = ChannelData(ObjectType.ELECTION, List.empty)
 
-  private final val channelDataLeftElection: ChannelData = ChannelData(ObjectType.ELECTION, List.empty)
+  private final val channelDataRightElection: ChannelData = ChannelData(ObjectType.ELECTION, List.empty)
   private final val channelDataWrongElection: ChannelData = ChannelData(ObjectType.LAO, List.empty)
 
   private def mockDbWorkingSetup: AskableActorRef = {
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeftSetup)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRightSetup)
       }
     })
     system.actorOf(dbActorMock)
@@ -75,7 +75,7 @@ class MeetingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWrongSetup)
       }
@@ -89,7 +89,7 @@ class MeetingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
         case DbActor.ReadLaoData(_) =>
           sender() ! DbActor.DbActorReadLaoDataAck(laoDataWrong)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeftSetup)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRightSetup)
       }
     })
     system.actorOf(dbActorMock)

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/MeetingValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/MeetingValidatorSuite.scala
@@ -51,21 +51,21 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
   private final val PUBLIC_KEY: PublicKey = PublicKey(Base64Data("jsNj23IHALvppqV1xQfP71_3IyAHzivxiCz236_zzQc="))
   private final val PRIVATE_KEY: PrivateKey = PrivateKey(Base64Data("qRfms3wzSLkxAeBz6UtwA-L1qP0h8D9XI1FSvY68t7Y="))
   private final val PK_OWNER: PublicKey = PublicKey(Base64Data.encode("wrongOwner"))
-  private final val laoDataRight: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
+  private final val laoDataLeft: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
   private final val laoDataWrong: LaoData = LaoData(PK_OWNER, List(PK_OWNER), PRIVATE_KEY, PUBLIC_KEY, List.empty)
-  private final val channelDataRightSetup: ChannelData = ChannelData(ObjectType.LAO, List.empty)
+  private final val channelDataLeftSetup: ChannelData = ChannelData(ObjectType.LAO, List.empty)
   private final val channelDataWrongSetup: ChannelData = ChannelData(ObjectType.ELECTION, List.empty)
 
-  private final val channelDataRightElection: ChannelData = ChannelData(ObjectType.ELECTION, List.empty)
+  private final val channelDataLeftElection: ChannelData = ChannelData(ObjectType.ELECTION, List.empty)
   private final val channelDataWrongElection: ChannelData = ChannelData(ObjectType.LAO, List.empty)
 
   private def mockDbWorkingSetup: AskableActorRef = {
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRightSetup)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeftSetup)
       }
     })
     system.actorOf(dbActorMock)
@@ -75,7 +75,7 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWrongSetup)
       }
@@ -89,7 +89,7 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
         case DbActor.ReadLaoData(_) =>
           sender() ! DbActor.DbActorReadLaoDataAck(laoDataWrong)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRightSetup)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeftSetup)
       }
     })
     system.actorOf(dbActorMock)
@@ -99,7 +99,7 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
   test("Creating a valid meeting works as intended") {
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateCreateMeeting(CREATE_MEETING_RPC)
-    message should equal(Left(CREATE_MEETING_RPC))
+    message should equal(Right(CREATE_MEETING_RPC))
     system.stop(dbActorRef.actorRef)
   }
 
@@ -110,8 +110,8 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     val dbActorRef = mockDbWrongSetupBadChannel
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateCreateMeeting(CREATE_MEETING_WRONG_CHANNEL_RPC)
     val messageStandardActor: GraphMessage = MeetingValidator.validateCreateMeeting(CREATE_MEETING_WRONG_CHANNEL_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -120,8 +120,8 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     val dbActorRef = mockDbInvalidSetupWrongOwner
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateCreateMeeting(CREATE_MEETING_RPC)
     val messageStandardActor: GraphMessage = MeetingValidator.validateCreateMeeting(CREATE_MEETING_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
   // invalid data hash
@@ -129,8 +129,8 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateCreateMeeting(CREATE_MEETING_INVALID_DATA_RPC)
     val messageStandardActor: GraphMessage = MeetingValidator.validateCreateMeeting(CREATE_MEETING_INVALID_DATA_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -139,8 +139,8 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateCreateMeeting(CREATE_MEETING_INVALID_CREATION_RPC)
     val messageStandardActor: GraphMessage = MeetingValidator.validateCreateMeeting(CREATE_MEETING_INVALID_CREATION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -149,8 +149,8 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateCreateMeeting(CREATE_MEETING_INVALID_START_RPC)
     val messageStandardActor: GraphMessage = MeetingValidator.validateCreateMeeting(CREATE_MEETING_INVALID_START_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -159,8 +159,8 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateCreateMeeting(CREATE_MEETING_INVALID_STARTEND_RPC)
     val messageStandardActor: GraphMessage = MeetingValidator.validateCreateMeeting(CREATE_MEETING_INVALID_STARTEND_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -169,8 +169,8 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateCreateMeeting(CREATE_MEETING_INVALID_END_RPC)
     val messageStandardActor: GraphMessage = MeetingValidator.validateCreateMeeting(CREATE_MEETING_INVALID_END_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -178,7 +178,7 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
   test("Creating a valid meeting state works as intended") {
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateStateMeeting(STATE_MEETING_RPC)
-    message should equal(Left(STATE_MEETING_RPC))
+    message should equal(Right(STATE_MEETING_RPC))
     system.stop(dbActorRef.actorRef)
   }
 
@@ -189,8 +189,8 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateStateMeeting(STATE_MEETING_INVALID_DATA_RPC)
     val messageStandardActor: GraphMessage = MeetingValidator.validateStateMeeting(STATE_MEETING_INVALID_DATA_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -199,8 +199,8 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateStateMeeting(STATE_MEETING_INVALID_CREATION_RPC)
     val messageStandardActor: GraphMessage = MeetingValidator.validateStateMeeting(STATE_MEETING_INVALID_CREATION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -209,8 +209,8 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateStateMeeting(STATE_MEETING_INVALID_START_RPC)
     val messageStandardActor: GraphMessage = MeetingValidator.validateStateMeeting(STATE_MEETING_INVALID_START_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -220,8 +220,8 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     println(dbActorRef)
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateStateMeeting(STATE_MEETING_SMALL_END_RPC)
     val messageStandardActor: GraphMessage = MeetingValidator.validateStateMeeting(STATE_MEETING_SMALL_END_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -230,8 +230,8 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateStateMeeting(STATE_MEETING_BIG_START_RPC)
     val messageStandardActor: GraphMessage = MeetingValidator.validateStateMeeting(STATE_MEETING_BIG_START_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -240,8 +240,8 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateStateMeeting(STATE_MEETING_WRONGWITNESS_RPC)
     val messageStandardActor: GraphMessage = MeetingValidator.validateStateMeeting(STATE_MEETING_WRONGWITNESS_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -250,8 +250,8 @@ class MertingValidatorSuite extends TestKit(ActorSystem("meetingValidatorTestAct
     val dbActorRef = mockDbWorkingSetup
     val message: GraphMessage = new MeetingValidator(dbActorRef).validateStateMeeting(STATE_MEETING_SMALLMODIFICATION_RPC)
     val messageStandardActor: GraphMessage = MeetingValidator.validateStateMeeting(STATE_MEETING_SMALLMODIFICATION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
-    messageStandardActor shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
+    messageStandardActor shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/MessageValidatorSuite.scala
@@ -132,19 +132,19 @@ class MessageValidatorSuite extends TestKit(ActorSystem("messageValidatorTestAct
   }
 
   test("validateMessage accepts valid Message example") {
-    MessageValidator.validateMessage(VALID_RPC) should be(Left(VALID_RPC))
+    MessageValidator.validateMessage(VALID_RPC) should be(Right(VALID_RPC))
   }
 
   test("validateMessage rejects request with invalid id") {
-    MessageValidator.validateMessage(INVALID_ID_RPC) shouldBe a[Right[_, PipelineError]]
+    MessageValidator.validateMessage(INVALID_ID_RPC) shouldBe a[Left[_, PipelineError]]
   }
 
   test("validateMessage rejects request with invalid WS pair") {
-    MessageValidator.validateMessage(INVALID_WS_PAIR_RPC) shouldBe a[Right[_, PipelineError]]
+    MessageValidator.validateMessage(INVALID_WS_PAIR_RPC) shouldBe a[Left[_, PipelineError]]
   }
 
   test("validateMessage rejects request with invalid signature") {
-    MessageValidator.validateMessage(INVALID_SIGNATURE_RPC) shouldBe a[Right[_, PipelineError]]
+    MessageValidator.validateMessage(INVALID_SIGNATURE_RPC) shouldBe a[Left[_, PipelineError]]
   }
 
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidatorSuite.scala
@@ -51,10 +51,10 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
   private final val PUBLIC_KEY: PublicKey = PublicKey(Base64Data("jsNj23IHALvppqV1xQfP71_3IyAHzivxiCz236_zzQc="))
   private final val PRIVATE_KEY: PrivateKey = PrivateKey(Base64Data("qRfms3wzSLkxAeBz6UtwA-L1qP0h8D9XI1FSvY68t7Y="))
   private final val PK_OWNER: PublicKey = PublicKey(Base64Data.encode("wrongOwner"))
-  private final val laoDataRight: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
+  private final val laoDataLeft: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
   private final val laoDataWrong: LaoData = LaoData(sender, List(PK_OWNER), PRIVATE_KEY, PUBLIC_KEY, List.empty)
   private final val channelDataWrong: ChannelData = ChannelData(ObjectType.INVALID, List.empty)
-  private final val channelDataRight: ChannelData = ChannelData(ObjectType.LAO, List.empty)
+  private final val channelDataLeft: ChannelData = ChannelData(ObjectType.LAO, List.empty)
   private final val rollcallDataCreate: RollCallData = RollCallData(CreateRollCallExamples.R_ID, ActionType.CREATE)
   private final val rollcallDataOpen: RollCallData = RollCallData(OpenRollCallExamples.UPDATE_ID, ActionType.OPEN)
   private final val rollcallDataClose: RollCallData = RollCallData(CloseRollCallExamples.UPDATE_ID, ActionType.CLOSE)
@@ -63,7 +63,7 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWrong)
         case DbActor.ReadRollCallData(_) =>
@@ -79,7 +79,7 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
         case DbActor.ReadLaoData(_) =>
           sender() ! DbActor.DbActorReadLaoDataAck(laoDataWrong)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRight)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeft)
         case DbActor.ReadRollCallData(_) =>
           sender() ! DbActor.DbActorReadRollCallDataAck(rollcallDataOpen)
       }
@@ -91,7 +91,7 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWrong)
         case DbActor.ReadRollCallData(_) =>
@@ -105,9 +105,9 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRight)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeft)
         case DbActor.ReadRollCallData(_) =>
           sender() ! DbActor.DbActorReadRollCallDataAck(rollcallDataCreate)
       }
@@ -119,9 +119,9 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRight)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeft)
         case DbActor.ReadRollCallData(_) =>
           sender() ! DbActor.DbActorReadRollCallDataAck(rollcallDataOpen)
       }
@@ -133,9 +133,9 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRight)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeft)
         case DbActor.ReadRollCallData(_) =>
           sender() ! DbActor.DbActorReadRollCallDataAck(rollcallDataClose)
       }
@@ -147,42 +147,42 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
   test("Create Roll Call works as intended") {
     val dbActorRef = mockDbWorkingCreate
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateCreateRollCall(CREATE_ROLL_CALL_RPC)
-    message should equal(Left(CREATE_ROLL_CALL_RPC))
+    message should equal(Right(CREATE_ROLL_CALL_RPC))
     system.stop(dbActorRef.actorRef)
   }
 
   test("Create Roll Call should fail with invalid Timestamp") {
     val dbActorRef = mockDbWorkingCreate
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateCreateRollCall(CREATE_ROLL_CALL_WRONG_TIMESTAMP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Create Roll Call should fail with invalid Timestamp order") {
     val dbActorRef = mockDbWorkingCreate
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateCreateRollCall(CREATE_ROLL_CALL_WRONG_TIMESTAMP_ORDER_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Create Roll Call should fail with invalid id") {
     val dbActorRef = mockDbWorkingCreate
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateCreateRollCall(CREATE_ROLL_CALL_WRONG_ID_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Create Roll Call should fail with wrong sender") {
     val dbActorRef = mockDbWorkingCreate
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateCreateRollCall(CREATE_ROLL_CALL_WRONG_SENDER_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Create Roll Call should fail with wrong type of channel") {
     val dbActorRef = mockDbWrongChannelCreate
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateCreateRollCall(CREATE_ROLL_CALL_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -190,63 +190,63 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
   test("Close Roll Call works as intended") {
     val dbActorRef = mockDbWorkingOpen
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateCloseRollCall(CLOSE_ROLL_CALL_RPC)
-    message should equal(Left(CLOSE_ROLL_CALL_RPC))
+    message should equal(Right(CLOSE_ROLL_CALL_RPC))
     system.stop(dbActorRef.actorRef)
   }
 
   test("Close Roll Call should fail with invalid Timestamp") {
     val dbActorRef = mockDbWorkingOpen
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateCloseRollCall(CLOSE_ROLL_CALL_WRONG_TIMESTAMP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Close Roll Call should fail with invalid update id") {
     val dbActorRef = mockDbWorkingOpen
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateCloseRollCall(CLOSE_ROLL_CALL_WRONG_ID_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Close Roll Call should fail with duplicate attendees") {
     val dbActorRef = mockDbWorkingOpen
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateCloseRollCall(CLOSE_ROLL_CALL_WRONG_DUPLICATE_ATTENDEES_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Close Roll Call should fail with wrong attendees") {
     val dbActorRef = mockDbWrongToken
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateCloseRollCall(CLOSE_ROLL_CALL_WRONG_ATTENDEES_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Close Roll Call should fail with wrong sender") {
     val dbActorRef = mockDbWorkingOpen
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateCloseRollCall(CLOSE_ROLL_CALL_WRONG_SENDER_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Close Roll Call should fail if it is already closed") {
     val dbActorRef = mockDbWorkingOpen
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateCloseRollCall(CLOSE_ROLL_CALL_ALREADY_CLOSED_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Close Roll Call should fail with wrong type of channel") {
     val dbActorRef = mockDbWrongChannelOpen
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateCloseRollCall(CLOSE_ROLL_CALL_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Close Roll Call should fail with wrong closes id") {
     val dbActorRef = mockDbWorkingOpen
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateCloseRollCall(CLOSE_ROLL_CALL_WRONG_CLOSES_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -254,49 +254,49 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
   test("Open Roll Call works as intended") {
     val dbActorRef = mockDbWorkingCreate
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateOpenRollCall(OPEN_ROLL_CALL_RPC)
-    message should equal(Left(OPEN_ROLL_CALL_RPC))
+    message should equal(Right(OPEN_ROLL_CALL_RPC))
     system.stop(dbActorRef.actorRef)
   }
 
   test("Open Roll Call should fail with invalid Timestamp") {
     val dbActorRef = mockDbWorkingCreate
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateOpenRollCall(OPEN_ROLL_CALL_WRONG_TIMESTAMP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Open Roll Call should fail with invalid update id") {
     val dbActorRef = mockDbWorkingCreate
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateOpenRollCall(OPEN_ROLL_CALL_WRONG_ID_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Open Roll Call should fail with wrong sender") {
     val dbActorRef = mockDbWorkingCreate
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateOpenRollCall(OPEN_ROLL_CALL_WRONG_SENDER_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Open Roll Call should fail with wrong type of channel") {
     val dbActorRef = mockDbWrongChannelCreate
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateOpenRollCall(OPEN_ROLL_CALL_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Open Roll Call should fail with wrong opens id") {
     val dbActorRef = mockDbWorkingCreate
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateOpenRollCall(OPEN_ROLL_CALL_WRONG_OPENS_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Open Roll Call should succeed with valid opens id after closing a roll call") {
     val dbActorRef = mockDbWorkingClose
     val message: GraphMessage = new RollCallValidator(dbActorRef).validateOpenRollCall(OPEN_ROLL_CALL_VALID_OPENS_RPC)
-    message should equal(Left(OPEN_ROLL_CALL_VALID_OPENS_RPC))
+    message should equal(Right(OPEN_ROLL_CALL_VALID_OPENS_RPC))
     system.stop(dbActorRef.actorRef)
   }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/RollCallValidatorSuite.scala
@@ -51,10 +51,10 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
   private final val PUBLIC_KEY: PublicKey = PublicKey(Base64Data("jsNj23IHALvppqV1xQfP71_3IyAHzivxiCz236_zzQc="))
   private final val PRIVATE_KEY: PrivateKey = PrivateKey(Base64Data("qRfms3wzSLkxAeBz6UtwA-L1qP0h8D9XI1FSvY68t7Y="))
   private final val PK_OWNER: PublicKey = PublicKey(Base64Data.encode("wrongOwner"))
-  private final val laoDataLeft: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
+  private final val laoDataRight: LaoData = LaoData(sender, List(sender), PRIVATE_KEY, PUBLIC_KEY, List.empty)
   private final val laoDataWrong: LaoData = LaoData(sender, List(PK_OWNER), PRIVATE_KEY, PUBLIC_KEY, List.empty)
   private final val channelDataWrong: ChannelData = ChannelData(ObjectType.INVALID, List.empty)
-  private final val channelDataLeft: ChannelData = ChannelData(ObjectType.LAO, List.empty)
+  private final val channelDataRight: ChannelData = ChannelData(ObjectType.LAO, List.empty)
   private final val rollcallDataCreate: RollCallData = RollCallData(CreateRollCallExamples.R_ID, ActionType.CREATE)
   private final val rollcallDataOpen: RollCallData = RollCallData(OpenRollCallExamples.UPDATE_ID, ActionType.OPEN)
   private final val rollcallDataClose: RollCallData = RollCallData(CloseRollCallExamples.UPDATE_ID, ActionType.CLOSE)
@@ -63,7 +63,7 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWrong)
         case DbActor.ReadRollCallData(_) =>
@@ -79,7 +79,7 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
         case DbActor.ReadLaoData(_) =>
           sender() ! DbActor.DbActorReadLaoDataAck(laoDataWrong)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeft)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRight)
         case DbActor.ReadRollCallData(_) =>
           sender() ! DbActor.DbActorReadRollCallDataAck(rollcallDataOpen)
       }
@@ -91,7 +91,7 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWrong)
         case DbActor.ReadRollCallData(_) =>
@@ -105,9 +105,9 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeft)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRight)
         case DbActor.ReadRollCallData(_) =>
           sender() ! DbActor.DbActorReadRollCallDataAck(rollcallDataCreate)
       }
@@ -119,9 +119,9 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeft)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRight)
         case DbActor.ReadRollCallData(_) =>
           sender() ! DbActor.DbActorReadRollCallDataAck(rollcallDataOpen)
       }
@@ -133,9 +133,9 @@ class RollCallValidatorSuite extends TestKit(ActorSystem("rollcallValidatorTestA
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeft)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRight)
         case DbActor.ReadRollCallData(_) =>
           sender() ! DbActor.DbActorReadRollCallDataAck(rollcallDataClose)
       }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SchemaVerifierSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SchemaVerifierSuite.scala
@@ -27,7 +27,7 @@ class SchemaVerifierSuite extends FunSuite with Matchers {
   test("Invalid jsonString - string instead of JSON object") {
     val invalidJSON = "wrond JSON string"
 
-    verifyRpcSchema(invalidJSON) shouldBe a[Right[_, PipelineError]]
+    verifyRpcSchema(invalidJSON) shouldBe a[Left[_, PipelineError]]
   }
 
   /* ----------------------------- High-level (JSON-rpc) tests ----------------------------- */
@@ -35,21 +35,21 @@ class SchemaVerifierSuite extends FunSuite with Matchers {
     val subscribePath = "../protocol/examples/query/subscribe/subscribe.json"
     val subscribeJson = getJsonStringFromFile(subscribePath)
 
-    verifyRpcSchema(subscribeJson) should be(Left(subscribeJson))
+    verifyRpcSchema(subscribeJson) should be(Right(subscribeJson))
   }
 
   test("Incorrect subscribe query: additional params") {
     val subscribePath = "../protocol/examples/query/subscribe/wrong_subscribe__additional_params.json"
     val subscribeJson = getJsonStringFromFile(subscribePath)
 
-    verifyRpcSchema(subscribeJson) shouldBe a[Right[_, PipelineError]]
+    verifyRpcSchema(subscribeJson) shouldBe a[Left[_, PipelineError]]
   }
 
   test("Incorrect subscribe query: missing channel") {
     val subscribePath = "../protocol/examples/query/subscribe/wrong_subscribe_missing_channel.json"
     val subscribeJson = getJsonStringFromFile(subscribePath)
 
-    verifyRpcSchema(subscribeJson) shouldBe a[Right[_, PipelineError]]
+    verifyRpcSchema(subscribeJson) shouldBe a[Left[_, PipelineError]]
   }
 
   /* Test broadcast query with message format */
@@ -57,49 +57,49 @@ class SchemaVerifierSuite extends FunSuite with Matchers {
     val broadcastPath = "../protocol/examples/query/broadcast/broadcast.json"
     val broadcastJson = getJsonStringFromFile(broadcastPath)
 
-    verifyRpcSchema(broadcastJson) should be(Left(broadcastJson))
+    verifyRpcSchema(broadcastJson) should be(Right(broadcastJson))
   }
 
   test("Incorrect broadcast query: additional params") {
     val broadcastPath = "../protocol/examples/query/broadcast/wrong_broadcast_additional_params.json"
     val broadcastJson = getJsonStringFromFile(broadcastPath)
 
-    verifyRpcSchema(broadcastJson) shouldBe a[Right[_, PipelineError]]
+    verifyRpcSchema(broadcastJson) shouldBe a[Left[_, PipelineError]]
   }
 
   test("Incorrect broadcast query: missing message") {
     val broadcastPath = "../protocol/examples/query/broadcast/wrong_broadcast_missing_message.json"
     val broadcastJson = getJsonStringFromFile(broadcastPath)
 
-    verifyRpcSchema(broadcastJson) shouldBe a[Right[_, PipelineError]]
+    verifyRpcSchema(broadcastJson) shouldBe a[Left[_, PipelineError]]
   }
 
   test("Correct unsubscribe JSON-RPC query") {
     val unsubscribePath = "../protocol/examples/query/unsubscribe/unsubscribe.json"
     val unsubscribeJson = getJsonStringFromFile(unsubscribePath)
 
-    verifyRpcSchema(unsubscribeJson) should be(Left(unsubscribeJson))
+    verifyRpcSchema(unsubscribeJson) should be(Right(unsubscribeJson))
   }
 
   test("Incorrect unsubscribe query: additional params") {
     val unsubscribePath = "../protocol/examples/query/unsubscribe/wrong_unsubscribe__additional_params.json"
     val unsubscribeJson = getJsonStringFromFile(unsubscribePath)
 
-    verifyRpcSchema(unsubscribeJson) shouldBe a[Right[_, PipelineError]]
+    verifyRpcSchema(unsubscribeJson) shouldBe a[Left[_, PipelineError]]
   }
 
   test("Incorrect unsubscribe query: missing channel") {
     val unsubscribePath = "../protocol/examples/query/unsubscribe/wrong_unsubscribe_missing_channel.json"
     val unsubscribeJson = getJsonStringFromFile(unsubscribePath)
 
-    verifyRpcSchema(unsubscribeJson) shouldBe a[Right[_, PipelineError]]
+    verifyRpcSchema(unsubscribeJson) shouldBe a[Left[_, PipelineError]]
   }
 
   test("Incorrect unsubscribe query: wrong channel") {
     val unsubscribePath = "../protocol/examples/query/unsubscribe/wrong_unsubscribe_channel.json"
     val unsubscribeJson = getJsonStringFromFile(unsubscribePath)
 
-    verifyRpcSchema(unsubscribeJson) shouldBe a[Right[_, PipelineError]]
+    verifyRpcSchema(unsubscribeJson) shouldBe a[Left[_, PipelineError]]
   }
 
   /* ----------------------------- Low-level (data) tests ----------------------------- */

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SchemaVerifierSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SchemaVerifierSuite.scala
@@ -27,7 +27,7 @@ class SchemaVerifierSuite extends FunSuite with Matchers {
   test("Invalid jsonString - string instead of JSON object") {
     val invalidJSON = "wrond JSON string"
 
-    verifyRpcSchema(invalidJSON) shouldBe a[Left[_, PipelineError]]
+    verifyRpcSchema(invalidJSON) shouldBe a[Right[_, PipelineError]]
   }
 
   /* ----------------------------- High-level (JSON-rpc) tests ----------------------------- */
@@ -35,21 +35,21 @@ class SchemaVerifierSuite extends FunSuite with Matchers {
     val subscribePath = "../protocol/examples/query/subscribe/subscribe.json"
     val subscribeJson = getJsonStringFromFile(subscribePath)
 
-    verifyRpcSchema(subscribeJson) should be(Right(subscribeJson))
+    verifyRpcSchema(subscribeJson) should be(Left(subscribeJson))
   }
 
   test("Incorrect subscribe query: additional params") {
     val subscribePath = "../protocol/examples/query/subscribe/wrong_subscribe__additional_params.json"
     val subscribeJson = getJsonStringFromFile(subscribePath)
 
-    verifyRpcSchema(subscribeJson) shouldBe a[Left[_, PipelineError]]
+    verifyRpcSchema(subscribeJson) shouldBe a[Right[_, PipelineError]]
   }
 
   test("Incorrect subscribe query: missing channel") {
     val subscribePath = "../protocol/examples/query/subscribe/wrong_subscribe_missing_channel.json"
     val subscribeJson = getJsonStringFromFile(subscribePath)
 
-    verifyRpcSchema(subscribeJson) shouldBe a[Left[_, PipelineError]]
+    verifyRpcSchema(subscribeJson) shouldBe a[Right[_, PipelineError]]
   }
 
   /* Test broadcast query with message format */
@@ -57,49 +57,49 @@ class SchemaVerifierSuite extends FunSuite with Matchers {
     val broadcastPath = "../protocol/examples/query/broadcast/broadcast.json"
     val broadcastJson = getJsonStringFromFile(broadcastPath)
 
-    verifyRpcSchema(broadcastJson) should be(Right(broadcastJson))
+    verifyRpcSchema(broadcastJson) should be(Left(broadcastJson))
   }
 
   test("Incorrect broadcast query: additional params") {
     val broadcastPath = "../protocol/examples/query/broadcast/wrong_broadcast_additional_params.json"
     val broadcastJson = getJsonStringFromFile(broadcastPath)
 
-    verifyRpcSchema(broadcastJson) shouldBe a[Left[_, PipelineError]]
+    verifyRpcSchema(broadcastJson) shouldBe a[Right[_, PipelineError]]
   }
 
   test("Incorrect broadcast query: missing message") {
     val broadcastPath = "../protocol/examples/query/broadcast/wrong_broadcast_missing_message.json"
     val broadcastJson = getJsonStringFromFile(broadcastPath)
 
-    verifyRpcSchema(broadcastJson) shouldBe a[Left[_, PipelineError]]
+    verifyRpcSchema(broadcastJson) shouldBe a[Right[_, PipelineError]]
   }
 
   test("Correct unsubscribe JSON-RPC query") {
     val unsubscribePath = "../protocol/examples/query/unsubscribe/unsubscribe.json"
     val unsubscribeJson = getJsonStringFromFile(unsubscribePath)
 
-    verifyRpcSchema(unsubscribeJson) should be(Right(unsubscribeJson))
+    verifyRpcSchema(unsubscribeJson) should be(Left(unsubscribeJson))
   }
 
   test("Incorrect unsubscribe query: additional params") {
     val unsubscribePath = "../protocol/examples/query/unsubscribe/wrong_unsubscribe__additional_params.json"
     val unsubscribeJson = getJsonStringFromFile(unsubscribePath)
 
-    verifyRpcSchema(unsubscribeJson) shouldBe a[Left[_, PipelineError]]
+    verifyRpcSchema(unsubscribeJson) shouldBe a[Right[_, PipelineError]]
   }
 
   test("Incorrect unsubscribe query: missing channel") {
     val unsubscribePath = "../protocol/examples/query/unsubscribe/wrong_unsubscribe_missing_channel.json"
     val unsubscribeJson = getJsonStringFromFile(unsubscribePath)
 
-    verifyRpcSchema(unsubscribeJson) shouldBe a[Left[_, PipelineError]]
+    verifyRpcSchema(unsubscribeJson) shouldBe a[Right[_, PipelineError]]
   }
 
   test("Incorrect unsubscribe query: wrong channel") {
     val unsubscribePath = "../protocol/examples/query/unsubscribe/wrong_unsubscribe_channel.json"
     val unsubscribeJson = getJsonStringFromFile(unsubscribePath)
 
-    verifyRpcSchema(unsubscribeJson) shouldBe a[Left[_, PipelineError]]
+    verifyRpcSchema(unsubscribeJson) shouldBe a[Right[_, PipelineError]]
   }
 
   /* ----------------------------- Low-level (data) tests ----------------------------- */

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SocialMediaValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/SocialMediaValidatorSuite.scala
@@ -45,9 +45,9 @@ class SocialMediaValidatorSuite extends TestKit(ActorSystem("socialMediaValidato
   private final val PUBLIC_KEY: PublicKey = PublicKey(Base64Data("jsNj23IHALvppqV1xQfP71_3IyAHzivxiCz236_zzQc="))
   private final val PRIVATE_KEY: PrivateKey = PrivateKey(Base64Data("qRfms3wzSLkxAeBz6UtwA-L1qP0h8D9XI1FSvY68t7Y="))
   private final val PK_OWNER: PublicKey = PublicKey(Base64Data.encode("owner"))
-  private final val laoDataRight: LaoData = LaoData(PK_OWNER, List(AddChirpExamples.SENDER_ADDCHIRP), PRIVATE_KEY, PUBLIC_KEY, List.empty)
+  private final val laoDataLeft: LaoData = LaoData(PK_OWNER, List(AddChirpExamples.SENDER_ADDCHIRP), PRIVATE_KEY, PUBLIC_KEY, List.empty)
   private final val laoDataWrong: LaoData = LaoData(PK_OWNER, List(PK_OWNER), PRIVATE_KEY, PUBLIC_KEY, List.empty)
-  private final val channelDataRight: ChannelData = ChannelData(ObjectType.CHIRP, List.empty)
+  private final val channelDataLeft: ChannelData = ChannelData(ObjectType.CHIRP, List.empty)
   private final val channelDataWrong: ChannelData = ChannelData(ObjectType.LAO, List.empty)
   private final val channelDataReaction: ChannelData = ChannelData(ObjectType.REACTION, List.empty)
 
@@ -55,9 +55,9 @@ class SocialMediaValidatorSuite extends TestKit(ActorSystem("socialMediaValidato
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRight)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeft)
       }
     })
     system.actorOf(dbActorMock)
@@ -67,7 +67,7 @@ class SocialMediaValidatorSuite extends TestKit(ActorSystem("socialMediaValidato
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataReaction)
       }
@@ -93,7 +93,7 @@ class SocialMediaValidatorSuite extends TestKit(ActorSystem("socialMediaValidato
         case DbActor.ReadLaoData(_) =>
           sender() ! DbActor.DbActorReadLaoDataAck(laoDataWrong)
         case DbActor.ReadChannelData(_) =>
-          sender() ! DbActor.DbActorReadChannelDataAck(channelDataRight)
+          sender() ! DbActor.DbActorReadChannelDataAck(channelDataLeft)
       }
     })
     system.actorOf(dbActorMock)
@@ -103,7 +103,7 @@ class SocialMediaValidatorSuite extends TestKit(ActorSystem("socialMediaValidato
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
         case DbActor.ReadChannelData(_) =>
           sender() ! DbActor.DbActorReadChannelDataAck(channelDataWrong)
       }
@@ -115,49 +115,49 @@ class SocialMediaValidatorSuite extends TestKit(ActorSystem("socialMediaValidato
   test("Adding a chirp works as intended") {
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateAddChirp(ADD_CHIRP_RPC)
-    message should equal(Left(ADD_CHIRP_RPC))
+    message should equal(Right(ADD_CHIRP_RPC))
     system.stop(dbActorRef.actorRef)
   }
 
   test("Adding a chirp with too long text fails") {
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateAddChirp(ADD_CHIRP_WRONG_TEXT_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Adding a chirp with invalid Timestamp fails") {
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateAddChirp(ADD_CHIRP_WRONG_TIMESTAMP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Adding a chirp without valid PoP token fails") {
     val dbActorRef = mockDbWrongToken
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateAddChirp(ADD_CHIRP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Adding a chirp on wrong type of channel fails") {
     val dbActorRef = mockDbWrongChannel
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateAddChirp(ADD_CHIRP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Adding a chirp on channel which is not our own social channel fails") {
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateAddChirp(ADD_CHIRP_WRONG_CHANNEL_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Validating a RpcMessage without Params does not work in validateAddChirp") {
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateAddChirp(RPC_NO_PARAMS)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -165,42 +165,42 @@ class SocialMediaValidatorSuite extends TestKit(ActorSystem("socialMediaValidato
   test("Deleting a chirp works as intended") {
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateDeleteChirp(DELETE_CHIRP_RPC)
-    message should equal(Left(DELETE_CHIRP_RPC))
+    message should equal(Right(DELETE_CHIRP_RPC))
     system.stop(dbActorRef.actorRef)
   }
 
   test("Deleting a chirp with invalid Timestamp fails") {
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateDeleteChirp(DELETE_CHIRP_WRONG_TIMESTAMP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Deleting a chirp without valid PoP token fails") {
     val dbActorRef = mockDbWrongToken
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateDeleteChirp(DELETE_CHIRP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Deleting a chirp on wrong type of channel fails") {
     val dbActorRef = mockDbWrongChannel
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateDeleteChirp(DELETE_CHIRP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Deleting a chirp on channel which is not our own social channel fails") {
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateDeleteChirp(DELETE_CHIRP_WRONG_CHANNEL_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Validating a RpcMessage without Params does not work in validateDeleteChirp") {
     val dbActorRef = mockDbWorking
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateDeleteChirp(RPC_NO_PARAMS)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -208,35 +208,35 @@ class SocialMediaValidatorSuite extends TestKit(ActorSystem("socialMediaValidato
   test("Adding a reaction works as intended") {
     val dbActorRef = mockDbWorkingReaction
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateAddReaction(ADD_REACTION_RPC)
-    message should equal(Left(ADD_REACTION_RPC))
+    message should equal(Right(ADD_REACTION_RPC))
     system.stop(dbActorRef.actorRef)
   }
 
   test("Adding a reaction with invalid Timestamp fails") {
     val dbActorRef = mockDbWorkingReaction
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateAddReaction(ADD_REACTION_WRONG_TIMESTAMP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Adding a reaction without valid PoP token fails") {
     val dbActorRef = mockDbWrongTokenReaction
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateAddReaction(ADD_REACTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Adding a reaction on wrong type of channel fails") {
     val dbActorRef = mockDbWrongChannel
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateAddReaction(ADD_REACTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Validating a RpcMessage without Params does not work in validateAddReaction") {
     val dbActorRef = mockDbWorkingReaction
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateAddReaction(RPC_NO_PARAMS)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
@@ -244,35 +244,35 @@ class SocialMediaValidatorSuite extends TestKit(ActorSystem("socialMediaValidato
   test("Deleting a reaction works as intended") {
     val dbActorRef = mockDbWorkingReaction
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateDeleteReaction(DELETE_REACTION_RPC)
-    message should equal(Left(DELETE_REACTION_RPC))
+    message should equal(Right(DELETE_REACTION_RPC))
     system.stop(dbActorRef.actorRef)
   }
 
   test("Deleting a reaction with invalid Timestamp fails") {
     val dbActorRef = mockDbWorkingReaction
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateDeleteReaction(DELETE_REACTION_WRONG_TIMESTAMP_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Deleting a reaction without valid PoP token fails") {
     val dbActorRef = mockDbWrongTokenReaction
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateDeleteReaction(DELETE_REACTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Deleting a reaction on wrong type of channel fails") {
     val dbActorRef = mockDbWrongChannel
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateDeleteReaction(DELETE_REACTION_RPC)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 
   test("Validating a RpcMessage without Params does not work in validateDeleteReaction") {
     val dbActorRef = mockDbWorkingReaction
     val message: GraphMessage = new SocialMediaValidator(dbActorRef).validateDeleteReaction(RPC_NO_PARAMS)
-    message shouldBe a[Right[_, PipelineError]]
+    message shouldBe a[Left[_, PipelineError]]
     system.stop(dbActorRef.actorRef)
   }
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/validators/WitnessValidatorSuite.scala
@@ -43,14 +43,14 @@ class WitnessValidatorSuite extends TestKit(ActorSystem("witnessValidatorTestAct
   private final val PUBLIC_KEY: PublicKey = WitnessMessageExamples.SENDER
   private final val PRIVATE_KEY: PrivateKey = WitnessMessageExamples.privateKey
   private final val PK_WRONG_OWNER: PublicKey = PublicKey(Base64Data.encode("wrongOwner"))
-  private final val laoDataLeft: LaoData = LaoData(PUBLIC_KEY, List(PUBLIC_KEY), PRIVATE_KEY, PUBLIC_KEY, List.empty)
+  private final val laoDataRight: LaoData = LaoData(PUBLIC_KEY, List(PUBLIC_KEY), PRIVATE_KEY, PUBLIC_KEY, List.empty)
   private final val laoDataWrong: LaoData = LaoData(PK_WRONG_OWNER, List(PK_WRONG_OWNER), PRIVATE_KEY, PUBLIC_KEY, List.empty)
 
   private def mockDbWorking: AskableActorRef = {
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
         case DbActor.ReadLaoData(_) =>
-          sender() ! DbActor.DbActorReadLaoDataAck(laoDataLeft)
+          sender() ! DbActor.DbActorReadLaoDataAck(laoDataRight)
         case x =>
           system.log.info(s"Received - error $x")
       }


### PR DESCRIPTION
The scala convention for the use of Either is using Right as the success pipe and Left as the error pipe. However, the inverse is done in this project regarding the GraphMessage type. This works as is but is a technical specificity that needs to be learnt by newcomers in the project, and as the scala standard library is based on a different convention, this prevents us from using parts of it. Therefore, conforming us to the standard convention could let us use these features which would help turn the code into a cleaner form (the first commit shows a usage example in the `validateWitnessMessage`, turned into `WitnessValidatorTest`, of the `WitnessValidator` class).