### PR TITLE
Prefix db keys

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/storage/Storage.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/storage/Storage.scala
@@ -2,6 +2,11 @@ package ch.epfl.pop.storage
 
 trait Storage {
 
+  /** List of prefix to the keys
+    */
+  final val CHANNEL_DATA_KEY = "ChannelData:"
+  final val DATA_KEY = "Data:"
+
   /** Optionally returns the value associated with a key
     *
     * @param key

--- a/be2-scala/src/main/scala/ch/epfl/pop/storage/Storage.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/storage/Storage.scala
@@ -23,6 +23,8 @@ trait Storage {
     */
   def write(keyValues: (String, String)*): Unit
 
+  def filterKeysByPrefix(prefix: String): Set[String]
+
   /** Removes a single element from the storage
     *
     * @param key

--- a/be2-scala/src/test/scala/ch/epfl/pop/storage/DbActorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/storage/DbActorSuite.scala
@@ -4,11 +4,11 @@ import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.pattern.AskableActorRef
 import akka.testkit.{ImplicitSender, TestKit}
 import ch.epfl.pop.model.network.method.message.Message
-import ch.epfl.pop.model.network.method.message.data.ActionType.{ActionType, CREATE}
 import ch.epfl.pop.model.network.method.message.data.{ActionType, ObjectType}
 import ch.epfl.pop.model.objects.Channel.ROOT_CHANNEL_PREFIX
 import ch.epfl.pop.model.objects._
 import ch.epfl.pop.pubsub.{AskPatternConstants, MessageRegistry, PubSubMediator}
+import ch.epfl.pop.storage.DbActor.GetAllChannels
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
@@ -26,7 +26,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
   final val MESSAGE: Message = MessageExample.MESSAGE_CREATELAO_WORKING
   val LAO_ID: Hash = Hash(Base64Data.encode("laoId"))
   val ELECTION_ID: Hash = Hash(Base64Data.encode("electionId"))
-  val ELECTION_NAME: String = s"${ROOT_CHANNEL_PREFIX}${LAO_ID.toString}/private/${ELECTION_ID.toString}"
+  val ELECTION_DATA_KEY: String = "Data:" + s"${ROOT_CHANNEL_PREFIX}${LAO_ID.toString}/private/${ELECTION_ID.toString}"
   val KEYPAIR: KeyPair = KeyPair()
 
   override def afterAll(): Unit = {
@@ -44,7 +44,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     storage.size should equal(0)
 
-    dbActor ! DbActor.CreateChannel(Channel(CHANNEL_NAME), ObjectType.LAO);
+    dbActor ! DbActor.CreateChannel(Channel(CHANNEL_NAME), ObjectType.LAO)
     sleep()
 
     expectMsg(DbActor.DbActorAck())
@@ -56,8 +56,8 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(2)
-    storage.elements(CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, MESSAGE.message_id :: Nil).toJsonString)
-    storage.elements(s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}") should equal(MESSAGE.toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, MESSAGE.message_id :: Nil).toJsonString)
+    storage.elements(storage.DATA_KEY + s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}") should equal(MESSAGE.toJsonString)
   }
 
   test("write can WRITE in a non-existing channel") {
@@ -72,8 +72,8 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(2)
-    storage.elements(CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, MESSAGE.message_id :: Nil).toJsonString)
-    storage.elements(s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}") should equal(MESSAGE.toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, MESSAGE.message_id :: Nil).toJsonString)
+    storage.elements(storage.DATA_KEY + s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}") should equal(MESSAGE.toJsonString)
   }
 
   test("write behaves normally for multiple WRITE requests") {
@@ -103,8 +103,8 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(2) // ChannelData for channel 1 + payload for message 1
-    storage.elements(channelName1) should equal(ChannelData(ObjectType.LAO, message1.message_id :: Nil).toJsonString)
-    storage.elements(s"$channelName1${Channel.DATA_SEPARATOR}${message1.message_id}") should equal(message1.toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + channelName1) should equal(ChannelData(ObjectType.LAO, message1.message_id :: Nil).toJsonString)
+    storage.elements(storage.DATA_KEY + s"$channelName1${Channel.DATA_SEPARATOR}${message1.message_id}") should equal(message1.toJsonString)
 
     // ------------------------- 2nd WRITE REQUEST ------------------------- //
 
@@ -114,10 +114,10 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(4) // ChannelData for channel 1 & 2 + payload for message 1 & 2
-    storage.elements(channelName1) should equal(ChannelData(ObjectType.LAO, message1.message_id :: Nil).toJsonString)
-    storage.elements(s"$channelName1${Channel.DATA_SEPARATOR}${message1.message_id}") should equal(message1.toJsonString)
-    storage.elements(channelName2) should equal(ChannelData(ObjectType.LAO, message2.message_id :: Nil).toJsonString)
-    storage.elements(s"$channelName2${Channel.DATA_SEPARATOR}${message2.message_id}") should equal(message2.toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + channelName1) should equal(ChannelData(ObjectType.LAO, message1.message_id :: Nil).toJsonString)
+    storage.elements(storage.DATA_KEY + s"$channelName1${Channel.DATA_SEPARATOR}${message1.message_id}") should equal(message1.toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + channelName2) should equal(ChannelData(ObjectType.LAO, message2.message_id :: Nil).toJsonString)
+    storage.elements(storage.DATA_KEY + s"$channelName2${Channel.DATA_SEPARATOR}${message2.message_id}") should equal(message2.toJsonString)
 
     // ------------------------- 3rd WRITE REQUEST ------------------------- //
 
@@ -127,11 +127,11 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(5) // ChannelData for channel 1 & 2 + payload for message 1 & 2 (on channel 1) & 2 (on channel 2)
-    storage.elements(channelName1) should equal(ChannelData(ObjectType.LAO, message2.message_id :: message1.message_id :: Nil).toJsonString)
-    storage.elements(s"$channelName1${Channel.DATA_SEPARATOR}${message1.message_id}") should equal(message1.toJsonString)
-    storage.elements(s"$channelName1${Channel.DATA_SEPARATOR}${message2.message_id}") should equal(message2.toJsonString)
-    storage.elements(channelName2) should equal(ChannelData(ObjectType.LAO, message2.message_id :: Nil).toJsonString)
-    storage.elements(s"$channelName2${Channel.DATA_SEPARATOR}${message2.message_id}") should equal(message2.toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + channelName1) should equal(ChannelData(ObjectType.LAO, message2.message_id :: message1.message_id :: Nil).toJsonString)
+    storage.elements(storage.DATA_KEY + s"$channelName1${Channel.DATA_SEPARATOR}${message1.message_id}") should equal(message1.toJsonString)
+    storage.elements(storage.DATA_KEY + s"$channelName1${Channel.DATA_SEPARATOR}${message2.message_id}") should equal(message2.toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + channelName2) should equal(ChannelData(ObjectType.LAO, message2.message_id :: Nil).toJsonString)
+    storage.elements(storage.DATA_KEY + s"$channelName2${Channel.DATA_SEPARATOR}${message2.message_id}") should equal(message2.toJsonString)
   }
 
   test("createChannel effectively creates a new channel") {
@@ -145,7 +145,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(1)
-    storage.elements(CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, Nil).toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, Nil).toJsonString)
   }
 
   test("createChannel does not overwrite channels on duplicates") {
@@ -159,13 +159,13 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(1)
-    storage.elements(CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, Nil).toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, Nil).toJsonString)
 
     dbActor ! DbActor.CreateChannel(Channel(CHANNEL_NAME), ObjectType.LAO);
     sleep()
 
     storage.size should equal(1)
-    storage.elements(CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, Nil).toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, Nil).toJsonString)
   }
 
   test("createElectionData effectively creates a new channel for the electionData") {
@@ -179,7 +179,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(1)
-    storage.elements(ELECTION_NAME) should equal(ElectionData(ELECTION_ID, KEYPAIR).toJsonString)
+    storage.elements(ELECTION_DATA_KEY) should equal(ElectionData(ELECTION_ID, KEYPAIR).toJsonString)
   }
 
   test("createElectionData does not overwrite channels on duplicates") {
@@ -193,13 +193,13 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(1)
-    storage.elements(ELECTION_NAME) should equal(ElectionData(ELECTION_ID, KEYPAIR).toJsonString)
+    storage.elements(ELECTION_DATA_KEY) should equal(ElectionData(ELECTION_ID, KEYPAIR).toJsonString)
 
     dbActor ! DbActor.CreateElectionData(LAO_ID, ELECTION_ID, KEYPAIR);
     sleep()
 
     storage.size should equal(1)
-    storage.elements(ELECTION_NAME) should equal(ElectionData(ELECTION_ID, KEYPAIR).toJsonString)
+    storage.elements(ELECTION_DATA_KEY) should equal(ElectionData(ELECTION_ID, KEYPAIR).toJsonString)
   }
 
   test("createChannelsFromList creates multiple channels") {
@@ -213,8 +213,8 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(2)
-    storage.elements(CHANNEL_NAME) should equal(ChannelData(ObjectType.ELECTION, Nil).toJsonString)
-    storage.elements(s"${CHANNEL_NAME}2") should equal(ChannelData(ObjectType.ROLL_CALL, Nil).toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + CHANNEL_NAME) should equal(ChannelData(ObjectType.ELECTION, Nil).toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + s"${CHANNEL_NAME}2") should equal(ChannelData(ObjectType.ROLL_CALL, Nil).toJsonString)
   }
 
   test("createChannelsFromList does not overwrite channels on duplicates (duplicates already created)") {
@@ -235,8 +235,8 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(2)
-    storage.elements(CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, Nil).toJsonString)
-    storage.elements(s"${CHANNEL_NAME}2") should equal(ChannelData(ObjectType.ROLL_CALL, Nil).toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, Nil).toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + s"${CHANNEL_NAME}2") should equal(ChannelData(ObjectType.ROLL_CALL, Nil).toJsonString)
   }
 
   test("createChannelsFromList does not overwrite channels on duplicates (duplicates in the list)") {
@@ -251,7 +251,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(1)
-    storage.elements(CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, Nil).toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, Nil).toJsonString)
   }
 
   test("createChannelsFromList works for 0 or 1 element") {
@@ -272,7 +272,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(1)
-    storage.elements(CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, Nil).toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, Nil).toJsonString)
   }
 
   test("checkChannelExistence does not detect a non-existing channel") {
@@ -309,7 +309,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(1)
-    storage.elements(CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, Nil).toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, Nil).toJsonString)
   }
 
   test("writeLaoData succeeds for both new and updated data") {
@@ -330,7 +330,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(1)
 
-    val actualLaoData1: LaoData = LaoData.buildFromJson(storage.elements(s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}laodata"))
+    val actualLaoData1: LaoData = LaoData.buildFromJson(storage.elements(storage.DATA_KEY + s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}laodata"))
 
     actualLaoData1.owner should equal(PublicKey(Base64Data.encode("key")))
     actualLaoData1.attendees should equal(List(PublicKey(Base64Data.encode("key"))))
@@ -339,12 +339,13 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
   test("writeLaoData succeeds for updated data") {
     // arrange
+    val initialStorage: InMemoryStorage = InMemoryStorage()
+
     val messageRollCall: Message = MessageExample.MESSAGE_CLOSEROLLCALL
     val messageLao: Message = MessageExample.MESSAGE_CREATELAO_SIMPLIFIED
     val address: Option[String] = Option("ws://popdemo.dedis.ch")
     val laoData: LaoData = LaoData().updateWith(messageLao, address)
-    val laoDataKey: String = s"$CHANNEL_NAME${Channel.LAO_DATA_LOCATION}"
-    val initialStorage: InMemoryStorage = InMemoryStorage()
+    val laoDataKey: String = initialStorage.DATA_KEY + s"$CHANNEL_NAME${Channel.LAO_DATA_LOCATION}"
     initialStorage.write((laoDataKey, laoData.toJsonString))
     val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 
@@ -356,7 +357,9 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     expectMsg(DbActor.DbActorAck())
     initialStorage.size should equal(1)
 
-    val actualLaoData2: LaoData = LaoData.buildFromJson(initialStorage.elements(s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}laodata"))
+    val actualLaoData2: LaoData = LaoData.buildFromJson(
+      initialStorage.elements(initialStorage.DATA_KEY + s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}laodata")
+    )
 
     actualLaoData2.owner should equal(PublicKey(Base64Data.encode("key")))
     actualLaoData2.attendees should equal(List(PublicKey(Base64Data.encode("key")), PublicKey(Base64Data.encode("keyAttendee"))))
@@ -364,13 +367,15 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
   }
 
   test("readLaoData succeeds for existing LaoData") {
+
     // arrange
+    val initialStorage: InMemoryStorage = InMemoryStorage()
+
     val channelName1: Channel = Channel(CHANNEL_NAME)
     val publicKey: PublicKey = PublicKey(Base64Data("jsNj23IHALvppqV1xQfP71_3IyAHzivxiCz236_zzQc="))
     val privateKey: PrivateKey = PrivateKey(Base64Data("qRfms3wzSLkxAeBz6UtwA-L1qP0h8D9XI1FSvY68t7Y="))
     val laoData: LaoData = LaoData(PublicKey(Base64Data.encode("key")), List(PublicKey(Base64Data.encode("key"))), privateKey, publicKey, List.empty)
-    val laoDataKey: String = s"$CHANNEL_NAME${Channel.LAO_DATA_LOCATION}"
-    val initialStorage: InMemoryStorage = InMemoryStorage()
+    val laoDataKey: String = initialStorage.DATA_KEY + s"$CHANNEL_NAME${Channel.LAO_DATA_LOCATION}"
     initialStorage.write((laoDataKey, laoData.toJsonString))
     val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 
@@ -392,7 +397,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     // arrange
     val channelName1: Channel = Channel(CHANNEL_NAME)
     val initialStorage: InMemoryStorage = InMemoryStorage()
-    initialStorage.write((s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}", MESSAGE.toJsonString))
+    initialStorage.write((initialStorage.DATA_KEY + s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}", MESSAGE.toJsonString))
     val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 
     // act
@@ -427,7 +432,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     val channelName1: Channel = Channel(CHANNEL_NAME)
     val initialStorage: InMemoryStorage = InMemoryStorage()
     val channelData: ChannelData = ChannelData(ObjectType.LAO, Nil)
-    initialStorage.write((CHANNEL_NAME, channelData.toJsonString))
+    initialStorage.write((initialStorage.CHANNEL_DATA_KEY + CHANNEL_NAME, channelData.toJsonString))
     val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 
     // act
@@ -446,7 +451,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     // arrange
     val initialStorage: InMemoryStorage = InMemoryStorage()
     val electionData: ElectionData = ElectionData(ELECTION_ID, KEYPAIR)
-    initialStorage.write((ELECTION_NAME, electionData.toJsonString))
+    initialStorage.write((ELECTION_DATA_KEY, electionData.toJsonString))
     val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 
     // act
@@ -468,9 +473,9 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     val listIds: List[Hash] = MESSAGE.message_id :: message2.message_id :: Nil
     val channelData: ChannelData = ChannelData(ObjectType.LAO, listIds)
     initialStorage.write(
-      (CHANNEL_NAME, channelData.toJsonString),
-      (s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}", MESSAGE.toJsonString),
-      (s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${message2.message_id}", message2.toJsonString)
+      (initialStorage.CHANNEL_DATA_KEY + CHANNEL_NAME, channelData.toJsonString),
+      (initialStorage.DATA_KEY + s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}", MESSAGE.toJsonString),
+      (initialStorage.DATA_KEY + s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${message2.message_id}", message2.toJsonString)
     )
     val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 
@@ -512,8 +517,8 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     // assert
     expectMsg(DbActor.DbActorAck())
     storage.size should equal(2)
-    storage.elements(CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, MESSAGE.message_id :: Nil).toJsonString)
-    storage.elements(s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}") should equal(message.toJsonString)
+    storage.elements(storage.CHANNEL_DATA_KEY + CHANNEL_NAME) should equal(ChannelData(ObjectType.LAO, MESSAGE.message_id :: Nil).toJsonString)
+    storage.elements(storage.DATA_KEY + s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}") should equal(message.toJsonString)
   }
 
   test("catchup should not fail on a channel with ChannelData containing missing message_ids (and only return valid messages)") {
@@ -525,8 +530,8 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     val listIds: List[Hash] = MESSAGE.message_id :: message2Id :: Nil
     val channelData: ChannelData = ChannelData(ObjectType.LAO, listIds)
     initialStorage.write(
-      (CHANNEL_NAME, channelData.toJsonString),
-      (s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}", MESSAGE.toJsonString)
+      (initialStorage.CHANNEL_DATA_KEY + CHANNEL_NAME, channelData.toJsonString),
+      (initialStorage.DATA_KEY + s"$CHANNEL_NAME${Channel.DATA_SEPARATOR}${MESSAGE.message_id}", MESSAGE.toJsonString)
     )
     val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 
@@ -548,7 +553,7 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     val storage: InMemoryStorage = InMemoryStorage()
     val dbActor: ActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), storage)))
     val laoId: Hash = Hash(Base64Data.encode("laoId"))
-    val rollcallKey: String = s"${ROOT_CHANNEL_PREFIX}${laoId.toString}/rollcall"
+    val rollcallKey: String = storage.DATA_KEY + s"${ROOT_CHANNEL_PREFIX}${laoId.toString}/rollcall"
 
     val messageRollcall: Message = CreateRollCallExamples.MESSAGE_CREATE_ROLL_CALL_WORKING
 
@@ -584,11 +589,12 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
 
   test("readRollCallData succeeds for existing RollCallData") {
     // arrange
+    val initialStorage: InMemoryStorage = InMemoryStorage()
+
     val laoId: Hash = Hash(Base64Data.encode("laoId"))
     val updateId: Hash = Hash(Base64Data.encode("updateId"))
-    val rollcallKey: String = s"${ROOT_CHANNEL_PREFIX}${laoId.toString}/rollcall"
+    val rollcallKey: String = initialStorage.DATA_KEY + s"${ROOT_CHANNEL_PREFIX}${laoId.toString}/rollcall"
     val rollcallData: RollCallData = RollCallData(updateId, ActionType.CREATE)
-    val initialStorage: InMemoryStorage = InMemoryStorage()
     initialStorage.write((rollcallKey, rollcallData.toJsonString))
     val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/storage/DiskStorageSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/storage/DiskStorageSuite.scala
@@ -90,6 +90,35 @@ class DiskStorageSuite extends FunSuite with Matchers with BeforeAndAfterAll {
     an[DbActorNAckException] should be thrownBy storage.write(faultyBatch: _*)
   }
 
+  test("all the keys are retrieved") {
+    val storage = generateDiskStorage()
+
+    storage.write(BATCH: _*)
+    storage.filterKeysByPrefix("key") should equal(BATCH.map(s => s._1).toSet)
+  }
+
+  test("Only some of the keys are retrieved") {
+    val storage = generateDiskStorage()
+    val prefix = "test"
+
+    var set = Set[String]()
+    val MIXED_BATCH = BATCH
+      .map(s =>
+        (
+          if (s._1.hashCode % 2 == 0) {
+            set += prefix + s._1
+            prefix + s._1
+          } else
+            s._1
+          ,
+          s._2
+        )
+      )
+
+    storage.write(MIXED_BATCH: _*)
+    storage.filterKeysByPrefix(prefix) should equal(set)
+  }
+
   test("delete successfully deletes a key") {
     val storage: DiskStorage = generateDiskStorage()
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/storage/InMemoryStorage.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/storage/InMemoryStorage.scala
@@ -14,6 +14,8 @@ case class InMemoryStorage(initial: Map[String, String] = Map.empty) extends Sto
     }
   }
 
+  override def filterKeysByPrefix(prefix: String): Set[String] = elements.keys.filter(str => str.startsWith(prefix)).toSet
+
   override def delete(key: String): Unit = elements -= key
 
   override def close(): Unit = ()


### PR DESCRIPTION
This pr introduces two prefix for the database: 

1.  CHANNEL_DATA_KEY = "ChannelData:"
2.  DATA_KEY = "Data:"

The first corresponds to data stored as: `Key -> List[Message ids]`
Where the second one means actual data: `Key -> Message` 

The first prefix allows us to get all the channel we have stored in the db since the key is built as: PREFIX + Channel
A new function has also been added to the storage, this function retrieves all keys based on the given prefix. 