### PR TITLE
Add heartbeat get_messages_by_id Json support

### DIFF
--- a/be2-scala/src/main/resources/protocol/query/query.json
+++ b/be2-scala/src/main/resources/protocol/query/query.json
@@ -32,6 +32,12 @@
         },
         {
             "$ref": "method/catchup.json"
+        },
+        {
+            "$ref": "method/heartbeat.json"
+        },
+        {
+            "$ref": "method/get_messages_by_id.json"
         }
     ],
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/json/HighLevelProtocol.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/json/HighLevelProtocol.scala
@@ -8,9 +8,12 @@ import ch.epfl.pop.model.network.method.message.Message
 import ch.epfl.pop.model.objects._
 import spray.json._
 
-import scala.collection.immutable.ListMap
+import scala.collection.immutable.{HashMap, ListMap}
+import scala.collection.mutable
 
 object HighLevelProtocol extends DefaultJsonProtocol {
+
+  final private val PARAM_CHANNEL: String = "channel"
 
   // ----------------------------------- ENUM FORMATTERS ----------------------------------- //
   implicit object methodTypeFormat extends RootJsonFormat[MethodType] {
@@ -76,6 +79,46 @@ object HighLevelProtocol extends DefaultJsonProtocol {
     }
   }
 
+  implicit object ParamsWithMapFormat extends RootJsonFormat[ParamsWithMap] {
+
+    override def read(json: JsValue): ParamsWithMap = {
+      val map = mutable.HashMap[Channel, Set[Hash]]()
+      json.asJsObject.fields.foreach {
+        case (k: String, JsArray(v)) => map.put(Channel(k), v.map(_.convertTo[Hash]).toSet)
+        case _                       => throw new IllegalArgumentException(s"Unrecognizable value in $json")
+      }
+
+      new ParamsWithMap(HashMap.from(map))
+    }
+
+    override def write(obj: ParamsWithMap): JsValue = {
+      val map = mutable.HashMap[String, JsValue]()
+      obj.channelsToMessageIds.foreach {
+        case (channel, set) =>
+          map.put(channel.channel, set.toJson)
+      }
+
+      JsObject.apply(HashMap.from(map))
+    }
+  }
+
+  implicit object ParamsFormat extends RootJsonFormat[Params] {
+
+    override def read(json: JsValue): Params =
+      json.asJsObject.getFields(PARAM_CHANNEL) match {
+        case Seq(_) => ParamsWithChannelFormat.read(json)
+        // if no Seq can be retrieved, the json is of type ParamsWithMap or faulty
+        case _ => ParamsWithMapFormat.read(json)
+      }
+
+    override def write(obj: Params): JsValue =
+      obj match {
+        case paramsWithChannel: ParamsWithChannel => paramsWithChannel.toJson
+        case paramsWithMap: ParamsWithMap         => paramsWithMap.toJson
+      }
+
+  }
+
   implicit object BroadcastFormat extends RootJsonFormat[Broadcast] {
     override def read(json: JsValue): Broadcast = {
       val params: ParamsWithMessage = json.convertTo[ParamsWithChannel].asInstanceOf[ParamsWithMessage]
@@ -110,6 +153,20 @@ object HighLevelProtocol extends DefaultJsonProtocol {
     override def read(json: JsValue): Unsubscribe = Unsubscribe(json.convertTo[ParamsWithChannel].channel)
 
     override def write(obj: Unsubscribe): JsValue = obj.toJson(ParamsFormat.write)
+  }
+
+  implicit object HeartbeatFormat extends RootJsonFormat[Heartbeat] {
+    override def read(json: JsValue): Heartbeat =
+      Heartbeat(json.convertTo[ParamsWithMap].channelsToMessageIds)
+
+    override def write(obj: Heartbeat): JsValue = obj.toJson(ParamsWithMapFormat.write)
+  }
+
+  implicit object GetMessagesByIdFormat extends RootJsonFormat[GetMessagesById] {
+    override def read(json: JsValue): GetMessagesById =
+      GetMessagesById(json.convertTo[ParamsWithMap].channelsToMessageIds)
+
+    override def write(obj: GetMessagesById): JsValue = obj.toJson(ParamsWithMapFormat.write)
   }
 
   implicit val errorObjectFormat: JsonFormat[ErrorObject] = jsonFormat2(ErrorObject.apply)
@@ -155,12 +212,14 @@ object HighLevelProtocol extends DefaultJsonProtocol {
 
         JsonRpcRequest(version, method, params, id)
 
-      // Broadcast does not have an Id and should be treated separately
+      // Heartbeat, GetMessagesById and Broadcast do not have an Id and should be treated separately
       case Seq(JsString(version), methodJsString @ JsString(_), paramsJsObject @ JsObject(_)) =>
         val method: MethodType = methodJsString.convertTo[MethodType]
-        val params: Params = method match {
-          case MethodType.BROADCAST => paramsJsObject.convertTo[Broadcast]
-          case _                    => throw new IllegalArgumentException(s"Can't parse json value $json with unknown method ${method.toString}")
+        val params = method match {
+          case MethodType.HEARTBEAT          => paramsJsObject.convertTo[Heartbeat]
+          case MethodType.GET_MESSAGES_BY_ID => paramsJsObject.convertTo[GetMessagesById]
+          case MethodType.BROADCAST          => paramsJsObject.convertTo[Broadcast]
+          case _                             => throw new IllegalArgumentException(s"Can't parse json value $json with unknown method ${method.toString}")
         }
         JsonRpcRequest(version, method, params, None)
       case _ => throw new IllegalArgumentException(s"Can't parse json value $json to a JsonRpcRequest object")

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/MethodType.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/MethodType.scala
@@ -12,6 +12,9 @@ object MethodType extends Enumeration {
   val UNSUBSCRIBE: Value = MatchingValue("unsubscribe")
   val CATCHUP: Value = MatchingValue("catchup")
 
+  val HEARTBEAT: Value = MatchingValue("heartbeat")
+  val GET_MESSAGES_BY_ID: Value = MatchingValue("get_messages_by_id")
+
   def MatchingValue(v: String): Value with Matching = new Val(nextId, v) with Matching
 
   def unapply(s: String): Option[Value] = values.find(s == _.toString)

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Catchup.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Catchup.scala
@@ -5,7 +5,7 @@ import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.objects.Channel
 import spray.json._
 
-final case class Catchup(override val channel: Channel) extends Params(channel)
+final case class Catchup(override val channel: Channel) extends ParamsWithChannel(channel)
 
 object Catchup extends Parsable {
   def apply(channel: Channel): Catchup = {

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/GetMessagesById.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/GetMessagesById.scala
@@ -1,0 +1,16 @@
+package ch.epfl.pop.model.network.method
+
+import ch.epfl.pop.json.HighLevelProtocol._
+import ch.epfl.pop.model.network.Parsable
+import ch.epfl.pop.model.objects.{Channel, Hash}
+import spray.json._
+
+final case class GetMessagesById(override val channelsToMessageIds: Map[Channel, Set[Hash]]) extends ParamsWithMap(channelsToMessageIds: Map[Channel, Set[Hash]])
+
+object GetMessagesById extends Parsable {
+
+  def apply(channelsToMessageIds: Map[Channel, Set[Hash]]): GetMessagesById =
+    new GetMessagesById(channelsToMessageIds)
+
+  override def buildFromJson(payload: String): Any = payload.parseJson.asJsObject.convertTo[GetMessagesById]
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Heartbeat.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Heartbeat.scala
@@ -1,0 +1,16 @@
+package ch.epfl.pop.model.network.method
+
+import ch.epfl.pop.json.HighLevelProtocol._
+import ch.epfl.pop.model.network.Parsable
+import ch.epfl.pop.model.objects.{Channel, Hash}
+import spray.json._
+
+final case class Heartbeat(override val channelsToMessageIds: Map[Channel, Set[Hash]]) extends ParamsWithMap(channelsToMessageIds: Map[Channel, Set[Hash]])
+
+object Heartbeat extends Parsable {
+
+  def apply(channelsToMessageIds: Map[Channel, Set[Hash]]): Heartbeat =
+    new Heartbeat(channelsToMessageIds)
+
+  override def buildFromJson(payload: String): Any = payload.parseJson.asJsObject.convertTo[Heartbeat]
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Params.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Params.scala
@@ -2,6 +2,9 @@ package ch.epfl.pop.model.network.method
 
 import ch.epfl.pop.model.objects.Channel
 
-class Params(val channel: Channel) {
-  def hasMessage: Boolean = false
+abstract class Params {
+  // Default channel
+  val channel: Channel = Channel.ROOT_CHANNEL
+  def hasMessage: Boolean
+
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/ParamsWithChannel.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/ParamsWithChannel.scala
@@ -1,0 +1,7 @@
+package ch.epfl.pop.model.network.method
+
+import ch.epfl.pop.model.objects.Channel
+
+class ParamsWithChannel(override val channel: Channel) extends Params {
+  def hasMessage: Boolean = false
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/ParamsWithMap.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/ParamsWithMap.scala
@@ -1,0 +1,7 @@
+package ch.epfl.pop.model.network.method
+
+import ch.epfl.pop.model.objects.{Channel, Hash}
+
+class ParamsWithMap(val channelsToMessageIds: Map[Channel, Set[Hash]]) extends Params {
+  def hasMessage: Boolean = false
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/ParamsWithMessage.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/ParamsWithMessage.scala
@@ -3,6 +3,6 @@ package ch.epfl.pop.model.network.method
 import ch.epfl.pop.model.network.method.message.Message
 import ch.epfl.pop.model.objects.Channel
 
-class ParamsWithMessage(override val channel: Channel, val message: Message) extends Params(channel) {
+class ParamsWithMessage(override val channel: Channel, val message: Message) extends ParamsWithChannel(channel) {
   override def hasMessage: Boolean = true
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Subscribe.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Subscribe.scala
@@ -5,7 +5,7 @@ import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.objects.Channel
 import spray.json._
 
-final case class Subscribe(override val channel: Channel) extends Params(channel)
+final case class Subscribe(override val channel: Channel) extends ParamsWithChannel(channel)
 
 object Subscribe extends Parsable {
   def apply(channel: Channel): Subscribe = {

--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Unsubscribe.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/method/Unsubscribe.scala
@@ -5,7 +5,7 @@ import ch.epfl.pop.model.network.Parsable
 import ch.epfl.pop.model.objects.Channel
 import spray.json._
 
-final case class Unsubscribe(override val channel: Channel) extends Params(channel)
+final case class Unsubscribe(override val channel: Channel) extends ParamsWithChannel(channel)
 
 object Unsubscribe extends Parsable {
   def apply(channel: Channel): Unsubscribe = {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/network/JsonRpcRequestSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/network/JsonRpcRequestSuite.scala
@@ -3,7 +3,7 @@ package ch.epfl.pop.model.network
 import ch.epfl.pop.model.network.method.message.Message
 import ch.epfl.pop.model.network.method.message.data.lao.CreateLao
 import ch.epfl.pop.model.network.method.message.data.{ActionType, MessageData, ObjectType}
-import ch.epfl.pop.model.network.method.{Params, ParamsWithMessage}
+import ch.epfl.pop.model.network.method.{ParamsWithChannel, ParamsWithMessage}
 import ch.epfl.pop.model.objects._
 import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
 import org.scalatest.matchers.should.Matchers
@@ -16,7 +16,7 @@ class JsonRpcRequestSuite extends FunSuite with Matchers {
   private final val electionId: String = "defg"
   private final val channelEx: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + laoId)
   private final val channelElectionEx: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + laoId + Channel.CHANNEL_SEPARATOR + electionId)
-  private final val params: Params = new Params(channelEx)
+  private final val params: ParamsWithChannel = new ParamsWithChannel(channelEx)
   private final val paramsWithMessage: ParamsWithMessage = new ParamsWithMessage(channelEx, messageEx)
   private final val paramsWithMessage2: ParamsWithMessage = new ParamsWithMessage(channelElectionEx, messageEx)
   private final val rpc: String = "rpc"

--- a/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
+++ b/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
@@ -1,6 +1,6 @@
 package util.examples
 
-import ch.epfl.pop.model.network.method.{Params, ParamsWithMessage}
+import ch.epfl.pop.model.network.method.{ParamsWithChannel, ParamsWithMessage}
 import ch.epfl.pop.model.network.{JsonRpcRequest, MethodType}
 import ch.epfl.pop.model.objects.{Base64Data, Channel}
 import util.examples.Election.CastVoteElectionExamples._
@@ -25,7 +25,7 @@ object JsonRpcRequestExample {
   private final val id: Option[Int] = Some(0)
   private final val methodType: MethodType.MethodType = MethodType.PUBLISH
   private final val channel: Channel = Channel(Channel.ROOT_CHANNEL_PREFIX + "channel")
-  private final val paramsWithoutMessage: Params = new Params(channel)
+  private final val paramsWithoutMessage: ParamsWithChannel = new ParamsWithChannel(channel)
   private final val paramsWithMessage: ParamsWithMessage = new ParamsWithMessage(channel, MESSAGE_WORKING_WS_PAIR)
   private final val paramsWithFaultyIdMessage: ParamsWithMessage = new ParamsWithMessage(channel, MESSAGE_FAULTY_ID)
   private final val paramsWithFaultyWSMessage: ParamsWithMessage = new ParamsWithMessage(channel, MESSAGE_FAULTY_WS_PAIR)


### PR DESCRIPTION
This Pr does a couple things: 

1) Refactor our Params type to ParamsWithChannel and convert Params to an abstract class

The above is done so that JsonRpcType can accept heartbeat and get_messages_by_id, since they don't have a `channel` type.

2) Add ParamsWithMap which fits the new methods
3) Add the support to read and write the new methods jsons