### PR TITLE
Social - make chirp like/dislike exclusive

### DIFF
--- a/fe1-web/src/features/social/__tests__/utils.ts
+++ b/fe1-web/src/features/social/__tests__/utils.ts
@@ -48,7 +48,7 @@ export const mockChirp4 = new Chirp({
   time: new Timestamp(1608888800),
 });
 
-export const mockChirp0DeletedFake = new Chirp({
+export const mockChirp0Deleted = new Chirp({
   id: mockChirpId0,
   sender: new PublicKey('Joker'),
   text: '',

--- a/fe1-web/src/features/social/components/ChirpCard.tsx
+++ b/fe1-web/src/features/social/components/ChirpCard.tsx
@@ -155,9 +155,8 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
 
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
 
-  const thumbsPressed = (isThumbsUp: boolean) => {
-    const reactionToAdd = isThumbsUp ? '👍' : '👎';
-    const reactionToRemove = isThumbsUp ? '👎' : '👍';
+  const thumbsPressed = (reactionToAdd: '👍' | '👎') => {
+    const reactionToRemove = reactionToAdd === '👍' ? '👎' : '👍';
 
     if (reacted[reactionToAdd]) {
       deleteReaction(reacted[reactionToAdd].id);
@@ -171,9 +170,6 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
 
     addReaction(reactionToAdd);
   };
-
-  const thumbsUpPressed = () => thumbsPressed(true);
-  const thumbsDownPressed = () => thumbsPressed(false);
 
   return (
     <ListItem containerStyle={listStyle} style={listStyle} bottomDivider>
@@ -222,7 +218,7 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
                 <PoPIconButton
                   name="thumbsUp"
                   testID="thumbs-up"
-                  onPress={thumbsUpPressed}
+                  onPress={() => thumbsPressed('👍')}
                   disabled={reactionsDisabled['👍']}
                   size="small"
                   buttonStyle={reacted['👍'] ? 'primary' : 'secondary'}
@@ -236,7 +232,7 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
                 <PoPIconButton
                   name="thumbsDown"
                   testID="thumbs-down"
-                  onPress={thumbsDownPressed}
+                  onPress={() => thumbsPressed('👎')}
                   disabled={reactionsDisabled['👎']}
                   size="small"
                   buttonStyle={reacted['👎'] ? 'primary' : 'secondary'}

--- a/fe1-web/src/features/social/components/ChirpCard.tsx
+++ b/fe1-web/src/features/social/components/ChirpCard.tsx
@@ -155,6 +155,30 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
 
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
 
+  function thumbsUpPressed() {
+    if (reacted['👍']) {
+      deleteReaction(reacted['👍'].id);
+    } else {
+      // If the user has already reacted with a thumbs down, remove it
+      if (reacted['👎']) {
+        deleteReaction(reacted['👎'].id);
+      }
+      addReaction('👍');
+    }
+  }
+
+  function thumbsDownPressed() {
+    if (reacted['👎']) {
+      deleteReaction(reacted['👎'].id);
+    } else {
+      // If the user has already reacted with a thumbs up, remove it
+      if (reacted['👍']) {
+        deleteReaction(reacted['👍'].id);
+      }
+      addReaction('👎');
+    }
+  }
+
   return (
     <ListItem containerStyle={listStyle} style={listStyle} bottomDivider>
       <PoPTouchableOpacity
@@ -202,9 +226,7 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
                 <PoPIconButton
                   name="thumbsUp"
                   testID="thumbs-up"
-                  onPress={() =>
-                    reacted['👍'] ? deleteReaction(reacted['👍'].id) : addReaction('👍')
-                  }
+                  onPress={() => thumbsUpPressed()}
                   disabled={reactionsDisabled['👍']}
                   size="small"
                   buttonStyle={reacted['👍'] ? 'primary' : 'secondary'}
@@ -218,9 +240,7 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
                 <PoPIconButton
                   name="thumbsDown"
                   testID="thumbs-down"
-                  onPress={() =>
-                    reacted['👎'] ? deleteReaction(reacted['👎'].id) : addReaction('👎')
-                  }
+                  onPress={() => thumbsDownPressed()}
                   disabled={reactionsDisabled['👎']}
                   size="small"
                   buttonStyle={reacted['👎'] ? 'primary' : 'secondary'}

--- a/fe1-web/src/features/social/components/ChirpCard.tsx
+++ b/fe1-web/src/features/social/components/ChirpCard.tsx
@@ -155,31 +155,25 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
 
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
 
-  const thumbsUpPressed = () => {
-    if (reacted['👍']) {
-      deleteReaction(reacted['👍'].id);
+  const thumbsPressed = (isThumbsUp: boolean) => {
+    const reactionToAdd = isThumbsUp ? '👍' : '👎';
+    const reactionToRemove = isThumbsUp ? '👎' : '👍';
+
+    if (reacted[reactionToAdd]) {
+      deleteReaction(reacted[reactionToAdd].id);
       return;
     }
 
-    // If the user has already reacted with a thumbs down, remove it
-    if (reacted['👎']) {
-      deleteReaction(reacted['👎'].id);
+    // If the user has already reacted with the other reaction, remove it
+    if (reacted[reactionToRemove]) {
+      deleteReaction(reacted[reactionToRemove].id);
     }
 
-    addReaction('👍');
+    addReaction(reactionToAdd);
   };
 
-  const thumbsDownPressed = () => {
-    if (reacted['👎']) {
-      deleteReaction(reacted['👎'].id);
-    } else {
-      // If the user has already reacted with a thumbs up, remove it
-      if (reacted['👍']) {
-        deleteReaction(reacted['👍'].id);
-      }
-      addReaction('👎');
-    }
-  };
+  const thumbsUpPressed = () => thumbsPressed(true);
+  const thumbsDownPressed = () => thumbsPressed(false);
 
   return (
     <ListItem containerStyle={listStyle} style={listStyle} bottomDivider>

--- a/fe1-web/src/features/social/components/ChirpCard.tsx
+++ b/fe1-web/src/features/social/components/ChirpCard.tsx
@@ -155,19 +155,21 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
 
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
 
-  function thumbsUpPressed() {
+  const thumbsUpPressed = () => {
     if (reacted['👍']) {
       deleteReaction(reacted['👍'].id);
-    } else {
-      // If the user has already reacted with a thumbs down, remove it
-      if (reacted['👎']) {
-        deleteReaction(reacted['👎'].id);
-      }
-      addReaction('👍');
+      return;
     }
-  }
 
-  function thumbsDownPressed() {
+    // If the user has already reacted with a thumbs down, remove it
+    if (reacted['👎']) {
+      deleteReaction(reacted['👎'].id);
+    }
+
+    addReaction('👍');
+  };
+
+  const thumbsDownPressed = () => {
     if (reacted['👎']) {
       deleteReaction(reacted['👎'].id);
     } else {
@@ -177,7 +179,7 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
       }
       addReaction('👎');
     }
-  }
+  };
 
   return (
     <ListItem containerStyle={listStyle} style={listStyle} bottomDivider>
@@ -226,7 +228,7 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
                 <PoPIconButton
                   name="thumbsUp"
                   testID="thumbs-up"
-                  onPress={() => thumbsUpPressed()}
+                  onPress={thumbsUpPressed}
                   disabled={reactionsDisabled['👍']}
                   size="small"
                   buttonStyle={reacted['👍'] ? 'primary' : 'secondary'}
@@ -240,7 +242,7 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
                 <PoPIconButton
                   name="thumbsDown"
                   testID="thumbs-down"
-                  onPress={() => thumbsDownPressed()}
+                  onPress={thumbsDownPressed}
                   disabled={reactionsDisabled['👎']}
                   size="small"
                   buttonStyle={reacted['👎'] ? 'primary' : 'secondary'}
@@ -270,7 +272,7 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
                 <View style={styles.reactionView}>
                   <PoPIconButton
                     name="delete"
-                    testID="delete"
+                    testID="delete_chirp"
                     onPress={() => setShowDeleteConfirmation(true)}
                     size="small"
                     buttonStyle="secondary"

--- a/fe1-web/src/features/social/components/__tests__/ChirpCard.test.tsx
+++ b/fe1-web/src/features/social/components/__tests__/ChirpCard.test.tsx
@@ -171,5 +171,21 @@ describe('ChirpCard', () => {
       expect(mockRequestAddReaction).toHaveBeenCalledWith('👎', ID, mockLaoId);
       expect(mockRequestDeleteReaction).toHaveBeenCalledWith(mockReaction1.id, mockLaoId);
     });
+
+    it('adds thumps down to thumbs up chirp removes thumbs up', () => {
+      const { getByTestId } = renderChirp(chirp, true);
+      const thumbsDownButton = getByTestId('thumbs-down');
+
+      // sets the button with thumbs down
+      fireEvent.press(thumbsDownButton);
+      expect(mockRequestAddReaction).toHaveBeenCalledWith('👎', ID, mockLaoId);
+
+      const thumbsUpButton = getByTestId('thumbs-up');
+      fireEvent.press(thumbsUpButton);
+      expect(mockRequestDeleteReaction).toHaveBeenCalledWith(mockReaction1.id, mockLaoId);
+      // TODO: fix this test
+      // expect(mockRequestAddReaction).toHaveBeenCalledTimes(2);
+      // expect(mockRequestAddReaction).toHaveBeenCalledWith('👍', ID, mockLaoId);
+    });
   });
 });

--- a/fe1-web/src/features/social/components/__tests__/ChirpCard.test.tsx
+++ b/fe1-web/src/features/social/components/__tests__/ChirpCard.test.tsx
@@ -163,5 +163,13 @@ describe('ChirpCard', () => {
       fireEvent.press(heartButton);
       expect(mockRequestAddReaction).toHaveBeenCalledWith('❤️', ID, mockLaoId);
     });
+
+    it('adds thumps up to thumbs down chirp removes thumbs down', () => {
+      const { getByTestId } = renderChirp(chirp, true);
+      const thumbsDownButton = getByTestId('thumbs-down');
+      fireEvent.press(thumbsDownButton);
+      expect(mockRequestAddReaction).toHaveBeenCalledWith('👎', ID, mockLaoId);
+      expect(mockRequestDeleteReaction).toHaveBeenCalledWith(mockReaction1.id, mockLaoId);
+    });
   });
 });

--- a/fe1-web/src/features/social/components/__tests__/__snapshots__/ChirpCard.test.tsx.snap
+++ b/fe1-web/src/features/social/components/__tests__/__snapshots__/ChirpCard.test.tsx.snap
@@ -429,7 +429,7 @@ exports[`ChirpCard for deletion render correct for a deleted chirp 1`] = `
                                       ]
                                     }
                                   >
-                                    oKHk
+                                    Joke
                                   </Text>
                                 </View>
                               </View>
@@ -594,10 +594,10 @@ exports[`ChirpCard for deletion render correct for a deleted chirp 1`] = `
                                   }
                                 >
                                   <time
-                                    dateTime="2020-12-31T23:00:00.000Z"
-                                    title="2020-12-31 23:00"
+                                    dateTime="2020-11-29T16:16:40.000Z"
+                                    title="2020-11-29 16:16"
                                   >
-                                    4 months ago
+                                    5 months ago
                                   </time>
                                 </Text>
                               </View>
@@ -1047,7 +1047,7 @@ exports[`ChirpCard for deletion renders correctly for non-sender 1`] = `
                                       ]
                                     }
                                   >
-                                    oKHk
+                                    Doug
                                   </Text>
                                 </View>
                               </View>
@@ -1162,7 +1162,7 @@ exports[`ChirpCard for deletion renders correctly for non-sender 1`] = `
                                   }
                                 }
                               >
-                                Don't panic.
+                                Don't delete me!
                               </Text>
                             </Text>
                             <View
@@ -1233,11 +1233,14 @@ exports[`ChirpCard for deletion renders correctly for non-sender 1`] = `
                                               "borderWidth": 1,
                                               "padding": 8,
                                             },
+                                            {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"thumbs-up-sharp","size":16,"color":"#fff"}
+                                          {"name":"thumbs-up-sharp","size":16,"color":"#3742fa"}
                                         </View>
                                       </View>
                                     </View>
@@ -1262,7 +1265,7 @@ exports[`ChirpCard for deletion renders correctly for non-sender 1`] = `
                                     ]
                                   }
                                 >
-                                  1
+                                  0
                                 </Text>
                               </View>
                               <View
@@ -1486,10 +1489,10 @@ exports[`ChirpCard for deletion renders correctly for non-sender 1`] = `
                                   }
                                 >
                                   <time
-                                    dateTime="2020-12-31T23:00:00.000Z"
-                                    title="2020-12-31 23:00"
+                                    dateTime="2020-11-29T16:16:40.000Z"
+                                    title="2020-11-29 16:16"
                                   >
-                                    4 months ago
+                                    5 months ago
                                   </time>
                                 </Text>
                               </View>
@@ -1939,7 +1942,7 @@ exports[`ChirpCard for deletion renders correctly for sender 1`] = `
                                       ]
                                     }
                                   >
-                                    oKHk
+                                    Doug
                                   </Text>
                                 </View>
                               </View>
@@ -2054,7 +2057,7 @@ exports[`ChirpCard for deletion renders correctly for sender 1`] = `
                                   }
                                 }
                               >
-                                Don't panic.
+                                Don't delete me!
                               </Text>
                             </Text>
                             <View
@@ -2125,11 +2128,14 @@ exports[`ChirpCard for deletion renders correctly for sender 1`] = `
                                               "borderWidth": 1,
                                               "padding": 8,
                                             },
+                                            {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"thumbs-up-sharp","size":16,"color":"#fff"}
+                                          {"name":"thumbs-up-sharp","size":16,"color":"#3742fa"}
                                         </View>
                                       </View>
                                     </View>
@@ -2154,7 +2160,7 @@ exports[`ChirpCard for deletion renders correctly for sender 1`] = `
                                     ]
                                   }
                                 >
-                                  1
+                                  0
                                 </Text>
                               </View>
                               <View
@@ -2369,7 +2375,7 @@ exports[`ChirpCard for deletion renders correctly for sender 1`] = `
                                   onResponderTerminationRequest={[Function]}
                                   onStartShouldSetResponder={[Function]}
                                   style={{}}
-                                  testID="delete"
+                                  testID="delete_chirp"
                                 >
                                   <RNGestureHandlerButton
                                     collapsable={false}
@@ -2457,10 +2463,10 @@ exports[`ChirpCard for deletion renders correctly for sender 1`] = `
                                   }
                                 >
                                   <time
-                                    dateTime="2020-12-31T23:00:00.000Z"
-                                    title="2020-12-31 23:00"
+                                    dateTime="2020-11-29T16:16:40.000Z"
+                                    title="2020-11-29 16:16"
                                   >
-                                    4 months ago
+                                    5 months ago
                                   </time>
                                 </Text>
                               </View>
@@ -2910,7 +2916,7 @@ exports[`ChirpCard for reaction renders correctly with reaction 1`] = `
                                       ]
                                     }
                                   >
-                                    oKHk
+                                    Doug
                                   </Text>
                                 </View>
                               </View>
@@ -3025,7 +3031,7 @@ exports[`ChirpCard for reaction renders correctly with reaction 1`] = `
                                   }
                                 }
                               >
-                                Don't panic.
+                                Don't delete me!
                               </Text>
                             </Text>
                             <View
@@ -3096,11 +3102,14 @@ exports[`ChirpCard for reaction renders correctly with reaction 1`] = `
                                               "borderWidth": 1,
                                               "padding": 8,
                                             },
+                                            {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"thumbs-up-sharp","size":16,"color":"#fff"}
+                                          {"name":"thumbs-up-sharp","size":16,"color":"#3742fa"}
                                         </View>
                                       </View>
                                     </View>
@@ -3319,85 +3328,6 @@ exports[`ChirpCard for reaction renders correctly with reaction 1`] = `
                               <View
                                 style={
                                   {
-                                    "alignItems": "center",
-                                    "flexDirection": "row",
-                                    "marginRight": 16,
-                                    "marginTop": 16,
-                                  }
-                                }
-                              >
-                                <View
-                                  accessible={true}
-                                  collapsable={false}
-                                  focusable={true}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onResponderGrant={[Function]}
-                                  onResponderMove={[Function]}
-                                  onResponderRelease={[Function]}
-                                  onResponderTerminate={[Function]}
-                                  onResponderTerminationRequest={[Function]}
-                                  onStartShouldSetResponder={[Function]}
-                                  style={{}}
-                                  testID="delete"
-                                >
-                                  <RNGestureHandlerButton
-                                    collapsable={false}
-                                    delayLongPress={600}
-                                    enabled={true}
-                                    exclusive={true}
-                                    handlerTag={29}
-                                    handlerType="NativeViewGestureHandler"
-                                    onGestureEvent={[Function]}
-                                    onGestureHandlerEvent={[Function]}
-                                    onGestureHandlerStateChange={[Function]}
-                                    onHandlerStateChange={[Function]}
-                                    rippleColor={0}
-                                    touchSoundDisabled={false}
-                                  >
-                                    <View
-                                      accessible={true}
-                                      collapsable={false}
-                                      style={
-                                        {
-                                          "opacity": 1,
-                                        }
-                                      }
-                                    >
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "backgroundColor": "#3742fa",
-                                              "borderColor": "#3742fa",
-                                              "borderRadius": 8,
-                                              "borderWidth": 1,
-                                              "padding": 8,
-                                            },
-                                            {
-                                              "backgroundColor": "transparent",
-                                            },
-                                          ]
-                                        }
-                                      >
-                                        <View>
-                                          {"name":"ios-trash","size":16,"color":"#3742fa"}
-                                        </View>
-                                      </View>
-                                    </View>
-                                  </RNGestureHandlerButton>
-                                </View>
-                                <Modal
-                                  hardwareAccelerated={false}
-                                  onRequestClose={[Function]}
-                                  transparent={true}
-                                  visible={false}
-                                />
-                              </View>
-                              <View
-                                style={
-                                  {
                                     "flexGrow": 1,
                                   }
                                 }
@@ -3428,10 +3358,10 @@ exports[`ChirpCard for reaction renders correctly with reaction 1`] = `
                                   }
                                 >
                                   <time
-                                    dateTime="2020-12-31T23:00:00.000Z"
-                                    title="2020-12-31 23:00"
+                                    dateTime="2020-11-29T16:16:40.000Z"
+                                    title="2020-11-29 16:16"
                                   >
-                                    4 months ago
+                                    5 months ago
                                   </time>
                                 </Text>
                               </View>
@@ -3728,7 +3658,7 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
               <View
                 collapsable={false}
                 forwardedRef={[Function]}
-                handlerTag={30}
+                handlerTag={29}
                 handlerType="PanGestureHandler"
                 needsOffscreenAlphaCompositing={false}
                 onGestureHandlerEvent={[Function]}
@@ -3820,7 +3750,7 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
                               delayLongPress={600}
                               enabled={true}
                               exclusive={true}
-                              handlerTag={31}
+                              handlerTag={30}
                               handlerType="NativeViewGestureHandler"
                               onGestureEvent={[Function]}
                               onGestureHandlerEvent={[Function]}
@@ -3881,7 +3811,7 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
                                       ]
                                     }
                                   >
-                                    Anon
+                                    Doug
                                   </Text>
                                 </View>
                               </View>
@@ -3996,7 +3926,7 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
                                   }
                                 }
                               >
-                                Ignore me
+                                Don't delete me!
                               </Text>
                             </Text>
                             <View
@@ -4039,7 +3969,7 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
                                     delayLongPress={600}
                                     enabled={true}
                                     exclusive={true}
-                                    handlerTag={32}
+                                    handlerTag={31}
                                     handlerType="NativeViewGestureHandler"
                                     onGestureEvent={[Function]}
                                     onGestureHandlerEvent={[Function]}
@@ -4067,11 +3997,14 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
                                               "borderWidth": 1,
                                               "padding": 8,
                                             },
+                                            {
+                                              "backgroundColor": "transparent",
+                                            },
                                           ]
                                         }
                                       >
                                         <View>
-                                          {"name":"thumbs-up-sharp","size":16,"color":"#fff"}
+                                          {"name":"thumbs-up-sharp","size":16,"color":"#3742fa"}
                                         </View>
                                       </View>
                                     </View>
@@ -4096,7 +4029,7 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
                                     ]
                                   }
                                 >
-                                  1
+                                  0
                                 </Text>
                               </View>
                               <View
@@ -4130,7 +4063,7 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
                                     delayLongPress={600}
                                     enabled={true}
                                     exclusive={true}
-                                    handlerTag={33}
+                                    handlerTag={32}
                                     handlerType="NativeViewGestureHandler"
                                     onGestureEvent={[Function]}
                                     onGestureHandlerEvent={[Function]}
@@ -4224,7 +4157,7 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
                                     delayLongPress={600}
                                     enabled={true}
                                     exclusive={true}
-                                    handlerTag={34}
+                                    handlerTag={33}
                                     handlerType="NativeViewGestureHandler"
                                     onGestureEvent={[Function]}
                                     onGestureHandlerEvent={[Function]}
@@ -4320,10 +4253,10 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
                                   }
                                 >
                                   <time
-                                    dateTime="2020-12-31T23:00:00.000Z"
-                                    title="2020-12-31 23:00"
+                                    dateTime="2020-11-29T16:16:40.000Z"
+                                    title="2020-11-29 16:16"
                                   >
-                                    4 months ago
+                                    5 months ago
                                   </time>
                                 </Text>
                               </View>

--- a/fe1-web/src/features/social/reducer/__tests__/SocialReducer.test.ts
+++ b/fe1-web/src/features/social/reducer/__tests__/SocialReducer.test.ts
@@ -7,7 +7,7 @@ import { AnyAction } from 'redux';
 import { serializedMockLaoId, mockLaoId } from '__tests__/utils/TestUtils';
 import {
   mockChirp0,
-  mockChirp0DeletedFake,
+  mockChirp0Deleted,
   mockChirp1,
   mockChirp1Deleted,
   mockChirp1DeletedFake,
@@ -52,7 +52,7 @@ const chirpFilledState0Deleted: SocialLaoReducerState = {
   byLaoId: {
     [serializedMockLaoId]: {
       allIdsInOrder: [],
-      byId: { [mockChirpId0.toState()]: mockChirp0DeletedFake.toState() },
+      byId: { [mockChirpId0.toState()]: mockChirp0Deleted.toState() },
       byUser: {},
       scoreByChirpId: {},
       reactionsByChirpId: {},
@@ -457,7 +457,7 @@ describe('SocialReducer', () => {
     });
 
     it('delete a non-stored chirp should store it in byId as deleted', () => {
-      expect(socialReduce(emptyState, deleteChirp(mockLaoId, mockChirp0DeletedFake))).toEqual(
+      expect(socialReduce(emptyState, deleteChirp(mockLaoId, mockChirp0Deleted))).toEqual(
         chirpFilledState0Deleted,
       );
     });


### PR DESCRIPTION
These changes makes that if a user likes a chirp that he previously had disliked, it will remove the dislike reaction (same thing for a liked chirp). This small change avoids the situation of a chirp being liked and disliked which in theory doesn't make a lot of sense.