### PR TITLE
Add counter when scanning during roll call

### DIFF
--- a/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
@@ -30,17 +30,23 @@ import { makeRollCallSelector } from '../reducer';
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
     justifyContent: 'space-between',
     marginVertical: Spacing.contentSpacing,
   } as ViewStyle,
   qrCode: {
+    alignItems: 'center',
     opacity: 0.5,
   } as ViewStyle,
   counter: {
+    alignItems: 'flex-start',
+    alignSelf: 'flex-start',
     marginTop: Spacing.x1,
+    backgroundColor: Color.contrast,
+    padding: Spacing.x05,
   } as ViewStyle,
-  enterManually: {} as ViewStyle,
+  enterManually: {
+    alignItems: 'center',
+  } as ViewStyle,
 });
 
 type NavigationProps = CompositeScreenProps<
@@ -190,7 +196,7 @@ const RollCallOpened = () => {
                 </Text>
               </PoPTouchableOpacity>
             </View>
-            <View style={[QrCodeScannerUIElementContainer, styles.counter]}>
+            <View style={styles.counter}>
               <Text style={[Typography.base, Typography.accent]}>
                 {/* -1 because we don't count the organizer */}
                 {STRINGS.roll_call_scan_counter}: {attendeePopTokens.current.length - 1}

--- a/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
@@ -44,7 +44,12 @@ const styles = StyleSheet.create({
     backgroundColor: Color.contrast,
     padding: Spacing.x05,
   } as ViewStyle,
-  enterManually: {
+  enterButton: {
+    ...QrCodeScannerUIElementContainer,
+    borderColor: Color.blue,
+    borderWidth: Spacing.x025,
+  } as ViewStyle,
+  textInformation: {
     alignItems: 'center',
   } as ViewStyle,
 });
@@ -186,8 +191,8 @@ const RollCallOpened = () => {
           <View style={styles.qrCode}>
             <QrCodeScanOverlay width={300} height={300} />
           </View>
-          <View style={styles.enterManually}>
-            <View style={QrCodeScannerUIElementContainer}>
+          <View style={styles.textInformation}>
+            <View style={styles.enterButton}>
               <PoPTouchableOpacity
                 testID="roll_call_open_add_manually"
                 onPress={() => setInputModalIsVisible(true)}>
@@ -197,7 +202,7 @@ const RollCallOpened = () => {
               </PoPTouchableOpacity>
             </View>
             <View style={styles.counter}>
-              <Text style={[Typography.base, Typography.accent]}>
+              <Text style={Typography.base}>
                 {/* -1 because we don't count the organizer */}
                 {STRINGS.roll_call_scan_counter}: {attendeePopTokens.current.length - 1}
               </Text>

--- a/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
@@ -49,7 +49,7 @@ const styles = StyleSheet.create({
     borderColor: Color.blue,
     borderWidth: Spacing.x025,
   } as ViewStyle,
-  textInformation: {
+  scannerTextItems: {
     alignItems: 'center',
   } as ViewStyle,
 });
@@ -191,7 +191,7 @@ const RollCallOpened = () => {
           <View style={styles.qrCode}>
             <QrCodeScanOverlay width={300} height={300} />
           </View>
-          <View style={styles.textInformation}>
+          <View style={styles.scannerTextItems}>
             <View style={styles.enterButton}>
               <PoPTouchableOpacity
                 testID="roll_call_open_add_manually"

--- a/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
@@ -186,7 +186,7 @@ const RollCallOpened = () => {
             <View style={[QrCodeScannerUIElementContainer, { marginTop: 10 }]}>
               <Text style={[Typography.base, Typography.accent]}>
                 {/* -1 because we don't count the organizer */}
-                Number of scanned attendees: {attendeePopTokens.current.length - 1}
+                {STRINGS.roll_call_scan_counter}: {attendeePopTokens.current.length - 1}
               </Text>
             </View>
           </View>

--- a/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
@@ -126,7 +126,6 @@ const RollCallOpened = () => {
       attendeePopTokens.current = newTokens;
       // trigger a state change to re-render the component
       forceUpdate();
-      // setShowScanner(false);
       // also change the navigation parameters so that when pressing the back button, the right parameters are passed
       navigation.setParams({
         attendeePopTokens: newTokens,
@@ -170,8 +169,6 @@ const RollCallOpened = () => {
       .then((popToken) => addAttendeePopToken(popToken.publicKey.valueOf()))
       .catch(handleError);
   }, [laoId, generateToken, rollCall, addAttendeePopToken, handleError]);
-
-  console.error('attendeePopTokens', attendeePopTokens.current.length);
 
   return (
     <>

--- a/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
@@ -178,10 +178,16 @@ const RollCallOpened = () => {
               <PoPTouchableOpacity
                 testID="roll_call_open_add_manually"
                 onPress={() => setInputModalIsVisible(true)}>
-                <Text style={[Typography.base, Typography.accent]}>
+                <Text style={[Typography.base, Typography.accent, Typography.centered]}>
                   {STRINGS.general_enter_manually}
                 </Text>
               </PoPTouchableOpacity>
+            </View>
+            <View style={[QrCodeScannerUIElementContainer, { marginTop: 10 }]}>
+              <Text style={[Typography.base, Typography.accent]}>
+                {/* -1 because we don't count the organizer */}
+                Number of scanned attendees: {attendeePopTokens.current.length - 1}
+              </Text>
             </View>
           </View>
         </View>

--- a/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
@@ -37,6 +37,9 @@ const styles = StyleSheet.create({
   qrCode: {
     opacity: 0.5,
   } as ViewStyle,
+  counter: {
+    marginTop: Spacing.x1,
+  } as ViewStyle,
   enterManually: {} as ViewStyle,
 });
 
@@ -68,6 +71,8 @@ const RollCallOpened = () => {
   // is never changed, i.e. the bound variables stay the same during the scanner's lifetime
   // this is due to a react-camera bug and is hopefully fixed at some point in the future
   const attendeePopTokens = useRef(navigationAttendeePopTokens);
+  const [, updateState] = React.useState<unknown>();
+  const forceUpdate = React.useCallback(() => updateState({}), []);
 
   // re-enable scanner on focus events
   useEffect(() => {
@@ -119,6 +124,9 @@ const RollCallOpened = () => {
 
       // update mutable reference that allows us to check for duplicates the next time this function is called
       attendeePopTokens.current = newTokens;
+      // trigger a state change to re-render the component
+      forceUpdate();
+      // setShowScanner(false);
       // also change the navigation parameters so that when pressing the back button, the right parameters are passed
       navigation.setParams({
         attendeePopTokens: newTokens,
@@ -126,7 +134,7 @@ const RollCallOpened = () => {
 
       return true;
     },
-    [navigation, attendeePopTokens],
+    [navigation, attendeePopTokens, forceUpdate],
   );
 
   const addAttendeePopTokenAndShowToast = (popToken: string) => {
@@ -163,6 +171,8 @@ const RollCallOpened = () => {
       .catch(handleError);
   }, [laoId, generateToken, rollCall, addAttendeePopToken, handleError]);
 
+  console.error('attendeePopTokens', attendeePopTokens.current.length);
+
   return (
     <>
       <QrCodeScanner
@@ -183,7 +193,7 @@ const RollCallOpened = () => {
                 </Text>
               </PoPTouchableOpacity>
             </View>
-            <View style={[QrCodeScannerUIElementContainer, { marginTop: 10 }]}>
+            <View style={[QrCodeScannerUIElementContainer, styles.counter]}>
               <Text style={[Typography.base, Typography.accent]}>
                 {/* -1 because we don't count the organizer */}
                 {STRINGS.roll_call_scan_counter}: {attendeePopTokens.current.length - 1}

--- a/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
+++ b/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
@@ -23,7 +23,6 @@ import { ROLLCALL_FEATURE_IDENTIFIER, RollCallReactContext } from 'features/roll
 import { RollCall } from 'features/rollCall/objects';
 import { addRollCall, rollCallReducer } from 'features/rollCall/reducer';
 import { getWalletState, walletReducer } from 'features/wallet/reducer';
-import STRINGS from 'resources/strings';
 
 import { requestCloseRollCall as mockRequestCloseRollCall } from '../../network/RollCallMessageApi';
 import RollCallScanner, { RollCallOpenedHeaderLeft } from '../RollCallScanner';

--- a/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
+++ b/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
@@ -23,6 +23,7 @@ import { ROLLCALL_FEATURE_IDENTIFIER, RollCallReactContext } from 'features/roll
 import { RollCall } from 'features/rollCall/objects';
 import { addRollCall, rollCallReducer } from 'features/rollCall/reducer';
 import { getWalletState, walletReducer } from 'features/wallet/reducer';
+import STRINGS from 'resources/strings';
 
 import { requestCloseRollCall as mockRequestCloseRollCall } from '../../network/RollCallMessageApi';
 import RollCallScanner, { RollCallOpenedHeaderLeft } from '../RollCallScanner';
@@ -237,8 +238,7 @@ describe('RollCallOpened', () => {
 
     const { getByText } = renderRollCallOpened(mockAttendeePopTokens);
 
-    // assert that there exists a text element with "0" in it
-    expect(getByText(/Number of scanned attendees: 0/)).toBeTruthy();
+    expect(getByText(`${STRINGS.roll_call_scan_counter}: 0`)).toBeTruthy();
 
     await waitFor(() => {
       expect(mockGenerateToken).toHaveBeenCalled();
@@ -246,6 +246,7 @@ describe('RollCallOpened', () => {
       fakeQrReaderScan(ScannablePopToken.encodePopToken({ pop_token: mockPublicKey3.valueOf() }));
     });
 
-    expect(getByText(/Number of scanned attendees: 0/)).toBeTruthy();
+    // TODO: fix this test (why still 0?)
+    expect(getByText(`${STRINGS.roll_call_scan_counter}: 0`)).toBeTruthy();
   });
 });

--- a/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
+++ b/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
@@ -231,4 +231,21 @@ describe('RollCallOpened', () => {
       ],
     });
   });
+
+  it('shows the correct number of attendees', async () => {
+    const mockAttendeePopTokens = [mockPopToken.publicKey.valueOf()];
+
+    const { getByText } = renderRollCallOpened(mockAttendeePopTokens);
+
+    // assert that there exists a text element with "0" in it
+    expect(getByText(/Number of scanned attendees: 0/)).toBeTruthy();
+
+    await waitFor(() => {
+      expect(mockGenerateToken).toHaveBeenCalled();
+      fakeQrReaderScan(ScannablePopToken.encodePopToken({ pop_token: mockPublicKey2.valueOf() }));
+      fakeQrReaderScan(ScannablePopToken.encodePopToken({ pop_token: mockPublicKey3.valueOf() }));
+    });
+
+    expect(getByText(/Number of scanned attendees: 0/)).toBeTruthy();
+  });
 });

--- a/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
+++ b/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
@@ -241,12 +241,12 @@ describe('RollCallOpened', () => {
     expect(getByText(`${STRINGS.roll_call_scan_counter}: 0`)).toBeTruthy();
 
     await waitFor(() => {
-      expect(mockGenerateToken).toHaveBeenCalled();
       fakeQrReaderScan(ScannablePopToken.encodePopToken({ pop_token: mockPublicKey2.valueOf() }));
       fakeQrReaderScan(ScannablePopToken.encodePopToken({ pop_token: mockPublicKey3.valueOf() }));
+      expect(mockGenerateToken).toHaveBeenCalled();
     });
 
     // TODO: fix this test (why still 0?)
-    expect(getByText(`${STRINGS.roll_call_scan_counter}: 0`)).toBeTruthy();
+    expect(getByText(`${STRINGS.roll_call_scan_counter}: 2`)).toBeTruthy();
   });
 });

--- a/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
+++ b/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
@@ -246,7 +246,6 @@ describe('RollCallOpened', () => {
       expect(mockGenerateToken).toHaveBeenCalled();
     });
 
-    // TODO: fix this test (why still 0?)
     expect(getByText(`${STRINGS.roll_call_scan_counter}: 2`)).toBeTruthy();
   });
 });

--- a/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
+++ b/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
@@ -236,9 +236,10 @@ describe('RollCallOpened', () => {
   it('shows the correct number of attendees', async () => {
     const mockAttendeePopTokens = [mockPopToken.publicKey.valueOf()];
 
-    const { getByText } = renderRollCallOpened(mockAttendeePopTokens);
+    const { toJSON } = renderRollCallOpened(mockAttendeePopTokens);
 
-    expect(getByText(`${STRINGS.roll_call_scan_counter}: 0`)).toBeTruthy();
+    // counter should be at 0
+    expect(toJSON()).toMatchSnapshot();
 
     await waitFor(() => {
       fakeQrReaderScan(ScannablePopToken.encodePopToken({ pop_token: mockPublicKey2.valueOf() }));
@@ -246,6 +247,7 @@ describe('RollCallOpened', () => {
       expect(mockGenerateToken).toHaveBeenCalled();
     });
 
-    expect(getByText(`${STRINGS.roll_call_scan_counter}: 2`)).toBeTruthy();
+    // counter should be at 2
+    expect(toJSON()).toMatchSnapshot();
   });
 });

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallScanner.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallScanner.test.tsx.snap
@@ -535,6 +535,9 @@ exports[`RollCallOpened renders correctly when no scan 1`] = `
                                               {
                                                 "color": "#3742fa",
                                               },
+                                              {
+                                                "textAlign": "center",
+                                              },
                                             ]
                                           }
                                         >
@@ -543,6 +546,39 @@ exports[`RollCallOpened renders correctly when no scan 1`] = `
                                       </View>
                                     </RNGestureHandlerButton>
                                   </View>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "backgroundColor": "#fff",
+                                        "borderRadius": 8,
+                                        "padding": 8,
+                                      },
+                                      {
+                                        "marginTop": 10,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <Text
+                                    style={
+                                      [
+                                        {
+                                          "color": "#000",
+                                          "fontSize": 20,
+                                          "lineHeight": 26,
+                                          "textAlign": "left",
+                                        },
+                                        {
+                                          "color": "#3742fa",
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    Number of scanned attendees: 
+                                    -1
+                                  </Text>
                                 </View>
                               </View>
                             </View>
@@ -1167,6 +1203,9 @@ exports[`RollCallOpened renders correctly when scanning attendees 1`] = `
                                               {
                                                 "color": "#3742fa",
                                               },
+                                              {
+                                                "textAlign": "center",
+                                              },
                                             ]
                                           }
                                         >
@@ -1175,6 +1214,39 @@ exports[`RollCallOpened renders correctly when scanning attendees 1`] = `
                                       </View>
                                     </RNGestureHandlerButton>
                                   </View>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "backgroundColor": "#fff",
+                                        "borderRadius": 8,
+                                        "padding": 8,
+                                      },
+                                      {
+                                        "marginTop": 10,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <Text
+                                    style={
+                                      [
+                                        {
+                                          "color": "#000",
+                                          "fontSize": 20,
+                                          "lineHeight": 26,
+                                          "textAlign": "left",
+                                        },
+                                        {
+                                          "color": "#3742fa",
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    Number of scanned attendees: 
+                                    -1
+                                  </Text>
                                 </View>
                               </View>
                             </View>

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallScanner.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallScanner.test.tsx.snap
@@ -1333,3 +1333,1337 @@ exports[`RollCallOpened renders correctly when scanning attendees 1`] = `
   </RNCSafeAreaProvider>
 </View>
 `;
+
+exports[`RollCallOpened shows the correct number of attendees 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <RNCSafeAreaProvider
+    onInsetsChange={[Function]}
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "rgb(242, 242, 242)",
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          {
+            "zIndex": 1,
+          }
+        }
+      >
+        <View
+          accessibilityElementsHidden={false}
+          importantForAccessibility="auto"
+          onLayout={[Function]}
+          pointerEvents="box-none"
+          style={null}
+        >
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 0,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "backgroundColor": "rgb(255, 255, 255)",
+                  "borderBottomColor": "rgb(216, 216, 216)",
+                  "flex": 1,
+                  "shadowColor": "rgb(216, 216, 216)",
+                  "shadowOffset": {
+                    "height": 0.5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.85,
+                  "shadowRadius": 0,
+                }
+              }
+            />
+          </View>
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "height": 44,
+                "maxHeight": undefined,
+                "minHeight": undefined,
+                "opacity": undefined,
+                "transform": undefined,
+              }
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                {
+                  "height": 0,
+                }
+              }
+            />
+            <View
+              pointerEvents="box-none"
+              style={
+                {
+                  "alignItems": "stretch",
+                  "flex": 1,
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginStart": 0,
+                    "opacity": 1,
+                  }
+                }
+              >
+                <View
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  testID="roll_call_open_stop_scanning"
+                >
+                  <RNGestureHandlerButton
+                    collapsable={false}
+                    delayLongPress={600}
+                    enabled={true}
+                    exclusive={true}
+                    handlerTag={37}
+                    handlerType="NativeViewGestureHandler"
+                    onGestureEvent={[Function]}
+                    onGestureHandlerEvent={[Function]}
+                    onGestureHandlerStateChange={[Function]}
+                    onHandlerStateChange={[Function]}
+                    rippleColor={0}
+                    touchSoundDisabled={false}
+                  >
+                    <View
+                      accessible={true}
+                      collapsable={false}
+                      style={
+                        {
+                          "opacity": 1,
+                        }
+                      }
+                    >
+                      <View>
+                        {"name":"ios-arrow-back","size":25,"color":"#8E8E8E"}
+                      </View>
+                    </View>
+                  </RNGestureHandlerButton>
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "justifyContent": "center",
+                    "marginHorizontal": 16,
+                    "maxWidth": 590,
+                    "opacity": 1,
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="header"
+                  aria-level="1"
+                  collapsable={false}
+                  numberOfLines={1}
+                  onLayout={[Function]}
+                  style={
+                    {
+                      "color": "rgb(28, 28, 30)",
+                      "fontSize": 17,
+                      "fontWeight": "600",
+                    }
+                  }
+                >
+                  MockScreen
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-end",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginEnd": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+      <RNSScreenContainer
+        onLayout={[Function]}
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <RNSScreen
+          activityState={2}
+          collapsable={false}
+          forwardedRef={[Function]}
+          gestureResponseDistance={
+            {
+              "bottom": -1,
+              "end": -1,
+              "start": -1,
+              "top": -1,
+            }
+          }
+          pointerEvents="box-none"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              {
+                "opacity": 1,
+              }
+            }
+          />
+          <View
+            accessibilityElementsHidden={false}
+            closing={false}
+            gestureVelocityImpact={0.3}
+            importantForAccessibility="auto"
+            onClose={[Function]}
+            onGestureBegin={[Function]}
+            onGestureCanceled={[Function]}
+            onGestureEnd={[Function]}
+            onOpen={[Function]}
+            onTransition={[Function]}
+            pointerEvents="box-none"
+            style={
+              [
+                {
+                  "display": "flex",
+                  "overflow": undefined,
+                },
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+              ]
+            }
+            transitionSpec={
+              {
+                "close": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+                "open": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                forwardedRef={[Function]}
+                handlerTag={38}
+                handlerType="PanGestureHandler"
+                needsOffscreenAlphaCompositing={false}
+                onGestureHandlerEvent={[Function]}
+                onGestureHandlerStateChange={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "transform": [
+                      {
+                        "translateX": 0,
+                      },
+                      {
+                        "translateX": 0,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  pointerEvents="box-none"
+                  style={
+                    [
+                      {
+                        "flex": 1,
+                        "overflow": "hidden",
+                      },
+                      [
+                        {
+                          "backgroundColor": "rgb(242, 242, 242)",
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                        "flexDirection": "column-reverse",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          {
+                            "flex": 1,
+                            "overflow": "hidden",
+                          }
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "bottom": 0,
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "zIndex": 0,
+                            }
+                          }
+                        >
+                          <View />
+                        </View>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                              "flexDirection": "column",
+                              "margin": 16,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              {
+                                "bottom": 0,
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "flex": 1,
+                                  "justifyContent": "space-between",
+                                  "marginVertical": 16,
+                                }
+                              }
+                            >
+                              <View />
+                              <View
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "opacity": 0.5,
+                                  }
+                                }
+                              >
+                                <RNSVGSvgView
+                                  align="xMidYMid"
+                                  bbHeight="300"
+                                  bbWidth="300"
+                                  focusable={false}
+                                  height={300}
+                                  meetOrSlice={0}
+                                  minX={0}
+                                  minY={0}
+                                  style={
+                                    [
+                                      {
+                                        "backgroundColor": "transparent",
+                                        "borderWidth": 0,
+                                      },
+                                      {
+                                        "flex": 0,
+                                        "height": 300,
+                                        "width": 300,
+                                      },
+                                    ]
+                                  }
+                                  vbHeight={494}
+                                  vbWidth={494}
+                                  width={300}
+                                >
+                                  <RNSVGGroup>
+                                    <RNSVGPath
+                                      d="M392.4 101.2h-22.398v22.398H392.4V101.2Zm44.801-44.801h-112v112h112v-112Zm-22.398 89.602h-67.199V78.802h67.199v67.199Zm-313.6-22.398h22.398v-22.398h-22.398v22.398ZM56.402 168.4h112v-112h-112v112Zm22.402-89.598h67.199v67.199H78.804V78.802Zm313.6 291.2h-22.398V392.4h22.398v-22.398Zm44.801-44.801h-112v112h112v-112Zm-22.398 89.602h-67.199v-67.199h67.199v67.199Zm-156.8-291.2h22.398v-22.398h22.398V78.807h-22.398V56.409h-67.199v22.398h44.801v22.398h-22.398v44.801h22.398v-22.403Zm-22.398 22.398h-22.398v22.398h22.398v-22.398Zm-44.801-22.398v22.398h22.398v-22.398h-22.398Zm0-22.402h22.398V78.803h-22.398v22.398Zm-44.801 112h-22.398v22.398h22.398v-22.398Zm89.602-22.398v22.398h67.199v-22.398H280.41v-44.801h-22.398v44.801h-22.403Zm-22.402-22.402h-22.398v44.801h22.398v-44.801Zm-44.801 22.402h-22.398v22.398h22.398v-22.398Zm-89.598 0v22.398h44.801v-22.398H78.808Zm112 44.801v-22.398H168.41v22.398h22.398Zm-44.801 22.398h22.398v-22.398h-22.398v22.398Zm-89.602-22.398h22.398v-22.398H56.405v22.398Zm0 22.398V280.4h22.398v-22.398H56.405ZM78.807 280.4v22.398h22.398V280.4H78.807Zm-22.402 44.801v44.801h22.398v-22.398h22.398v-22.398l-44.796-.005Zm44.801 44.801h44.801v-22.398h-44.801v22.398Zm246.4-112v-22.398h-22.398v22.398h22.398Zm-156.8 112h-22.398V392.4h22.398v-22.398ZM168.404 392.4h-112v44.801h22.398v-22.398H101.2v22.398h22.398v-22.398h22.398v22.398h67.199v-22.398h-44.801l.01-22.403Zm89.602 44.801v-22.398h-22.398v22.398h22.398Zm22.398 0h22.398v-22.398h-22.398v22.398Zm0-156.8h44.801v-22.398h-22.398v-22.398h-22.398v22.398h-22.398v67.199h44.801v-22.398h-22.398l-.01-22.403Zm-67.199 134.4h22.398v-22.398h-22.398v22.398Zm-44.801-89.602h-22.398v22.398h44.801v-44.801h-22.398l-.005 22.403ZM146.006 258h-22.398v-22.398H101.21v44.801h22.398v22.398H101.21v22.398h44.801L146.006 258Zm89.602 112v22.398h22.398V370h22.398v22.398h22.398v-44.801h-67.199v-44.801h-22.398v67.199l22.403.005Zm-67.203-89.602h22.398v22.398h22.398v-22.398h22.398V258H168.4l.005 22.398Zm44.801-44.797h22.398v-22.398h-22.398v22.398Zm22.402 0v22.398h22.398v-22.398h-22.398Zm89.598 0v-22.398h-22.398v22.398h22.398Zm22.402-44.801H325.21v22.398h22.398V190.8Zm22.398 0v44.801h22.398V190.8h-22.398Zm0 89.598v22.398h22.398v-22.398h22.398V258H437.2v-44.801h-22.398v22.398h-22.398v22.398h-44.801v22.398l22.403.005ZM325.205 302.8h22.398v-22.398h-22.398V302.8ZM414.807.4v22.398h56v56h22.398V.4h-78.398Zm-392 22.402h56V.404H.409v78.398h22.398v-56Zm0 392H.409V493.2h78.398v-22.398h-56v-56Zm448 56h-56V493.2h78.398v-78.398h-22.398v56Zm-33.602-168v-22.398h-22.398v22.398h22.398Z"
+                                      fill={
+                                        {
+                                          "payload": 4294967295,
+                                          "type": 0,
+                                        }
+                                      }
+                                      propList={
+                                        [
+                                          "fill",
+                                        ]
+                                      }
+                                    />
+                                  </RNSVGGroup>
+                                </RNSVGSvgView>
+                              </View>
+                              <View
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "backgroundColor": "#fff",
+                                      "borderColor": "#2196F3",
+                                      "borderRadius": 8,
+                                      "borderWidth": 4,
+                                      "padding": 8,
+                                    }
+                                  }
+                                >
+                                  <View
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    testID="roll_call_open_add_manually"
+                                  >
+                                    <RNGestureHandlerButton
+                                      collapsable={false}
+                                      delayLongPress={600}
+                                      enabled={true}
+                                      exclusive={true}
+                                      handlerTag={39}
+                                      handlerType="NativeViewGestureHandler"
+                                      onGestureEvent={[Function]}
+                                      onGestureHandlerEvent={[Function]}
+                                      onGestureHandlerStateChange={[Function]}
+                                      onHandlerStateChange={[Function]}
+                                      rippleColor={0}
+                                      touchSoundDisabled={false}
+                                    >
+                                      <View
+                                        accessible={true}
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "opacity": 1,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "color": "#000",
+                                                "fontSize": 20,
+                                                "lineHeight": 26,
+                                                "textAlign": "left",
+                                              },
+                                              {
+                                                "color": "#3742fa",
+                                              },
+                                              {
+                                                "textAlign": "center",
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Enter Manually
+                                        </Text>
+                                      </View>
+                                    </RNGestureHandlerButton>
+                                  </View>
+                                </View>
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "flex-start",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#fff",
+                                      "marginTop": 16,
+                                      "padding": 8,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    style={
+                                      {
+                                        "color": "#000",
+                                        "fontSize": 20,
+                                        "lineHeight": 26,
+                                        "textAlign": "left",
+                                      }
+                                    }
+                                  >
+                                    Scanned attendees
+                                    : 
+                                    0
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                          <View
+                            style={
+                              {
+                                "flexDirection": "column",
+                              }
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "alignSelf": "flex-end",
+                                  "backgroundColor": "#fff",
+                                  "borderRadius": 8,
+                                  "padding": 8,
+                                }
+                              }
+                            >
+                              <View
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                              >
+                                <RNGestureHandlerButton
+                                  collapsable={false}
+                                  delayLongPress={600}
+                                  enabled={true}
+                                  exclusive={true}
+                                  handlerTag={40}
+                                  handlerType="NativeViewGestureHandler"
+                                  onGestureEvent={[Function]}
+                                  onGestureHandlerEvent={[Function]}
+                                  onGestureHandlerStateChange={[Function]}
+                                  onHandlerStateChange={[Function]}
+                                  rippleColor={0}
+                                  touchSoundDisabled={false}
+                                >
+                                  <View
+                                    accessible={true}
+                                    collapsable={false}
+                                    style={
+                                      {
+                                        "alignSelf": "flex-end",
+                                        "marginLeft": "auto",
+                                        "opacity": 1,
+                                      }
+                                    }
+                                  >
+                                    <View>
+                                      {"name":"ios-camera-reverse","size":25,"color":"#3742fa"}
+                                    </View>
+                                  </View>
+                                </RNGestureHandlerButton>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                      </View>
+                      <Modal
+                        hardwareAccelerated={false}
+                        onRequestClose={[Function]}
+                        transparent={true}
+                        visible={false}
+                      />
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RNSScreen>
+      </RNSScreenContainer>
+    </View>
+  </RNCSafeAreaProvider>
+</View>
+`;
+
+exports[`RollCallOpened shows the correct number of attendees 2`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <RNCSafeAreaProvider
+    onInsetsChange={[Function]}
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "rgb(242, 242, 242)",
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          {
+            "zIndex": 1,
+          }
+        }
+      >
+        <View
+          accessibilityElementsHidden={false}
+          importantForAccessibility="auto"
+          onLayout={[Function]}
+          pointerEvents="box-none"
+          style={null}
+        >
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 0,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "backgroundColor": "rgb(255, 255, 255)",
+                  "borderBottomColor": "rgb(216, 216, 216)",
+                  "flex": 1,
+                  "shadowColor": "rgb(216, 216, 216)",
+                  "shadowOffset": {
+                    "height": 0.5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.85,
+                  "shadowRadius": 0,
+                }
+              }
+            />
+          </View>
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "height": 44,
+                "maxHeight": undefined,
+                "minHeight": undefined,
+                "opacity": undefined,
+                "transform": undefined,
+              }
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                {
+                  "height": 0,
+                }
+              }
+            />
+            <View
+              pointerEvents="box-none"
+              style={
+                {
+                  "alignItems": "stretch",
+                  "flex": 1,
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginStart": 0,
+                    "opacity": 1,
+                  }
+                }
+              >
+                <View
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  testID="roll_call_open_stop_scanning"
+                >
+                  <RNGestureHandlerButton
+                    collapsable={false}
+                    delayLongPress={600}
+                    enabled={true}
+                    exclusive={true}
+                    handlerTag={37}
+                    handlerType="NativeViewGestureHandler"
+                    onGestureEvent={[Function]}
+                    onGestureHandlerEvent={[Function]}
+                    onGestureHandlerStateChange={[Function]}
+                    onHandlerStateChange={[Function]}
+                    rippleColor={0}
+                    touchSoundDisabled={false}
+                  >
+                    <View
+                      accessible={true}
+                      collapsable={false}
+                      style={
+                        {
+                          "opacity": 1,
+                        }
+                      }
+                    >
+                      <View>
+                        {"name":"ios-arrow-back","size":25,"color":"#8E8E8E"}
+                      </View>
+                    </View>
+                  </RNGestureHandlerButton>
+                </View>
+              </View>
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "justifyContent": "center",
+                    "marginHorizontal": 16,
+                    "maxWidth": 590,
+                    "opacity": 1,
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="header"
+                  aria-level="1"
+                  collapsable={false}
+                  numberOfLines={1}
+                  onLayout={[Function]}
+                  style={
+                    {
+                      "color": "rgb(28, 28, 30)",
+                      "fontSize": 17,
+                      "fontWeight": "600",
+                    }
+                  }
+                >
+                  MockScreen
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-end",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginEnd": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+      <RNSScreenContainer
+        onLayout={[Function]}
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <RNSScreen
+          activityState={2}
+          collapsable={false}
+          forwardedRef={[Function]}
+          gestureResponseDistance={
+            {
+              "bottom": -1,
+              "end": -1,
+              "start": -1,
+              "top": -1,
+            }
+          }
+          pointerEvents="box-none"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              {
+                "opacity": 1,
+              }
+            }
+          />
+          <View
+            accessibilityElementsHidden={false}
+            closing={false}
+            gestureVelocityImpact={0.3}
+            importantForAccessibility="auto"
+            onClose={[Function]}
+            onGestureBegin={[Function]}
+            onGestureCanceled={[Function]}
+            onGestureEnd={[Function]}
+            onOpen={[Function]}
+            onTransition={[Function]}
+            pointerEvents="box-none"
+            style={
+              [
+                {
+                  "display": "flex",
+                  "overflow": undefined,
+                },
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+              ]
+            }
+            transitionSpec={
+              {
+                "close": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+                "open": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                forwardedRef={[Function]}
+                handlerTag={38}
+                handlerType="PanGestureHandler"
+                needsOffscreenAlphaCompositing={false}
+                onGestureHandlerEvent={[Function]}
+                onGestureHandlerStateChange={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "transform": [
+                      {
+                        "translateX": 0,
+                      },
+                      {
+                        "translateX": 0,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  pointerEvents="box-none"
+                  style={
+                    [
+                      {
+                        "flex": 1,
+                        "overflow": "hidden",
+                      },
+                      [
+                        {
+                          "backgroundColor": "rgb(242, 242, 242)",
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                        "flexDirection": "column-reverse",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          {
+                            "flex": 1,
+                            "overflow": "hidden",
+                          }
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "bottom": 0,
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                              "zIndex": 0,
+                            }
+                          }
+                        >
+                          <View />
+                        </View>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                              "flexDirection": "column",
+                              "margin": 16,
+                            }
+                          }
+                        >
+                          <View
+                            style={
+                              {
+                                "bottom": 0,
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "flex": 1,
+                                  "justifyContent": "space-between",
+                                  "marginVertical": 16,
+                                }
+                              }
+                            >
+                              <View />
+                              <View
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "opacity": 0.5,
+                                  }
+                                }
+                              >
+                                <RNSVGSvgView
+                                  align="xMidYMid"
+                                  bbHeight="300"
+                                  bbWidth="300"
+                                  focusable={false}
+                                  height={300}
+                                  meetOrSlice={0}
+                                  minX={0}
+                                  minY={0}
+                                  style={
+                                    [
+                                      {
+                                        "backgroundColor": "transparent",
+                                        "borderWidth": 0,
+                                      },
+                                      {
+                                        "flex": 0,
+                                        "height": 300,
+                                        "width": 300,
+                                      },
+                                    ]
+                                  }
+                                  vbHeight={494}
+                                  vbWidth={494}
+                                  width={300}
+                                >
+                                  <RNSVGGroup>
+                                    <RNSVGPath
+                                      d="M392.4 101.2h-22.398v22.398H392.4V101.2Zm44.801-44.801h-112v112h112v-112Zm-22.398 89.602h-67.199V78.802h67.199v67.199Zm-313.6-22.398h22.398v-22.398h-22.398v22.398ZM56.402 168.4h112v-112h-112v112Zm22.402-89.598h67.199v67.199H78.804V78.802Zm313.6 291.2h-22.398V392.4h22.398v-22.398Zm44.801-44.801h-112v112h112v-112Zm-22.398 89.602h-67.199v-67.199h67.199v67.199Zm-156.8-291.2h22.398v-22.398h22.398V78.807h-22.398V56.409h-67.199v22.398h44.801v22.398h-22.398v44.801h22.398v-22.403Zm-22.398 22.398h-22.398v22.398h22.398v-22.398Zm-44.801-22.398v22.398h22.398v-22.398h-22.398Zm0-22.402h22.398V78.803h-22.398v22.398Zm-44.801 112h-22.398v22.398h22.398v-22.398Zm89.602-22.398v22.398h67.199v-22.398H280.41v-44.801h-22.398v44.801h-22.403Zm-22.402-22.402h-22.398v44.801h22.398v-44.801Zm-44.801 22.402h-22.398v22.398h22.398v-22.398Zm-89.598 0v22.398h44.801v-22.398H78.808Zm112 44.801v-22.398H168.41v22.398h22.398Zm-44.801 22.398h22.398v-22.398h-22.398v22.398Zm-89.602-22.398h22.398v-22.398H56.405v22.398Zm0 22.398V280.4h22.398v-22.398H56.405ZM78.807 280.4v22.398h22.398V280.4H78.807Zm-22.402 44.801v44.801h22.398v-22.398h22.398v-22.398l-44.796-.005Zm44.801 44.801h44.801v-22.398h-44.801v22.398Zm246.4-112v-22.398h-22.398v22.398h22.398Zm-156.8 112h-22.398V392.4h22.398v-22.398ZM168.404 392.4h-112v44.801h22.398v-22.398H101.2v22.398h22.398v-22.398h22.398v22.398h67.199v-22.398h-44.801l.01-22.403Zm89.602 44.801v-22.398h-22.398v22.398h22.398Zm22.398 0h22.398v-22.398h-22.398v22.398Zm0-156.8h44.801v-22.398h-22.398v-22.398h-22.398v22.398h-22.398v67.199h44.801v-22.398h-22.398l-.01-22.403Zm-67.199 134.4h22.398v-22.398h-22.398v22.398Zm-44.801-89.602h-22.398v22.398h44.801v-44.801h-22.398l-.005 22.403ZM146.006 258h-22.398v-22.398H101.21v44.801h22.398v22.398H101.21v22.398h44.801L146.006 258Zm89.602 112v22.398h22.398V370h22.398v22.398h22.398v-44.801h-67.199v-44.801h-22.398v67.199l22.403.005Zm-67.203-89.602h22.398v22.398h22.398v-22.398h22.398V258H168.4l.005 22.398Zm44.801-44.797h22.398v-22.398h-22.398v22.398Zm22.402 0v22.398h22.398v-22.398h-22.398Zm89.598 0v-22.398h-22.398v22.398h22.398Zm22.402-44.801H325.21v22.398h22.398V190.8Zm22.398 0v44.801h22.398V190.8h-22.398Zm0 89.598v22.398h22.398v-22.398h22.398V258H437.2v-44.801h-22.398v22.398h-22.398v22.398h-44.801v22.398l22.403.005ZM325.205 302.8h22.398v-22.398h-22.398V302.8ZM414.807.4v22.398h56v56h22.398V.4h-78.398Zm-392 22.402h56V.404H.409v78.398h22.398v-56Zm0 392H.409V493.2h78.398v-22.398h-56v-56Zm448 56h-56V493.2h78.398v-78.398h-22.398v56Zm-33.602-168v-22.398h-22.398v22.398h22.398Z"
+                                      fill={
+                                        {
+                                          "payload": 4294967295,
+                                          "type": 0,
+                                        }
+                                      }
+                                      propList={
+                                        [
+                                          "fill",
+                                        ]
+                                      }
+                                    />
+                                  </RNSVGGroup>
+                                </RNSVGSvgView>
+                              </View>
+                              <View
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "backgroundColor": "#fff",
+                                      "borderColor": "#2196F3",
+                                      "borderRadius": 8,
+                                      "borderWidth": 4,
+                                      "padding": 8,
+                                    }
+                                  }
+                                >
+                                  <View
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    testID="roll_call_open_add_manually"
+                                  >
+                                    <RNGestureHandlerButton
+                                      collapsable={false}
+                                      delayLongPress={600}
+                                      enabled={true}
+                                      exclusive={true}
+                                      handlerTag={39}
+                                      handlerType="NativeViewGestureHandler"
+                                      onGestureEvent={[Function]}
+                                      onGestureHandlerEvent={[Function]}
+                                      onGestureHandlerStateChange={[Function]}
+                                      onHandlerStateChange={[Function]}
+                                      rippleColor={0}
+                                      touchSoundDisabled={false}
+                                    >
+                                      <View
+                                        accessible={true}
+                                        collapsable={false}
+                                        style={
+                                          {
+                                            "opacity": 1,
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          style={
+                                            [
+                                              {
+                                                "color": "#000",
+                                                "fontSize": 20,
+                                                "lineHeight": 26,
+                                                "textAlign": "left",
+                                              },
+                                              {
+                                                "color": "#3742fa",
+                                              },
+                                              {
+                                                "textAlign": "center",
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Enter Manually
+                                        </Text>
+                                      </View>
+                                    </RNGestureHandlerButton>
+                                  </View>
+                                </View>
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "flex-start",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#fff",
+                                      "marginTop": 16,
+                                      "padding": 8,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    style={
+                                      {
+                                        "color": "#000",
+                                        "fontSize": 20,
+                                        "lineHeight": 26,
+                                        "textAlign": "left",
+                                      }
+                                    }
+                                  >
+                                    Scanned attendees
+                                    : 
+                                    2
+                                  </Text>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                          <View
+                            style={
+                              {
+                                "flexDirection": "column",
+                              }
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "alignSelf": "flex-end",
+                                  "backgroundColor": "#fff",
+                                  "borderRadius": 8,
+                                  "padding": 8,
+                                }
+                              }
+                            >
+                              <View
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                              >
+                                <RNGestureHandlerButton
+                                  collapsable={false}
+                                  delayLongPress={600}
+                                  enabled={true}
+                                  exclusive={true}
+                                  handlerTag={40}
+                                  handlerType="NativeViewGestureHandler"
+                                  onGestureEvent={[Function]}
+                                  onGestureHandlerEvent={[Function]}
+                                  onGestureHandlerStateChange={[Function]}
+                                  onHandlerStateChange={[Function]}
+                                  rippleColor={0}
+                                  touchSoundDisabled={false}
+                                >
+                                  <View
+                                    accessible={true}
+                                    collapsable={false}
+                                    style={
+                                      {
+                                        "alignSelf": "flex-end",
+                                        "marginLeft": "auto",
+                                        "opacity": 1,
+                                      }
+                                    }
+                                  >
+                                    <View>
+                                      {"name":"ios-camera-reverse","size":25,"color":"#3742fa"}
+                                    </View>
+                                  </View>
+                                </RNGestureHandlerButton>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                      </View>
+                      <Modal
+                        hardwareAccelerated={false}
+                        onRequestClose={[Function]}
+                        transparent={true}
+                        visible={false}
+                      />
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RNSScreen>
+      </RNSScreenContainer>
+    </View>
+  </RNCSafeAreaProvider>
+</View>
+`;

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallScanner.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallScanner.test.tsx.snap
@@ -484,7 +484,9 @@ exports[`RollCallOpened renders correctly when no scan 1`] = `
                                   style={
                                     {
                                       "backgroundColor": "#fff",
+                                      "borderColor": "#2196F3",
                                       "borderRadius": 8,
+                                      "borderWidth": 4,
                                       "padding": 8,
                                     }
                                   }
@@ -564,17 +566,12 @@ exports[`RollCallOpened renders correctly when no scan 1`] = `
                                 >
                                   <Text
                                     style={
-                                      [
-                                        {
-                                          "color": "#000",
-                                          "fontSize": 20,
-                                          "lineHeight": 26,
-                                          "textAlign": "left",
-                                        },
-                                        {
-                                          "color": "#3742fa",
-                                        },
-                                      ]
+                                      {
+                                        "color": "#000",
+                                        "fontSize": 20,
+                                        "lineHeight": 26,
+                                        "textAlign": "left",
+                                      }
                                     }
                                   >
                                     Number of scanned attendees
@@ -1154,7 +1151,9 @@ exports[`RollCallOpened renders correctly when scanning attendees 1`] = `
                                   style={
                                     {
                                       "backgroundColor": "#fff",
+                                      "borderColor": "#2196F3",
                                       "borderRadius": 8,
+                                      "borderWidth": 4,
                                       "padding": 8,
                                     }
                                   }
@@ -1234,17 +1233,12 @@ exports[`RollCallOpened renders correctly when scanning attendees 1`] = `
                                 >
                                   <Text
                                     style={
-                                      [
-                                        {
-                                          "color": "#000",
-                                          "fontSize": 20,
-                                          "lineHeight": 26,
-                                          "textAlign": "left",
-                                        },
-                                        {
-                                          "color": "#3742fa",
-                                        },
-                                      ]
+                                      {
+                                        "color": "#000",
+                                        "fontSize": 20,
+                                        "lineHeight": 26,
+                                        "textAlign": "left",
+                                      }
                                     }
                                   >
                                     Number of scanned attendees

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallScanner.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallScanner.test.tsx.snap
@@ -414,7 +414,6 @@ exports[`RollCallOpened renders correctly when no scan 1`] = `
                             <View
                               style={
                                 {
-                                  "alignItems": "center",
                                   "flex": 1,
                                   "justifyContent": "space-between",
                                   "marginVertical": 16,
@@ -425,6 +424,7 @@ exports[`RollCallOpened renders correctly when no scan 1`] = `
                               <View
                                 style={
                                   {
+                                    "alignItems": "center",
                                     "opacity": 0.5,
                                   }
                                 }
@@ -474,7 +474,11 @@ exports[`RollCallOpened renders correctly when no scan 1`] = `
                                 </RNSVGSvgView>
                               </View>
                               <View
-                                style={{}}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                  }
+                                }
                               >
                                 <View
                                   style={
@@ -549,16 +553,13 @@ exports[`RollCallOpened renders correctly when no scan 1`] = `
                                 </View>
                                 <View
                                   style={
-                                    [
-                                      {
-                                        "backgroundColor": "#fff",
-                                        "borderRadius": 8,
-                                        "padding": 8,
-                                      },
-                                      {
-                                        "marginTop": 16,
-                                      },
-                                    ]
+                                    {
+                                      "alignItems": "flex-start",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#fff",
+                                      "marginTop": 16,
+                                      "padding": 8,
+                                    }
                                   }
                                 >
                                   <Text
@@ -1083,7 +1084,6 @@ exports[`RollCallOpened renders correctly when scanning attendees 1`] = `
                             <View
                               style={
                                 {
-                                  "alignItems": "center",
                                   "flex": 1,
                                   "justifyContent": "space-between",
                                   "marginVertical": 16,
@@ -1094,6 +1094,7 @@ exports[`RollCallOpened renders correctly when scanning attendees 1`] = `
                               <View
                                 style={
                                   {
+                                    "alignItems": "center",
                                     "opacity": 0.5,
                                   }
                                 }
@@ -1143,7 +1144,11 @@ exports[`RollCallOpened renders correctly when scanning attendees 1`] = `
                                 </RNSVGSvgView>
                               </View>
                               <View
-                                style={{}}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                  }
+                                }
                               >
                                 <View
                                   style={
@@ -1218,16 +1223,13 @@ exports[`RollCallOpened renders correctly when scanning attendees 1`] = `
                                 </View>
                                 <View
                                   style={
-                                    [
-                                      {
-                                        "backgroundColor": "#fff",
-                                        "borderRadius": 8,
-                                        "padding": 8,
-                                      },
-                                      {
-                                        "marginTop": 16,
-                                      },
-                                    ]
+                                    {
+                                      "alignItems": "flex-start",
+                                      "alignSelf": "flex-start",
+                                      "backgroundColor": "#fff",
+                                      "marginTop": 16,
+                                      "padding": 8,
+                                    }
                                   }
                                 >
                                   <Text

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallScanner.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallScanner.test.tsx.snap
@@ -576,7 +576,8 @@ exports[`RollCallOpened renders correctly when no scan 1`] = `
                                       ]
                                     }
                                   >
-                                    Number of scanned attendees: 
+                                    Number of scanned attendees
+                                    : 
                                     -1
                                   </Text>
                                 </View>
@@ -1244,7 +1245,8 @@ exports[`RollCallOpened renders correctly when scanning attendees 1`] = `
                                       ]
                                     }
                                   >
-                                    Number of scanned attendees: 
+                                    Number of scanned attendees
+                                    : 
                                     -1
                                   </Text>
                                 </View>

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallScanner.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallScanner.test.tsx.snap
@@ -574,7 +574,7 @@ exports[`RollCallOpened renders correctly when no scan 1`] = `
                                       }
                                     }
                                   >
-                                    Number of scanned attendees
+                                    Scanned attendees
                                     : 
                                     -1
                                   </Text>
@@ -1241,7 +1241,7 @@ exports[`RollCallOpened renders correctly when scanning attendees 1`] = `
                                       }
                                     }
                                   >
-                                    Number of scanned attendees
+                                    Scanned attendees
                                     : 
                                     2
                                   </Text>

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallScanner.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/RollCallScanner.test.tsx.snap
@@ -556,7 +556,7 @@ exports[`RollCallOpened renders correctly when no scan 1`] = `
                                         "padding": 8,
                                       },
                                       {
-                                        "marginTop": 10,
+                                        "marginTop": 16,
                                       },
                                     ]
                                   }
@@ -1225,7 +1225,7 @@ exports[`RollCallOpened renders correctly when scanning attendees 1`] = `
                                         "padding": 8,
                                       },
                                       {
-                                        "marginTop": 10,
+                                        "marginTop": 16,
                                       },
                                     ]
                                   }
@@ -1247,7 +1247,7 @@ exports[`RollCallOpened renders correctly when scanning attendees 1`] = `
                                   >
                                     Number of scanned attendees
                                     : 
-                                    -1
+                                    2
                                   </Text>
                                 </View>
                               </View>

--- a/fe1-web/src/resources/strings.ts
+++ b/fe1-web/src/resources/strings.ts
@@ -330,6 +330,7 @@ namespace STRINGS {
   export const roll_call_scan_participant_twice = 'Participant already scanned';
   export const roll_call_scan_close = 'Close Roll-Call';
   export const roll_call_scan_close_confirmation = 'Do you confirm to close the roll-call ?';
+  export const roll_call_scan_counter = 'Number of scanned attendees';
 
   /* --- Roll-call manually add attendee manually Strings --- */
   export const roll_call_add_attendee_manually = 'Add an attendee manually';

--- a/fe1-web/src/resources/strings.ts
+++ b/fe1-web/src/resources/strings.ts
@@ -330,7 +330,7 @@ namespace STRINGS {
   export const roll_call_scan_participant_twice = 'Participant already scanned';
   export const roll_call_scan_close = 'Close Roll-Call';
   export const roll_call_scan_close_confirmation = 'Do you confirm to close the roll-call ?';
-  export const roll_call_scan_counter = 'Number of scanned attendees';
+  export const roll_call_scan_counter = 'Scanned attendees';
 
   /* --- Roll-call manually add attendee manually Strings --- */
   export const roll_call_add_attendee_manually = 'Add an attendee manually';


### PR DESCRIPTION
This modification makes it easier for the organizer to ensure that he has scanned everyone (when he knows how many people are attending the roll call). Visually it looks it like this:

![image](https://user-images.githubusercontent.com/82887324/226111429-18603b38-924a-4205-823f-e74c2ee173cd.png)

After each scan the counter is increased and shown on the screen. 