### PR TITLE
Added hash tests for emoji

### DIFF
--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/security/HashTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/security/HashTest.java
@@ -32,4 +32,23 @@ public class HashTest {
     String expected = "bkkql8ZyOdbqrWY1QJHPGiz29zNMOEtaXXBHK1aWgjY=";
     assertEquals(expected, Hash.hash("你们是真的", "好学生！"));
   }
+
+  @Test
+  public void hashEmojiTest() {
+    String expected = "8BMmJjQMPhtD0QwVor1uVB3B_PyMMyIbIvaDHcOQnTg=";
+    assertEquals(expected, Hash.hash("test \uD83D\uDE00"));
+  }
+
+  @Test
+  public void hashPureEmojiTest() {
+    String expected = "ht7cQAkPdd6o-ZFVW6gTbt0gEIEUcr5FTDgOaeW8BOU=";
+    assertEquals(expected, Hash.hash("🫡"));
+  }
+
+  @Test
+  public void hashMixEmojiTest() {
+    String expected = "wANKJFj9q_ncRKalYmK4yozUpet33JaFXVQEpMcHdfU=";
+    assertEquals(
+        expected, Hash.hash("text \uD83E\uDD70", "\uD83C\uDFC9", "more text\uD83C\uDF83️", "♠️"));
+  }
 }


### PR DESCRIPTION
- This PR resolves #1442, aligning with the other sub-systems.
- It simply adds 3 new unit tests for the hash function in presence of special characters (emoji)