### PR TITLE
Back navigation on transactions history

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/GlobalNetworkManager.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/GlobalNetworkManager.java
@@ -20,7 +20,7 @@ import io.reactivex.disposables.Disposable;
 @Singleton
 public class GlobalNetworkManager implements Disposable {
 
-  private static final String DEFAULT_URL = "ws://10.0.2.2:9000/organizer/client";
+  private static final String DEFAULT_URL = "ws://10.0.2.2:9000/client";
 
   private final MessageHandler messageHandler;
   private final ConnectionFactory connectionFactory;

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
@@ -37,8 +37,7 @@ import com.github.dedis.popstellar.utility.error.ErrorUtils;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 
 import java.security.GeneralSecurityException;
-import java.util.Objects;
-import java.util.Stack;
+import java.util.*;
 import java.util.function.Supplier;
 
 import dagger.hilt.android.AndroidEntryPoint;
@@ -49,7 +48,7 @@ public class LaoActivity extends AppCompatActivity {
 
   LaoViewModel laoViewModel;
   LaoActivityBinding binding;
-  private final Stack<Fragment> fragmentStack = new Stack<>();
+  private final Deque<Fragment> fragmentStack = new LinkedList<>();
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
@@ -154,6 +154,7 @@ public class LaoActivity extends AppCompatActivity {
                   R.id.fragment_digital_cash_history,
                   DigitalCashHistoryFragment::newInstance);
             } else {
+              // Restore the fragment pushed on the stack before opening the transaction history
               resetLastFragment();
             }
             return true;
@@ -277,6 +278,7 @@ public class LaoActivity extends AppCompatActivity {
     openEventsTab();
   }
 
+  /** Restore the fragment contained in the stack as container of the current lao */
   public void resetLastFragment() {
     Fragment fragment = fragmentStack.pop();
     getSupportFragmentManager()

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHistoryFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHistoryFragment.java
@@ -67,8 +67,6 @@ public class DigitalCashHistoryFragment extends Fragment {
         requireActivity(),
         getViewLifecycleOwner(),
         ActivityUtils.buildBackButtonCallback(
-            TAG,
-            "digital cash home",
-            () -> DigitalCashHomeFragment.openFragment(getParentFragmentManager())));
+            TAG, "last fragment", ((LaoActivity) requireActivity())::resetLastFragment));
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashReceiptFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashReceiptFragment.java
@@ -66,7 +66,7 @@ public class DigitalCashReceiptFragment extends Fragment {
               String address = stringEvent.getContentIfNotHandled();
               if (address != null) {
                 binding.digitalCashReceiptBeneficiary.setText(
-                    String.format("Beneficary : %n %s", address));
+                    String.format("Beneficiary : %n %s", address));
               }
             });
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
@@ -1,6 +1,7 @@
 package com.github.dedis.popstellar.ui.lao.event.rollcall;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.pm.ActivityInfo;
 import android.graphics.Bitmap;
 import android.graphics.Color;
@@ -284,12 +285,16 @@ public class RollCallFragment extends Fragment {
 
   @SuppressLint("SourceLockedOrientationActivity")
   private void handleRotation() {
+    Activity activity = getActivity();
+    if (activity == null) {
+      return;
+    }
     if (rollCall.isOpen() && !laoViewModel.isOrganizer()) {
       // If the qr is visible, then the activity rotation should be locked,
       // as the QR could not fit in the screen in landscape
-      requireActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+      activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
     } else {
-      requireActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
+      activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
     }
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
@@ -1,5 +1,7 @@
 package com.github.dedis.popstellar.ui.lao.event.rollcall;
 
+import android.annotation.SuppressLint;
+import android.content.pm.ActivityInfo;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
@@ -233,6 +235,7 @@ public class RollCallFragment extends Fragment {
 
     setupListOfAttendees();
     retrieveAndDisplayPublicKey();
+    handleRotation();
   }
 
   /**
@@ -276,6 +279,17 @@ public class RollCallFragment extends Fragment {
     if (attendeesList != null) {
       binding.listViewAttendees.setAdapter(
           new ArrayAdapter<>(requireContext(), android.R.layout.simple_list_item_1, attendeesList));
+    }
+  }
+
+  @SuppressLint("SourceLockedOrientationActivity")
+  private void handleRotation() {
+    if (rollCall.isOpen() && !laoViewModel.isOrganizer()) {
+      // If the qr is visible, then the activity rotation should be locked,
+      // as the QR could not fit in the screen in landscape
+      requireActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+    } else {
+      requireActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
     }
   }
 

--- a/fe2-android/app/src/main/res/layout/roll_call_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/roll_call_fragment.xml
@@ -144,11 +144,12 @@
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toBottomOf="@+id/roll_call_end_time"
       app:layout_constraintVertical_bias="@dimen/roll_call_attendees_text_vertical_bias" />
+
     <ListView
       android:id="@+id/list_view_attendees"
       android:scrollbarStyle="outsideOverlay"
       android:layout_width="@dimen/roll_call_attendees_list_width"
-      android:layout_height="wrap_content"
+      android:layout_height="@dimen/roll_call_attendees_list_height"
       android:layout_marginStart="@dimen/roll_call_attendees_margin"
       android:layout_marginEnd="@dimen/roll_call_attendees_margin"
       android:layout_centerHorizontal="true"

--- a/fe2-android/app/src/main/res/layout/roll_call_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/roll_call_fragment.xml
@@ -139,25 +139,29 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:text="@string/roll_call_attendees"
-      app:layout_constraintBottom_toTopOf="@+id/list_view_attendees"
+      app:layout_constraintBottom_toTopOf="@+id/roll_call_management_button"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/roll_call_fragment_end_time_title" />
+      app:layout_constraintTop_toBottomOf="@+id/roll_call_end_time"
+      app:layout_constraintVertical_bias="@dimen/roll_call_attendees_text_vertical_bias" />
     <ListView
       android:id="@+id/list_view_attendees"
       android:scrollbarStyle="outsideOverlay"
-      android:layout_width="@dimen/qr_rollcall_img"
-      android:layout_height="@dimen/qr_rollcall_img"
-      android:layout_marginEnd="@dimen/roll_call_attendees_end_margin"
+      android:layout_width="@dimen/roll_call_attendees_list_width"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="@dimen/roll_call_attendees_margin"
+      android:layout_marginEnd="@dimen/roll_call_attendees_margin"
+      android:layout_centerHorizontal="true"
       android:fadeScrollbars="true"
-      android:scrollbarSize="@dimen/event_layout_arrow_end_margin"
+      android:scrollbarSize="@dimen/roll_call_attendees_scrollbar_size"
       android:scrollbars="vertical"
       android:scrollingCache="true"
       android:smoothScrollbar="true"
       app:layout_constraintBottom_toTopOf="@+id/roll_call_management_button"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="@+id/roll_call_pk_qr_code" />
+      app:layout_constraintTop_toBottomOf="@+id/roll_call_attendees_text"
+      app:layout_constraintVertical_bias="@dimen/roll_call_attendees_list_vertical_bias" />
 
   </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/fe2-android/app/src/main/res/values/dimens.xml
+++ b/fe2-android/app/src/main/res/values/dimens.xml
@@ -60,8 +60,8 @@
   <dimen name="roll_call_attendees_scrollbar_size">6dp</dimen>
   <dimen name="roll_call_attendees_list_width">320dp</dimen>
   <dimen name="roll_call_attendees_list_height">0dp</dimen>
-  <dimen name="roll_call_attendees_text_vertical_bias">0.16</dimen>
-  <dimen name="roll_call_attendees_list_vertical_bias">0.05</dimen>
+  <dimen name="roll_call_attendees_text_vertical_bias">0.05</dimen>
+  <dimen name="roll_call_attendees_list_vertical_bias">0.15</dimen>
 
   <!--  Event layout-->
   <dimen name="event_layout_arrow_end_margin">8dp</dimen>

--- a/fe2-android/app/src/main/res/values/dimens.xml
+++ b/fe2-android/app/src/main/res/values/dimens.xml
@@ -56,7 +56,11 @@
   <dimen name="status_margin_top">16dp</dimen>
   <dimen name="event_header_between_texts_margin">5dp</dimen>
   <dimen name="pickers_horizontal_margin">16dp</dimen>
-  <dimen name="roll_call_attendees_end_margin">10dp</dimen>
+  <dimen name="roll_call_attendees_margin">5dp</dimen>
+  <dimen name="roll_call_attendees_scrollbar_size">6dp</dimen>
+  <dimen name="roll_call_attendees_list_width">300dp</dimen>
+  <dimen name="roll_call_attendees_text_vertical_bias">0.16</dimen>
+  <dimen name="roll_call_attendees_list_vertical_bias">0.03</dimen>
 
   <!--  Event layout-->
   <dimen name="event_layout_arrow_end_margin">8dp</dimen>

--- a/fe2-android/app/src/main/res/values/dimens.xml
+++ b/fe2-android/app/src/main/res/values/dimens.xml
@@ -58,9 +58,10 @@
   <dimen name="pickers_horizontal_margin">16dp</dimen>
   <dimen name="roll_call_attendees_margin">5dp</dimen>
   <dimen name="roll_call_attendees_scrollbar_size">6dp</dimen>
-  <dimen name="roll_call_attendees_list_width">300dp</dimen>
+  <dimen name="roll_call_attendees_list_width">320dp</dimen>
+  <dimen name="roll_call_attendees_list_height">0dp</dimen>
   <dimen name="roll_call_attendees_text_vertical_bias">0.16</dimen>
-  <dimen name="roll_call_attendees_list_vertical_bias">0.03</dimen>
+  <dimen name="roll_call_attendees_list_vertical_bias">0.05</dimen>
 
   <!--  Event layout-->
   <dimen name="event_layout_arrow_end_margin">8dp</dimen>

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/digitalcash/DigitalCashPageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/digitalcash/DigitalCashPageObject.java
@@ -1,5 +1,6 @@
 package com.github.dedis.popstellar.testutils.pages.lao.digitalcash;
 
+import androidx.annotation.IdRes;
 import androidx.test.espresso.ViewInteraction;
 
 import com.github.dedis.popstellar.R;
@@ -33,5 +34,10 @@ public class DigitalCashPageObject {
 
   public static ViewInteraction issueButton() {
     return onView(withId(R.id.issue_button));
+  }
+
+  @IdRes
+  public static int fragmentDigitalCashHomeId() {
+    return R.id.fragment_digital_cash_home;
   }
 }

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashActivityTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashActivityTest.java
@@ -189,4 +189,11 @@ public class DigitalCashActivityTest {
     receiveButton().perform(click());
     fragmentContainer().check(matches(withChild(withId(fragmentDigitalCashReceiveId()))));
   }
+
+  @Test
+  public void historyButtonOnHistoryFragmentGoesBack() {
+    historyButton().perform(click());
+    historyButton().perform(click());
+    fragmentContainer().check(matches(withChild(withId(fragmentDigitalCashHomeId()))));
+  }
 }


### PR DESCRIPTION
This PR makes the following changes:
- going back from the history of transactions opens the last accesses fragment before entering there. Previously there was a non-smooth behaviour for which going back from the history was always taking to digital cash home.
- Fixed the UI of the roll call in landscape orientation: if the QR is displayed, then the rotation is locked (as it could be not displayed entirely). Also there's another fix on the list of attendees in landscape orientation