### PR TITLE
Modifying the makefile of the go backend to disable CGO:

### DIFF
--- a/be1-go/Makefile
+++ b/be1-go/Makefile
@@ -7,6 +7,7 @@ shaFlag="popstellar.ShortSHA=$(shortsha)"
 
 .PHONY: test
 
+build: export CGO_ENABLED=0
 build: protocol
 	go build -ldflags="-X $(versionFlag) -X $(timeFlag) -X $(shaFlag)" -o pop ./cli
 	GOOS=linux GOARCH=amd64 go build -ldflags="-X $(versionFlag) -X $(timeFlag) -X $(shaFlag)" -o pop-linux-amd64-$(versionFile) ./cli


### PR DESCRIPTION
* disables importing of C into go file
* binary doesn't have external C dependencies
* avoiding library incompatibilities between ubuntu and debian systems