### PR TITLE
Error handling

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/ElectionViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/ElectionViewModel.java
@@ -15,6 +15,7 @@ import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.repository.*;
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 import com.github.dedis.popstellar.utility.error.*;
+import com.github.dedis.popstellar.utility.error.keys.KeyException;
 import com.github.dedis.popstellar.utility.security.KeyManager;
 
 import java.util.List;
@@ -184,6 +185,20 @@ public class ElectionViewModel extends AndroidViewModel {
               Channel electionChannel = election.getChannel();
               return networkManager.getMessageSender().publish(token, electionChannel, vote);
             });
+  }
+
+  /**
+   * Function to enable the user to vote checking they have a valid pop token
+   *
+   * @return true if they can vote, false otherwise
+   */
+  public boolean canVote() {
+    try {
+      keyManager.getValidPoPToken(laoId, rollCallRepo.getLastClosedRollCall(laoId));
+    } catch (KeyException e) {
+      return false;
+    }
+    return true;
   }
 
   @NonNull

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionFragment.java
@@ -168,10 +168,14 @@ public class ElectionFragment extends Fragment {
           EventState state = election.getState();
           switch (state) {
             case OPENED:
-              LaoActivity.setCurrentFragment(
-                  getParentFragmentManager(),
-                  R.id.fragment_cast_vote,
-                  () -> CastVoteFragment.newInstance(electionId));
+              if (!electionViewModel.canVote()) {
+                ErrorUtils.logAndShow(requireContext(), TAG, R.string.error_retrieve_own_token);
+              } else {
+                LaoActivity.setCurrentFragment(
+                    getParentFragmentManager(),
+                    R.id.fragment_cast_vote,
+                    () -> CastVoteFragment.newInstance(electionId));
+              }
               break;
             case RESULTS_READY:
               LaoActivity.setCurrentFragment(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionFragment.java
@@ -92,6 +92,10 @@ public class ElectionFragment extends Fragment {
 
     managementVisibilityMap = buildManagementVisibilityMap();
 
+    if (!electionViewModel.canVote()) {
+      resetEnablingMap();
+    }
+
     managementButton.setOnClickListener(
         v -> {
           Election election;
@@ -168,14 +172,10 @@ public class ElectionFragment extends Fragment {
           EventState state = election.getState();
           switch (state) {
             case OPENED:
-              if (!electionViewModel.canVote()) {
-                ErrorUtils.logAndShow(requireContext(), TAG, R.string.error_vote_missing_token);
-              } else {
-                LaoActivity.setCurrentFragment(
-                    getParentFragmentManager(),
-                    R.id.fragment_cast_vote,
-                    () -> CastVoteFragment.newInstance(electionId));
-              }
+              LaoActivity.setCurrentFragment(
+                  getParentFragmentManager(),
+                  R.id.fragment_cast_vote,
+                  () -> CastVoteFragment.newInstance(electionId));
               break;
             case RESULTS_READY:
               LaoActivity.setCurrentFragment(
@@ -191,6 +191,10 @@ public class ElectionFragment extends Fragment {
 
     handleBackNav();
     return view;
+  }
+
+  private void resetEnablingMap() {
+    actionEnablingMap.keySet().forEach(k -> actionEnablingMap.put(k, false));
   }
 
   @Override

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionFragment.java
@@ -193,8 +193,10 @@ public class ElectionFragment extends Fragment {
     return view;
   }
 
+  /** Set to not enabled the button "Vote" */
   private void resetEnablingMap() {
-    actionEnablingMap.keySet().forEach(k -> actionEnablingMap.put(k, false));
+    actionEnablingMap.put(EventState.CREATED, false);
+    actionEnablingMap.put(EventState.OPENED, false);
   }
 
   @Override

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionFragment.java
@@ -169,7 +169,7 @@ public class ElectionFragment extends Fragment {
           switch (state) {
             case OPENED:
               if (!electionViewModel.canVote()) {
-                ErrorUtils.logAndShow(requireContext(), TAG, R.string.error_retrieve_own_token);
+                ErrorUtils.logAndShow(requireContext(), TAG, R.string.error_vote_missing_token);
               } else {
                 LaoActivity.setCurrentFragment(
                     getParentFragmentManager(),

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
@@ -32,6 +32,7 @@ import com.github.dedis.popstellar.utility.ActivityUtils;
 import com.github.dedis.popstellar.utility.Constants;
 import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.error.keys.KeyException;
+import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
 import com.google.gson.Gson;
 
 import net.glxn.qrgen.android.QRCode;
@@ -206,7 +207,24 @@ public class RollCallFragment extends Fragment {
     boolean isOrganizer = laoViewModel.isOrganizer();
 
     binding.rollCallFragmentTitle.setText(rollCall.getName());
-    binding.rollCallManagementButton.setVisibility(isOrganizer ? View.VISIBLE : View.GONE);
+
+    // Set invisible by default
+    binding.rollCallManagementButton.setVisibility(View.GONE);
+    try {
+      // If the roll call is not closed management button is open or close
+      // Then it should be visible only to the organizer
+      // However, if isOrganizer but the roll call is closed then the button is
+      // reopen, however this is a valid action only if this is the last closed roll call
+      if (isOrganizer
+          && (!rollCall.isClosed()
+              || (rollCall.isClosed()
+                  && rollCallRepo
+                      .getLastClosedRollCall(laoViewModel.getLaoId())
+                      .equals(rollCall)))) {
+        binding.rollCallManagementButton.setVisibility(View.VISIBLE);
+      }
+    } catch (NoRollCallException ignored) {
+    }
 
     binding.rollCallManagementButton.setText(managementTextMap.getOrDefault(rcState, ID_NULL));
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
@@ -207,9 +207,6 @@ public class RollCallFragment extends Fragment {
     boolean isOrganizer = laoViewModel.isOrganizer();
 
     binding.rollCallFragmentTitle.setText(rollCall.getName());
-
-    // Set invisible by default
-    binding.rollCallManagementButton.setVisibility(View.GONE);
     try {
       // If the roll call is not closed management button is open or close
       // Then it should be visible only to the organizer
@@ -222,8 +219,11 @@ public class RollCallFragment extends Fragment {
                       .getLastClosedRollCall(laoViewModel.getLaoId())
                       .equals(rollCall)))) {
         binding.rollCallManagementButton.setVisibility(View.VISIBLE);
+      } else {
+        throw new NoRollCallException("");
       }
-    } catch (NoRollCallException ignored) {
+    } catch (NoRollCallException e) {
+      binding.rollCallManagementButton.setVisibility(View.GONE);
     }
 
     binding.rollCallManagementButton.setText(managementTextMap.getOrDefault(rcState, ID_NULL));

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
@@ -207,23 +207,20 @@ public class RollCallFragment extends Fragment {
     boolean isOrganizer = laoViewModel.isOrganizer();
 
     binding.rollCallFragmentTitle.setText(rollCall.getName());
-    try {
-      // If the roll call is not closed management button is open or close
-      // Then it should be visible only to the organizer
-      // However, if isOrganizer but the roll call is closed then the button is
-      // reopen, however this is a valid action only if this is the last closed roll call
-      if (isOrganizer
-          && (!rollCall.isClosed()
-              || (rollCall.isClosed()
-                  && rollCallRepo
-                      .getLastClosedRollCall(laoViewModel.getLaoId())
-                      .equals(rollCall)))) {
-        binding.rollCallManagementButton.setVisibility(View.VISIBLE);
-      } else {
-        throw new NoRollCallException("");
+
+    // Set visibility of management button as Gone by default
+    binding.rollCallManagementButton.setVisibility(View.GONE);
+
+    // The management button is only visible to the organizer under the following conditions:
+    if (isOrganizer) {
+      // If the roll call is the last closed roll call or it's not closed (either opened or created)
+      try {
+        if (!rollCall.isClosed()
+            || rollCallRepo.getLastClosedRollCall(laoViewModel.getLaoId()).equals(rollCall)) {
+          binding.rollCallManagementButton.setVisibility(View.VISIBLE);
+        }
+      } catch (NoRollCallException ignored) {
       }
-    } catch (NoRollCallException e) {
-      binding.rollCallManagementButton.setVisibility(View.GONE);
     }
 
     binding.rollCallManagementButton.setText(managementTextMap.getOrDefault(rcState, ID_NULL));

--- a/fe2-android/app/src/main/res/layout/election_setup_question_layout.xml
+++ b/fe2-android/app/src/main/res/layout/election_setup_question_layout.xml
@@ -25,9 +25,8 @@
     android:layout_alignParentEnd="true"
     android:layout_alignParentBottom="true"
     android:layout_centerVertical="true"
-    android:layout_marginRight="@dimen/election_setup_text_field_margin_lateral"
+    android:layout_marginEnd="@dimen/election_setup_text_field_margin_lateral"
     android:text="@string/voting_method_spinner_text"
-    android:textColor="#7E000000"
     android:textStyle="bold"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="@+id/election_setup_spinner"
@@ -39,7 +38,7 @@
     android:layout_height="@dimen/election_setup_spinner_height"
     android:background="@android:drawable/btn_dropdown"
     android:clickable="true"
-    android:layout_marginRight="@dimen/election_setup_text_field_margin_lateral"
+    android:layout_marginEnd="@dimen/election_setup_text_field_margin_lateral"
     android:spinnerMode="dropdown"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintTop_toBottomOf="@+id/voting_method" />
@@ -50,24 +49,23 @@
     android:layout_height="wrap_content"
     android:clickable="true"
     android:text="@string/write_in_switch_text"
-    android:textColor="#7E000000"
     android:textStyle="bold"
     app:layout_constraintEnd_toEndOf="parent"
-    android:layout_marginRight="@dimen/election_setup_text_field_margin_lateral"
+    android:layout_marginEnd="@dimen/election_setup_text_field_margin_lateral"
     app:layout_constraintTop_toBottomOf="@+id/election_setup_spinner"
     tools:ignore="UseSwitchCompatOrMaterialXml" />
 
   <ScrollView
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginLeft="@dimen/election_setup_text_field_margin_lateral"
+    android:layout_marginStart="@dimen/election_setup_text_field_margin_lateral"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toBottomOf="@+id/add_ballot_option">
 
     <LinearLayout
       android:id="@+id/election_setup_ballot_options_ll"
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
+      android:layout_height="wrap_content"
       android:orientation="vertical" />
   </ScrollView>
 
@@ -76,7 +74,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:textAllCaps="false"
-    android:layout_marginLeft="@dimen/election_setup_text_field_margin_lateral"
+    android:layout_marginStart="@dimen/election_setup_text_field_margin_lateral"
     android:text="@string/add_ballot_options_button_text"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toBottomOf="@+id/election_question" />

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -264,7 +264,6 @@
   <string name="error_retrieve_own_token">Could not retrieve your own PoP Token\n%1$s</string>
   <string name="error_end_election">Could not complete the election\n%1$s</string>
   <string name="error_send_vote">Could not send the vote\n%1$s</string>
-  <string name="error_vote_missing_token">You don\'t have a valid token to cast a vote</string>
   <string name="error_create_election">Could not create the election\n%1$s</string>
   <string name="error_create_rollcall">Could not create the rollcall\n%1$s</string>
   <string name="error_start_election">Could not start the election\n%1$s</string>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -264,6 +264,7 @@
   <string name="error_retrieve_own_token">Could not retrieve your own PoP Token\n%1$s</string>
   <string name="error_end_election">Could not complete the election\n%1$s</string>
   <string name="error_send_vote">Could not send the vote\n%1$s</string>
+  <string name="error_vote_missing_token">You don\'t have a valid token to cast a vote</string>
   <string name="error_create_election">Could not create the election\n%1$s</string>
   <string name="error_create_rollcall">Could not create the rollcall\n%1$s</string>
   <string name="error_start_election">Could not start the election\n%1$s</string>

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/ElectionFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/ElectionFragmentTest.java
@@ -240,14 +240,9 @@ public class ElectionFragmentTest {
               };
             })
         .when(keyManager)
-        .getPoPToken(any(), any());
-
-    electionManagementButton().check(matches(withText("OPEN")));
-    electionManagementButton().perform(click());
-    dialogPositiveButton().performClick();
-    // Wait for the main thread to finish executing the calls made above
-    // before asserting their effect
-    InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+        .getValidPoPToken(any(), any());
+    activityScenarioRule.getScenario().recreate();
+    openElection();
 
     electionActionButton().check(matches(withText("VOTE")));
     electionActionButton().check(matches(isNotEnabled()));

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/ElectionFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/ElectionFragmentTest.java
@@ -18,6 +18,7 @@ import com.github.dedis.popstellar.testutils.fragment.ActivityFragmentScenarioRu
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.event.election.fragments.ElectionFragment;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
+import com.github.dedis.popstellar.utility.error.keys.KeyException;
 import com.github.dedis.popstellar.utility.security.KeyManager;
 
 import org.junit.Rule;
@@ -220,6 +221,36 @@ public class ElectionFragmentTest {
     verify(messageSenderHelper.getMockedSender())
         .publish(any(), eq(ELECTION.getChannel()), any(ElectionEnd.class));
     messageSenderHelper.assertSubscriptions();
+  }
+
+  @Test
+  public void actionButtonNotEnabledOpenTest() throws KeyException {
+    doAnswer(
+            invocation -> {
+              throw new KeyException("") {
+                @Override
+                public int getUserMessage() {
+                  return 0;
+                }
+
+                @Override
+                public Object[] getUserMessageArguments() {
+                  return new Object[0];
+                }
+              };
+            })
+        .when(keyManager)
+        .getPoPToken(any(), any());
+
+    electionManagementButton().check(matches(withText("OPEN")));
+    electionManagementButton().perform(click());
+    dialogPositiveButton().performClick();
+    // Wait for the main thread to finish executing the calls made above
+    // before asserting their effect
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+
+    electionActionButton().check(matches(withText("VOTE")));
+    electionActionButton().check(matches(isNotEnabled()));
   }
 
   @Test

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/ElectionFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/ElectionFragmentTest.java
@@ -5,13 +5,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.github.dedis.popstellar.model.network.method.message.data.election.*;
-import com.github.dedis.popstellar.model.objects.Election;
-import com.github.dedis.popstellar.model.objects.Lao;
+import com.github.dedis.popstellar.model.objects.*;
+import com.github.dedis.popstellar.model.objects.event.EventState;
 import com.github.dedis.popstellar.model.objects.security.KeyPair;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.model.objects.view.LaoView;
-import com.github.dedis.popstellar.repository.ElectionRepository;
-import com.github.dedis.popstellar.repository.LAORepository;
+import com.github.dedis.popstellar.repository.*;
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 import com.github.dedis.popstellar.testutils.BundleBuilder;
 import com.github.dedis.popstellar.testutils.MessageSenderHelper;
@@ -68,6 +67,20 @@ public class ElectionFragmentTest {
   private static final long CREATION = 10323411;
   private static final long START = 10323421;
   private static final long END = 10323431;
+  private static final String ROLL_CALL_DESC = "";
+  private static final String LOCATION = "EPFL";
+  private final RollCall ROLL_CALL =
+      new RollCall(
+          LAO.getId(),
+          LAO.getId(),
+          TITLE,
+          CREATION,
+          START,
+          END,
+          EventState.CLOSED,
+          new HashSet<>(),
+          LOCATION,
+          ROLL_CALL_DESC);
 
   private static final String ELECTION_ID = generateElectionSetupId(LAO_ID, CREATION, TITLE);
   private static final ElectionQuestion ELECTION_QUESTION_1 =
@@ -98,6 +111,7 @@ public class ElectionFragmentTest {
 
   @Inject ElectionRepository electionRepository;
 
+  @Inject RollCallRepository rollCallRepo;
   @BindValue @Mock LAORepository repository;
   @BindValue @Mock GlobalNetworkManager networkManager;
   @BindValue @Mock KeyManager keyManager;
@@ -123,6 +137,8 @@ public class ElectionFragmentTest {
 
           when(repository.getLaoObservable(anyString())).thenReturn(laoSubject);
           when(repository.getLaoView(any())).thenAnswer(invocation -> new LaoView(LAO));
+
+          rollCallRepo.updateRollCall(LAO_ID, ROLL_CALL);
 
           when(keyManager.getMainPublicKey()).thenReturn(SENDER);
           when(networkManager.getMessageSender()).thenReturn(messageSenderHelper.getMockedSender());
@@ -207,7 +223,7 @@ public class ElectionFragmentTest {
   }
 
   @Test
-  public void actionButtonOpenTest() {
+  public void actionButtonEnabledOpenTest() {
     openElection();
 
     electionActionButton().check(matches(withText("VOTE")));

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragmentTest.java
@@ -93,10 +93,10 @@ public class RollCallFragmentTest {
       new RollCall(
           LAO.getId() + "2",
           LAO.getId() + "2",
-          ROLL_CALL_TITLE,
-          CREATION,
-          ROLL_CALL_START,
-          ROLL_CALL_END,
+          ROLL_CALL_TITLE + "2",
+          CREATION + 1,
+          ROLL_CALL_START + 3,
+          ROLL_CALL_END + 3,
           EventState.CREATED,
           new HashSet<>(),
           LOCATION,
@@ -307,6 +307,16 @@ public class RollCallFragmentTest {
     // Check visibility as client
     rollCallRepo.updateRollCall(LAO_ID, RollCall.openRollCall(ROLL_CALL));
     rollCallQRCode().check(matches(withEffectiveVisibility(Visibility.VISIBLE)));
+  }
+
+  @Test
+  public void reopenButtonVisibilityTest() {
+    // Close the roll call 1
+    rollCallRepo.updateRollCall(LAO_ID, RollCall.closeRollCall(ROLL_CALL));
+    // Close then the roll call 2 (it becomes last closed)
+    rollCallRepo.updateRollCall(LAO_ID, RollCall.closeRollCall(ROLL_CALL_2));
+
+    managementButton().check(matches(withEffectiveVisibility(Visibility.GONE)));
   }
 
   /** Utility function to create a LAO when the user is not the organizer */


### PR DESCRIPTION
This PR resolves #1449.

Changes
---------

- Remove the possibility of reopening old roll calls (i.e. closed roll calls before the last closed one). Previously upon reopening a server error message was thrown
- Handled error message for casting a vote with no valid pop token. Previously, the user could enter in the cast vote fragment and then receive a generic message error
- Fixed the color of some text in election setup for dark mode