### PR TITLE
Add ParamsWithMapHandler

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/ResultObject.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/ResultObject.scala
@@ -1,19 +1,22 @@
 package ch.epfl.pop.model.network
 
 import ch.epfl.pop.model.network.method.message.Message
+import ch.epfl.pop.model.objects.Channel
 
-class ResultObject(val resultInt: Option[Int], val resultMessages: Option[List[Message]]) {
+class ResultObject(val resultInt: Option[Int], val resultMessages: Option[List[Message]], val resultMap: Option[Map[Channel, Set[Message]]]) {
 
-  def this(result: Int) = this(Some(result), None)
+  def this(result: Int) = this(Some(result), None, None)
 
-  def this(result: List[Message]) = this(None, Some(result))
+  def this(result: List[Message]) = this(None, Some(result), None)
+
+  def this(mapResult: Map[Channel, Set[Message]]) = this(None, None, Some(mapResult))
 
   def isIntResult: Boolean = resultInt.isDefined
 
   override def equals(o: Any): Boolean = {
     o match {
       case that: ResultObject =>
-        this.resultInt == that.resultInt && that.resultMessages == this.resultMessages
+        this.resultInt == that.resultInt && that.resultMessages == this.resultMessages && that.resultMap == this.resultMap
       case _ => false
     }
   }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -62,7 +62,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
       }
   })
 
-  def heartbeatHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map({
+  private def heartbeatHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map({
     case Right(jsonRpcMessage: JsonRpcRequest) =>
       /** first step is to retrieve the received heartbeat from the jsonRpcRequest * */
       val receivedHeartBeat: Map[Channel, Set[Hash]] = jsonRpcMessage.getParams.asInstanceOf[Heartbeat].channelsToMessageIds
@@ -95,7 +95,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
       val missingIds: mutable.HashMap[Channel, Set[Hash]] = mutable.HashMap()
       receivedHeartBeat.keys.foreach(channel => {
         if (localHeartBeat.contains(channel)) {
-          missingIds += (channel -> receivedHeartBeat.get(channel).get.filter(id =>
+          missingIds += (channel -> receivedHeartBeat(channel).filter(id =>
             !localHeartBeat.get(channel).contains(id)
           ))
         }
@@ -107,7 +107,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
     case graphMessage @ _ => graphMessage
   })
 
-  def getMessagesByIdHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map({
+  private def getMessagesByIdHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map({
     case Right(jsonRpcMessage: JsonRpcRequest) =>
       val receivedRequest: Map[Channel, Set[Hash]] = jsonRpcMessage.getParams.asInstanceOf[GetMessagesById].channelsToMessageIds
       var response: mutable.HashMap[Channel, Set[Message]] = mutable.HashMap()

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -84,7 +84,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
         val ask = dbActorRef ? DbActor.ReadChannelData(channel)
         Await.ready(ask, duration).value match {
           case Some(Success(DbActor.DbActorReadChannelDataAck(channelData))) =>
-            val setOfIds = channelData.messages.to(collection.mutable.Set)
+            val setOfIds = channelData.messages.to(collection.immutable.Set)
             localHeartBeat += (channel -> setOfIds.toList)
           case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(ex.code, s"couldn't readChannelData for local heartbeat", jsonRpcMessage.getId))
           case reply                                   => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"heartbeatHandler failed : unexpected DbActor reply '$reply'", jsonRpcMessage.getId))
@@ -100,7 +100,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
           ))
         }
       })
-      Right(JsonRpcRequest(RpcValidator.JSON_RPC_VERSION, MethodType.GET_MESSAGES_BY_ID, GetMessagesById(missingIds.toMap), None)) // how to pass the missing ids?? répondre par un getmsgsbyid et gérer les ids.
+      Right(JsonRpcRequest(RpcValidator.JSON_RPC_VERSION, MethodType.GET_MESSAGES_BY_ID, GetMessagesById(missingIds.toMap), None))
 
     case Right(jsonRpcMessage: JsonRpcResponse) =>
       Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "HeartbeatHandler received a 'JsonRpcResponse'", jsonRpcMessage.id))

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -61,19 +61,22 @@ object ParamsWithMapHandler extends AskPatternConstants {
 
   private def heartbeatHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map({
     case Right(jsonRpcMessage: JsonRpcRequest) =>
-      /** first step is to retrieve the received heartbeat from the jsonRpcRequest * */
+      /** first step is to retrieve the received heartbeat from the jsonRpcRequest */
       val receivedHeartBeat: Map[Channel, Set[Hash]] = jsonRpcMessage.getParams.asInstanceOf[Heartbeat].channelsToMessageIds
 
-      /** second step is to retrieve the local set of channels * */
+      /** second step is to retrieve the local set of channels */
       var setOfChannels: Set[Channel] = Set()
       val ask = dbActorRef ? DbActor.GetAllChannels()
       Await.ready(ask, duration).value match {
-        case Some(Success(DbActor.DbActorGetAllChannelsAck(channels))) => setOfChannels = channels
-        case Some(Failure(ex: DbActorNAckException))                   => Left(PipelineError(ex.code, s"couldn't retrieve local set of channels", jsonRpcMessage.getId))
-        case reply                                                     => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"heartbeatHandler failed : unexpected DbActor reply '$reply'", jsonRpcMessage.getId))
+        case Some(Success(DbActor.DbActorGetAllChannelsAck(channels))) =>
+          setOfChannels = channels
+        case Some(Failure(ex: DbActorNAckException)) =>
+          Left(PipelineError(ex.code, s"couldn't retrieve local set of channels", jsonRpcMessage.getId))
+        case reply =>
+          Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"heartbeatHandler failed : unexpected DbActor reply '$reply'", jsonRpcMessage.getId))
       }
 
-      /** third step is to ask the DB for the content of each channel in terms of message ids. * */
+      /** third step is to ask the DB for the content of each channel in terms of message ids. */
       val localHeartBeat: mutable.HashMap[Channel, Set[Hash]] = mutable.HashMap()
       setOfChannels.foreach(channel => {
         val ask = dbActorRef ? DbActor.ReadChannelData(channel)
@@ -81,19 +84,21 @@ object ParamsWithMapHandler extends AskPatternConstants {
           case Some(Success(DbActor.DbActorReadChannelDataAck(channelData))) =>
             val setOfIds = channelData.messages.toSet
             localHeartBeat += (channel -> setOfIds)
-          case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(ex.code, s"couldn't readChannelData for local heartbeat", jsonRpcMessage.getId))
-          case reply                                   => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"heartbeatHandler failed : unexpected DbActor reply '$reply'", jsonRpcMessage.getId))
+          case Some(Failure(ex: DbActorNAckException)) =>
+            Left(PipelineError(ex.code, s"couldn't readChannelData for local heartbeat", jsonRpcMessage.getId))
+          case reply =>
+            Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"heartbeatHandler failed : unexpected DbActor reply '$reply'", jsonRpcMessage.getId))
         }
       })
 
-      /** finally, we only keep from the received heartbeat the message ids that are not contained in the locally extracted heartbeat. * */
-      val missingIds: mutable.HashMap[Channel, Set[Hash]] = mutable.HashMap()
+      /** finally, we only keep from the received heartbeat the message ids that are not contained in the locally extracted heartbeat. */
+      var missingIdsMap: HashMap[Channel, Set[Hash]] = HashMap()
       receivedHeartBeat.keys.foreach(channel => {
-        if (localHeartBeat.contains(channel)) {
-          missingIds += (channel -> receivedHeartBeat(channel).diff(localHeartBeat(channel)))
-        }
+        val missingIdsSet = receivedHeartBeat(channel).diff(localHeartBeat.getOrElse(channel, Set.empty))
+        if (missingIdsSet.nonEmpty)
+          missingIdsMap += (channel -> missingIdsSet)
       })
-      Right(JsonRpcRequest(RpcValidator.JSON_RPC_VERSION, MethodType.GET_MESSAGES_BY_ID, GetMessagesById(missingIds.toMap), None))
+      Right(JsonRpcRequest(RpcValidator.JSON_RPC_VERSION, MethodType.GET_MESSAGES_BY_ID, GetMessagesById(missingIdsMap), Some(0)))
 
     case Right(jsonRpcMessage: JsonRpcResponse) =>
       Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "HeartbeatHandler received a 'JsonRpcResponse'", jsonRpcMessage.id))
@@ -110,11 +115,13 @@ object ParamsWithMapHandler extends AskPatternConstants {
           case Some(Success(DbActor.DbActorCatchupAck(messages))) =>
             val missingMessages = messages.filter(message => receivedRequest(channel).contains(message.message_id)).toSet
             response += (channel -> missingMessages)
-          case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(ex.code, s"getMessagesByIdHandler failed : ${ex.message}", jsonRpcMessage.getId))
-          case reply                                   => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"AnswerGenerator failed : unexpected DbActor reply '$reply'", jsonRpcMessage.getId))
+          case Some(Failure(ex: DbActorNAckException)) =>
+            Left(PipelineError(ex.code, s"getMessagesByIdHandler failed : ${ex.message}", jsonRpcMessage.getId))
+          case reply =>
+            Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"AnswerGenerator failed : unexpected DbActor reply '$reply'", jsonRpcMessage.getId))
         }
       })
-      Right(JsonRpcResponse(RpcValidator.JSON_RPC_VERSION, new ResultObject(HashMap.from(response)), None))
+      Right(JsonRpcResponse(RpcValidator.JSON_RPC_VERSION, new ResultObject(HashMap.from(response)), jsonRpcMessage.id))
 
     case Right(jsonRpcMessage: JsonRpcResponse) =>
       Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "getMessagesByIdHandler received a 'JsonRpcResponse'", jsonRpcMessage.id))
@@ -123,12 +130,15 @@ object ParamsWithMapHandler extends AskPatternConstants {
 
   private def isGetMessagesByIdEmpty(graphMessage: GraphMessage): Boolean = {
     graphMessage match {
-      case Left(_) => false
       case Right(value) =>
         value match {
-          case response: JsonRpcRequest => response.getParams.asInstanceOf[GetMessagesById].channelsToMessageIds.isEmpty
-          case _                                                                      => false
+          case response: JsonRpcRequest => response
+              .getParams
+              .asInstanceOf[GetMessagesById]
+              .channelsToMessageIds
+              .isEmpty
         }
+      case _ => false
     }
   }
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -1,17 +1,18 @@
 package ch.epfl.pop.pubsub.graph.handlers
 
 import akka.NotUsed
-import akka.actor.ActorRef
 import akka.pattern.AskableActorRef
-import akka.stream.FlowShape
 import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition}
 import ch.epfl.pop.model.network.method.{Catchup, GetMessagesById, Heartbeat, Subscribe, Unsubscribe}
 import ch.epfl.pop.model.network.{JsonRpcRequest, JsonRpcResponse}
-import ch.epfl.pop.model.objects.Channel
+import ch.epfl.pop.model.objects.{Channel, Hash}
 import ch.epfl.pop.pubsub.graph.{ErrorCodes, GraphMessage, PipelineError}
 import ch.epfl.pop.pubsub.{AskPatternConstants, ClientActor, PubSubMediator}
+import ch.epfl.pop.storage.DbActor
+import ch.epfl.pop.model.network.MethodType
+import ch.epfl.pop.pubsub.graph.validators.RpcValidator
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.collection.mutable
 import scala.concurrent.{Await, Future}
 
 object ParamsWithMapHandler extends AskPatternConstants{
@@ -40,9 +41,35 @@ object ParamsWithMapHandler extends AskPatternConstants{
           }
         ))
 
+        val heartbeatHandler = builder.add(ParamsWithMapHandler.heartBeatHandler(dbActorRef))
+
+
         // ajouter les handlers
 
       }
+  }
+
+  def heartBeatHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map ({
+    case Right(jsonRpcMessage: JsonRpcRequest) =>
+      val receivedHeartBeat: Map[Channel, Set[Hash]] = jsonRpcMessage.getParams.asInstanceOf[Heartbeat].channelsToMessageIds // pas sûr
+      val ask = dbActorRef ? DbActor.GetSetOfChannels()
+      val answer = Await.result(ask, duration)
+      val setOfChannels: Set[Channel] = answer.asInstanceOf[DbActor.DbActorGetSetOfChannelsAck].channels.map(s => Channel(s))
+      var localHeartBeat: mutable.HashMap[Channel, List[Hash]] = mutable.HashMap()
+      setOfChannels.foreach(channel => {
+        val ask = dbActorRef ? DbActor.ReadChannelData(channel)
+        val answer = Await.result(ask, duration)
+        val setOfIds = answer.asInstanceOf[DbActor.DbActorReadChannelDataAck].channelData.messages.to(collection.mutable.Set)
+        localHeartBeat += (channel -> setOfIds)
+      })
+      var missingIds: mutable.HashMap[Channel, Set[Hash]] = mutable.HashMap()
+      receivedHeartBeat.keys.foreach(channel =>{
+        if(localHeartBeat.contains(channel)){
+          missingIds += (channel -> receivedHeartBeat.get(channel).get.filter(id =>
+          !localHeartBeat.get(channel).contains(id)))
+        }
+      })
+      Right(JsonRpcRequest(RpcValidator.JSON_RPC_VERSION,MethodType.HEARTBEAT,Heartbeat(missingIds.toMap),None)) // how to pass the missing ids?? répondre par un getmsgsbyid et gérer les ids.
   })
 
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -115,7 +115,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
         val ask = dbActorRef ? DbActor.Catchup(channel)
         Await.ready(ask, duration).value match {
           case Some(Success(DbActor.DbActorCatchupAck(messages))) =>
-            val missingMessages = messages.filter(message => receivedRequest.get(channel).contains(message.message_id)).to(collection.immutable.Set)
+            val missingMessages = messages.filter(message => receivedRequest(channel).contains(message.message_id)).to(collection.immutable.Set)
             response += (channel -> missingMessages)
           case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(ex.code, s"getMessagesByIdHandler failed : ${ex.message}", jsonRpcMessage.getId))
           case reply                                   => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"AnswerGenerator failed : unexpected DbActor reply '$reply'", jsonRpcMessage.getId))

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -103,7 +103,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
     case Right(jsonRpcMessage: JsonRpcResponse) =>
       Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "HeartbeatHandler received a 'JsonRpcResponse'", jsonRpcMessage.id))
     case graphMessage @ _ => graphMessage
-  })
+  }).filter(!isEmptyAnswer(_))
 
   private def getMessagesByIdHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map({
     case Right(jsonRpcMessage: JsonRpcRequest) =>
@@ -124,7 +124,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
     case Right(jsonRpcMessage: JsonRpcResponse) =>
       Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "getMessagesByIdHandler received a 'JsonRpcResponse'", jsonRpcMessage.id))
     case graphMessage @ _ => graphMessage
-  }).filter(!isEmptyAnswer(_))
+  })
 
   private def isEmptyAnswer(graphMessage: GraphMessage): Boolean = {
     graphMessage match {

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -12,10 +12,13 @@ import ch.epfl.pop.storage.DbActor
 import ch.epfl.pop.model.network.MethodType
 import ch.epfl.pop.pubsub.graph.validators.RpcValidator
 import ch.epfl.pop.model.network.method.message.Message
+
 import scala.collection.mutable
 import akka.stream.FlowShape
 import ch.epfl.pop.model.network.JsonRpcResponse
 import ch.epfl.pop.model.network.ResultObject
+
+import scala.collection.immutable.HashMap
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success}
 
@@ -57,7 +60,6 @@ object ParamsWithMapHandler extends AskPatternConstants {
 
         /* close the shape */
         FlowShape(handlerPartitioner.in, handlerMerger.out)
-
 
       }
   })
@@ -121,13 +123,11 @@ object ParamsWithMapHandler extends AskPatternConstants {
           case reply                                   => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"AnswerGenerator failed : unexpected DbActor reply '$reply'", jsonRpcMessage.getId))
         }
       })
-      Right(JsonRpcResponse(RpcValidator.JSON_RPC_VERSION, new ResultObject(Map[Channel, Set[Message]]()), None))
-
-
+      Right(JsonRpcResponse(RpcValidator.JSON_RPC_VERSION, new ResultObject(HashMap.from(response)), None))
 
     case Right(jsonRpcMessage: JsonRpcResponse) =>
       Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "getMessagesByIdHandler received a 'JsonRpcResponse'", jsonRpcMessage.id))
-    case graphMessage@_ => graphMessage
+    case graphMessage @ _ => graphMessage
   })
 
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -74,9 +74,8 @@ object ParamsWithMapHandler extends AskPatternConstants {
       val ask = dbActorRef ? DbActor.GetAllChannels()
       Await.ready(ask, duration).value match {
         case Some(Success(DbActor.DbActorGetAllChannelsAck(channels))) => setOfChannels = channels
-
-        case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(ex.code, s"couldn't retrieve local set of channels", jsonRpcMessage.getId))
-        case reply                                   => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"heartbeatHandler failed : unexpected DbActor reply '$reply'", jsonRpcMessage.getId))
+        case Some(Failure(ex: DbActorNAckException))                   => Left(PipelineError(ex.code, s"couldn't retrieve local set of channels", jsonRpcMessage.getId))
+        case reply                                                     => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"heartbeatHandler failed : unexpected DbActor reply '$reply'", jsonRpcMessage.getId))
       }
 
       /** third step is to ask the DB for the content of each channel in terms of message ids. * */

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -100,7 +100,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
           ))
         }
       })
-      Right(JsonRpcRequest(RpcValidator.JSON_RPC_VERSION, MethodType.HEARTBEAT, Heartbeat(missingIds.toMap), None)) // how to pass the missing ids?? répondre par un getmsgsbyid et gérer les ids.
+      Right(JsonRpcRequest(RpcValidator.JSON_RPC_VERSION, MethodType.GET_MESSAGES_BY_ID, Heartbeat(missingIds.toMap), None)) // how to pass the missing ids?? répondre par un getmsgsbyid et gérer les ids.
 
     case Right(jsonRpcMessage: JsonRpcResponse) =>
       Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "HeartbeatHandler received a 'JsonRpcResponse'", jsonRpcMessage.id))

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -59,7 +59,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
       }
   })
 
-  private def heartbeatHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map({
+  private def heartbeatHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map {
     case Right(jsonRpcMessage: JsonRpcRequest) =>
       /** first step is to retrieve the received heartbeat from the jsonRpcRequest */
       val receivedHeartBeat: Map[Channel, Set[Hash]] = jsonRpcMessage.getParams.asInstanceOf[Heartbeat].channelsToMessageIds
@@ -103,7 +103,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
     case Right(jsonRpcMessage: JsonRpcResponse) =>
       Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "HeartbeatHandler received a 'JsonRpcResponse'", jsonRpcMessage.id))
     case graphMessage @ _ => graphMessage
-  }).filter(!isGetMessagesByIdEmpty(_)) // Answer to heartbeats only if some messages are actually missing
+  }.filter(!isGetMessagesByIdEmpty(_)) // Answer to heartbeats only if some messages are actually missing
 
   private def getMessagesByIdHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map {
     case Right(jsonRpcMessage: JsonRpcRequest) =>
@@ -132,7 +132,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
     graphMessage match {
       case Right(value) =>
         value match {
-          case response: JsonRpcRequest => response
+          case (response: JsonRpcRequest) => response
               .getParams
               .asInstanceOf[GetMessagesById]
               .channelsToMessageIds

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -11,13 +11,15 @@ import ch.epfl.pop.pubsub.{AskPatternConstants, ClientActor, PubSubMediator}
 import ch.epfl.pop.storage.DbActor
 import ch.epfl.pop.model.network.MethodType
 import ch.epfl.pop.pubsub.graph.validators.RpcValidator
-
+import ch.epfl.pop.model.network.method.message.Message
 import scala.collection.mutable
+import akka.stream.FlowShape
+import ch.epfl.pop.model.network.JsonRpcResponse
 import scala.concurrent.{Await, Future}
 
-object ParamsWithMapHandler extends AskPatternConstants{
+object ParamsWithMapHandler extends AskPatternConstants {
 
-  def graph(dbActorRef : AskableActorRef): Flow[GraphMessage, GraphMessage,NotUsed] = Flow.fromGraph(GraphDSL.create(){
+  def graph(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow.fromGraph(GraphDSL.create() {
     implicit builder: GraphDSL.Builder[NotUsed] =>
       {
         import GraphDSL.Implicits._
@@ -33,23 +35,33 @@ object ParamsWithMapHandler extends AskPatternConstants{
           totalPorts,
           {
             case Right(jsonRpcMessage: JsonRpcRequest) => jsonRpcMessage.getParams match {
-              case _: Heartbeat => portHeartBeatHandler
-              case _: GetMessagesById => portGetMsgsByIdHandler
+                case _: Heartbeat       => portHeartBeatHandler
+                case _: GetMessagesById => portGetMsgsByIdHandler
 
-            }
+              }
             case _ => portPipelineError // Pipeline error goes directly in handlerMerger
           }
         ))
 
         val heartbeatHandler = builder.add(ParamsWithMapHandler.heartBeatHandler(dbActorRef))
+        val getMessagesByIdHandler = builder.add(ParamsWithMapHandler.getMessagesByIdHandler(dbActorRef))
 
+        val handlerMerger = builder.add(Merge[GraphMessage](totalPorts))
+
+        /* glue the components together */
+        handlerPartitioner.out(portPipelineError) ~> handlerMerger
+        handlerPartitioner.out(portHeartBeatHandler) ~> heartBeatHandler ~> handlerMerger
+        handlerPartitioner.out(portGetMsgsByIdHandler) ~> getMessagesByIdHandler ~> handlerMerger
+
+        /* close the shape */
+        FlowShape(handlerPartitioner.in, handlerMerger.out)
 
         // ajouter les handlers
 
       }
-  }
+  })
 
-  def heartBeatHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map ({
+  def heartBeatHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map({
     case Right(jsonRpcMessage: JsonRpcRequest) =>
       val receivedHeartBeat: Map[Channel, Set[Hash]] = jsonRpcMessage.getParams.asInstanceOf[Heartbeat].channelsToMessageIds // pas sûr
       val ask = dbActorRef ? DbActor.GetSetOfChannels()
@@ -63,15 +75,36 @@ object ParamsWithMapHandler extends AskPatternConstants{
         localHeartBeat += (channel -> setOfIds)
       })
       var missingIds: mutable.HashMap[Channel, Set[Hash]] = mutable.HashMap()
-      receivedHeartBeat.keys.foreach(channel =>{
-        if(localHeartBeat.contains(channel)){
+      receivedHeartBeat.keys.foreach(channel => {
+        if (localHeartBeat.contains(channel)) {
           missingIds += (channel -> receivedHeartBeat.get(channel).get.filter(id =>
-          !localHeartBeat.get(channel).contains(id)))
+            !localHeartBeat.get(channel).contains(id)
+          ))
         }
       })
-      Right(JsonRpcRequest(RpcValidator.JSON_RPC_VERSION,MethodType.HEARTBEAT,Heartbeat(missingIds.toMap),None)) // how to pass the missing ids?? répondre par un getmsgsbyid et gérer les ids.
+      Right(JsonRpcRequest(RpcValidator.JSON_RPC_VERSION, MethodType.HEARTBEAT, Heartbeat(missingIds.toMap), None)) // how to pass the missing ids?? répondre par un getmsgsbyid et gérer les ids.
+
+    case Right(jsonRpcMessage: JsonRpcResponse) =>
+      Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "HeartbeatHandler received a 'JsonRpcResponse'", jsonRpcMessage.id))
+    case graphMessage @ _ => graphMessage
   })
 
+  def getMessagesByIdHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map({
+    case Right(jsonRpcMessage: JsonRpcRequest) => {
+      val receivedRequest: Map[Channel, Set[Hash]] = jsonRpcMessage.getParams.asInstanceOf[GetMessagesById].channelsToMessageIds
+      val ask = dbActorRef ? DbActor.GetSetOfChannels()
+      val answer = Await.result(ask, duration)
+      val setOfChannels: Set[Channel] = answer.asInstanceOf[DbActor.DbActorGetSetOfChannelsAck].channels.map(s => Channel(s))
+      var response: mutable.HashMap[Channel, Set[Message]] = mutable.HashMap()
+      receivedRequest.keys.foreach(channel => {
+        val ask = dbActorRef ? DbActor.Catchup(channel)
+        val answer = Await.result(ask, duration)
+        val missingIds = answer.asInstanceOf[DbActor.DbActorCatchupAck].messages.filter(message => receivedRequest.get(channel).contains(message.message_id)).to(collection.mutable.Set) // je retrieve tous les messages pour ne garder que ceux qui m'intéresse :((
+        response += (channel -> missingIds)
+      })
+      Right(JsonRpcResponse(RpcValidator.JSON_RPC_VERSION, Some(response), None, None))
 
+    }
+  })
 
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -86,7 +86,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
         Await.ready(ask, duration).value match {
           case Some(Success(DbActor.DbActorReadChannelDataAck(channelData))) =>
             val setOfIds = channelData.messages.toSet
-            localHeartBeat += (channel -> setOfIds.toList)
+            localHeartBeat += (channel -> setOfIds.toSet)
           case Some(Failure(ex: DbActorNAckException)) => Left(PipelineError(ex.code, s"couldn't readChannelData for local heartbeat", jsonRpcMessage.getId))
           case reply                                   => Left(PipelineError(ErrorCodes.SERVER_ERROR.id, s"heartbeatHandler failed : unexpected DbActor reply '$reply'", jsonRpcMessage.getId))
         }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -126,7 +126,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
       case Left(_) => false
       case Right(value) =>
         value match {
-          case response: JsonRpcResponse if response.result.get.resultMap.get.isEmpty => true
+          case response: JsonRpcRequest => response.getParams.asInstanceOf[GetMessagesById].channelsToMessageIds.isEmpty
           case _                                                                      => false
         }
     }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -96,11 +96,11 @@ object ParamsWithMapHandler extends AskPatternConstants {
       receivedHeartBeat.keys.foreach(channel => {
         if (localHeartBeat.contains(channel)) {
           missingIds += (channel -> receivedHeartBeat(channel).filter(id =>
-            !localHeartBeat.get(channel).contains(id)
+            !localHeartBeat(channel).contains(id)
           ))
         }
       })
-      Right(JsonRpcRequest(RpcValidator.JSON_RPC_VERSION, MethodType.GET_MESSAGES_BY_ID, Heartbeat(missingIds.toMap), None)) // how to pass the missing ids?? répondre par un getmsgsbyid et gérer les ids.
+      Right(JsonRpcRequest(RpcValidator.JSON_RPC_VERSION, MethodType.GET_MESSAGES_BY_ID, GetMessagesById(missingIds.toMap), None)) // how to pass the missing ids?? répondre par un getmsgsbyid et gérer les ids.
 
     case Right(jsonRpcMessage: JsonRpcResponse) =>
       Left(PipelineError(ErrorCodes.SERVER_ERROR.id, "HeartbeatHandler received a 'JsonRpcResponse'", jsonRpcMessage.id))

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -1,0 +1,50 @@
+package ch.epfl.pop.pubsub.graph.handlers
+
+import akka.NotUsed
+import akka.actor.ActorRef
+import akka.pattern.AskableActorRef
+import akka.stream.FlowShape
+import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition}
+import ch.epfl.pop.model.network.method.{Catchup, GetMessagesById, Heartbeat, Subscribe, Unsubscribe}
+import ch.epfl.pop.model.network.{JsonRpcRequest, JsonRpcResponse}
+import ch.epfl.pop.model.objects.Channel
+import ch.epfl.pop.pubsub.graph.{ErrorCodes, GraphMessage, PipelineError}
+import ch.epfl.pop.pubsub.{AskPatternConstants, ClientActor, PubSubMediator}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Await, Future}
+
+object ParamsWithMapHandler extends AskPatternConstants{
+
+  def graph(dbActorRef : AskableActorRef): Flow[GraphMessage, GraphMessage,NotUsed] = Flow.fromGraph(GraphDSL.create(){
+    implicit builder: GraphDSL.Builder[NotUsed] =>
+      {
+        import GraphDSL.Implicits._
+
+        /* partitioner port numbers */
+        val portPipelineError = 0
+        val portHeartBeatHandler = 1
+        val portGetMsgsByIdHandler = 2
+        val totalPorts = 3
+
+        /* building blocks */
+        val handlerPartitioner = builder.add(Partition[GraphMessage](
+          totalPorts,
+          {
+            case Right(jsonRpcMessage: JsonRpcRequest) => jsonRpcMessage.getParams match {
+              case _: Heartbeat => portHeartBeatHandler
+              case _: GetMessagesById => portGetMsgsByIdHandler
+
+            }
+            case _ => portPipelineError // Pipeline error goes directly in handlerMerger
+          }
+        ))
+
+        // ajouter les handlers
+
+      }
+  })
+
+
+
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -56,7 +56,6 @@ object ParamsWithMapHandler extends AskPatternConstants {
         /* close the shape */
         FlowShape(handlerPartitioner.in, handlerMerger.out)
 
-        // ajouter les handlers
 
       }
   })

--- a/be2-scala/src/test/scala/ch/epfl/pop/decentralized/ToyDbActor.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/decentralized/ToyDbActor.scala
@@ -1,0 +1,34 @@
+package ch.epfl.pop.decentralized
+
+import akka.actor.{Actor, ActorLogging}
+import ch.epfl.pop.model.network.method.message.Message
+import ch.epfl.pop.model.network.method.message.data.ObjectType
+import ch.epfl.pop.model.objects.{Base64Data, ChannelData, Hash}
+import ch.epfl.pop.storage.DbActor
+final case class ToyDbActor() extends Actor {
+
+  final val CHANNEL1_NAME: String = "/root/wex/lao1Id"
+  final val CHANNEL2_NAME: String = "/root/wex/lao2Id"
+  final val MESSAGE1_ID: Hash = Hash(Base64Data.encode("message1Id"))
+  final val MESSAGE2_ID: Hash = Hash(Base64Data.encode("message2Id"))
+  final val MESSAGE3_ID: Hash = Hash(Base64Data.encode("message3Id"))
+  final val MESSAGE4_ID: Hash = Hash(Base64Data.encode("message4Id"))
+  final val MESSAGE5_ID: Hash = Hash(Base64Data.encode("message5Id"))
+  final val MESSAGE1: Message = Message(null, null, null, MESSAGE1_ID, null, null)
+  final val MESSAGE4: Message = Message(null, null, null, MESSAGE4_ID, null, null)
+  override def receive: Receive = {
+    case DbActor.GetSetOfChannels() => sender() ! DbActor.DbActorGetSetOfChannelsAck(Set(CHANNEL1_NAME, CHANNEL2_NAME))
+    case DbActor.ReadChannelData(channel) =>
+      if (channel.channel.equals(CHANNEL1_NAME)) {
+        sender() ! DbActor.DbActorReadChannelDataAck(ChannelData(ObjectType.LAO, List(MESSAGE1_ID)))
+      } else {
+        sender() ! DbActor.DbActorReadChannelDataAck(ChannelData(ObjectType.LAO, List(MESSAGE4_ID)))
+      }
+    case DbActor.Catchup(channel) =>
+      if (channel.channel.equals(CHANNEL1_NAME)) {
+        sender() ! DbActor.DbActorCatchupAck(List(MESSAGE1))
+      } else {
+        sender() ! DbActor.DbActorCatchupAck(List(MESSAGE4))
+      }
+  }
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/decentralized/ToyDbActor.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/decentralized/ToyDbActor.scala
@@ -17,12 +17,13 @@ final case class ToyDbActor() extends Actor {
   final val MESSAGE1: Message = Message(null, null, null, MESSAGE1_ID, null, null)
   final val MESSAGE4: Message = Message(null, null, null, MESSAGE4_ID, null, null)
   override def receive: Receive = {
-    case DbActor.GetAllChannels() => sender() ! DbActor.DbActorGetAllChannelsAck(Set(Channel(CHANNEL1_NAME), Channel(CHANNEL2_NAME)))
+    case DbActor.GetAllChannels() =>
+      sender() ! DbActor.DbActorGetAllChannelsAck(Set(Channel(CHANNEL1_NAME), Channel(CHANNEL2_NAME)))
     case DbActor.ReadChannelData(channel) =>
       if (channel.channel.equals(CHANNEL1_NAME)) {
-        sender() ! DbActor.DbActorReadChannelDataAck(ChannelData(ObjectType.LAO, List(MESSAGE1_ID)))
+        sender() ! DbActor.DbActorReadChannelDataAck(ChannelData(ObjectType.LAO,List(MESSAGE1_ID)))
       } else {
-        sender() ! DbActor.DbActorReadChannelDataAck(ChannelData(ObjectType.LAO, List(MESSAGE4_ID)))
+        sender() ! DbActor.DbActorReadChannelDataAck(ChannelData(ObjectType.LAO,List(MESSAGE4_ID)))
       }
     case DbActor.Catchup(channel) =>
       if (channel.channel.equals(CHANNEL1_NAME)) {

--- a/be2-scala/src/test/scala/ch/epfl/pop/decentralized/ToyDbActor.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/decentralized/ToyDbActor.scala
@@ -3,7 +3,7 @@ package ch.epfl.pop.decentralized
 import akka.actor.{Actor, ActorLogging}
 import ch.epfl.pop.model.network.method.message.Message
 import ch.epfl.pop.model.network.method.message.data.ObjectType
-import ch.epfl.pop.model.objects.{Base64Data, ChannelData, Hash}
+import ch.epfl.pop.model.objects.{Base64Data, Channel, ChannelData, Hash}
 import ch.epfl.pop.storage.DbActor
 final case class ToyDbActor() extends Actor {
 
@@ -17,7 +17,7 @@ final case class ToyDbActor() extends Actor {
   final val MESSAGE1: Message = Message(null, null, null, MESSAGE1_ID, null, null)
   final val MESSAGE4: Message = Message(null, null, null, MESSAGE4_ID, null, null)
   override def receive: Receive = {
-    case DbActor.GetSetOfChannels() => sender() ! DbActor.DbActorGetSetOfChannelsAck(Set(CHANNEL1_NAME, CHANNEL2_NAME))
+    case DbActor.GetAllChannels() => sender() ! DbActor.DbActorGetAllChannelsAck(Set(Channel(CHANNEL1_NAME), Channel(CHANNEL2_NAME)))
     case DbActor.ReadChannelData(channel) =>
       if (channel.channel.equals(CHANNEL1_NAME)) {
         sender() ! DbActor.DbActorReadChannelDataAck(ChannelData(ObjectType.LAO, List(MESSAGE1_ID)))

--- a/be2-scala/src/test/scala/ch/epfl/pop/decentralized/ToyDbActor.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/decentralized/ToyDbActor.scala
@@ -21,9 +21,9 @@ final case class ToyDbActor() extends Actor {
       sender() ! DbActor.DbActorGetAllChannelsAck(Set(Channel(CHANNEL1_NAME), Channel(CHANNEL2_NAME)))
     case DbActor.ReadChannelData(channel) =>
       if (channel.channel.equals(CHANNEL1_NAME)) {
-        sender() ! DbActor.DbActorReadChannelDataAck(ChannelData(ObjectType.LAO,List(MESSAGE1_ID)))
+        sender() ! DbActor.DbActorReadChannelDataAck(ChannelData(ObjectType.LAO, List(MESSAGE1_ID)))
       } else {
-        sender() ! DbActor.DbActorReadChannelDataAck(ChannelData(ObjectType.LAO,List(MESSAGE4_ID)))
+        sender() ! DbActor.DbActorReadChannelDataAck(ChannelData(ObjectType.LAO, List(MESSAGE4_ID)))
       }
     case DbActor.Catchup(channel) =>
       if (channel.channel.equals(CHANNEL1_NAME)) {

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/network/ResultObjectSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/network/ResultObjectSuite.scala
@@ -1,5 +1,7 @@
 package ch.epfl.pop.model.network
 
+import ch.epfl.pop.model.network.method.message.Message
+import ch.epfl.pop.model.objects.Channel
 import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
 import org.scalatest.matchers.should.Matchers
 
@@ -9,31 +11,50 @@ class ResultObjectSuite extends FunSuite with Matchers {
 
     obj.resultInt should equal(Some(1))
     obj.resultMessages should equal(None)
+    obj.resultMap should equal(None)
   }
 
   test("List constructor works") {
     val obj: ResultObject = new ResultObject(List.empty)
 
     obj.resultInt should equal(None)
+    obj.resultMap should equal(None)
     obj.resultMessages should equal(Some(List.empty))
+  }
+
+  test("Map constructor works") {
+    val obj: ResultObject = new ResultObject(Map[Channel, Set[Message]]())
+
+    obj.resultInt should equal(None)
+    obj.resultMessages should equal(None)
+    obj.resultMap should equal(Some(Map.empty))
+
   }
 
   test("isIntResult returns right result") {
     val obj: ResultObject = new ResultObject(1)
     val obj2: ResultObject = new ResultObject(List.empty)
+    val obj3: ResultObject = new ResultObject(Map[Channel, Set[Message]]())
 
     obj.isIntResult should equal(true)
     obj2.isIntResult should equal(false)
+    obj3.isIntResult should equal(false)
+
   }
 
   test("equals works") {
     val obj: ResultObject = new ResultObject(1)
     val obj2: ResultObject = new ResultObject(List.empty)
+    val obj5: ResultObject = new ResultObject(Map[Channel, Set[Message]]())
     val obj3: ResultObject = new ResultObject(1)
     val obj4: ResultObject = new ResultObject(List.empty)
+    val obj6: ResultObject = new ResultObject(Map[Channel, Set[Message]]())
 
     obj.equals(obj3) should equal(true)
     obj2.equals(obj4) should equal(true)
     obj2.equals(obj) should equal(false)
+    obj5.equals(obj6) should equal(true)
+    obj5.equals(obj) should equal(false)
+    obj6.equals(obj2) should equal(false)
   }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
@@ -55,4 +55,18 @@ class ParamsWithMapHandlerSuite extends TestKit(ActorSystem("HbActorSuiteActorSy
 
   }
 
+  test("receiving a heartbeat with unknown channel asks back for this channel") {
+    val input: List[GraphMessage] = List(Right(VALID_RECEIVED_UNKNOWN_CHANNEL_HEARTBEAT_RPC))
+    val source = Source(input)
+    val s = source.via(boxUnderTest).runWith(Sink.seq[GraphMessage])
+    Await.ready(s, duration).value match {
+      case Some(Success(seq)) => seq.toList.head match {
+        case Right(jsonRpcReq: JsonRpcRequest) => jsonRpcReq.getParams.asInstanceOf[GetMessagesById].channelsToMessageIds should equal(EXPECTED_UNKNOWN_CHANNEL_MISSING_MESSAGE_IDS)
+        case _ => 1 should equal(0)
+      }
+
+      case _ => 1 should equal(0)
+    }
+  }
+
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
@@ -1,0 +1,69 @@
+package ch.epfl.pop.pubsub.graph.handlers
+
+import akka.NotUsed
+import akka.actor.{ActorSystem, Props}
+import akka.pattern.AskableActorRef
+import akka.stream.SinkShape
+import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.testkit.TestKit
+import ch.epfl.pop.decentralized.ToyDbActor
+import ch.epfl.pop.model.network.{JsonRpcRequest, MethodType}
+import ch.epfl.pop.model.network.method.{GetMessagesById, Heartbeat}
+import ch.epfl.pop.model.network.method.message.Message
+import ch.epfl.pop.model.objects.{Base64Data, Channel, Hash}
+import ch.epfl.pop.pubsub.AskPatternConstants
+import ch.epfl.pop.pubsub.graph.GraphMessage
+import org.scalatest.funsuite.{AnyFunSuite, AnyFunSuiteLike}
+import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, equal}
+
+import scala.collection.{immutable, mutable}
+import scala.concurrent.{Await, Future}
+import scala.util.{Failure, Success}
+class ParamsWithMapHandlerSuite extends TestKit(ActorSystem("HbActorSuiteActorSystem")) with AnyFunSuiteLike with AskPatternConstants{
+
+  final val toyDbActorRef: AskableActorRef = system.actorOf(Props(new ToyDbActor))
+  final val boxUnderTest: Flow[GraphMessage, GraphMessage, NotUsed] = ParamsWithMapHandler.graph(toyDbActorRef)
+  final val rpc: String = "rpc"
+  final val id: Option[Int] = Some(0)
+
+  // defining the channels
+  final val CHANNEL1_NAME: String = "/root/wex/lao1Id"
+  final val CHANNEL2_NAME: String = "/root/wex/lao2Id"
+  final val CHANNEL1 = new Channel(CHANNEL1_NAME)
+  final val CHANNEL2 = new Channel(CHANNEL2_NAME)
+
+  //defining the messages
+  final val MESSAGE1_ID: Hash = Hash(Base64Data.encode("message1Id"))
+  final val MESSAGE2_ID: Hash = Hash(Base64Data.encode("message2Id"))
+  final val MESSAGE3_ID: Hash = Hash(Base64Data.encode("message3Id"))
+  final val MESSAGE4_ID: Hash = Hash(Base64Data.encode("message4Id"))
+  final val MESSAGE5_ID: Hash = Hash(Base64Data.encode("message5Id"))
+  final val MESSAGE1: Message = Message(null, null, null, MESSAGE1_ID, null, null)
+  final val MESSAGE2: Message = Message(null, null, null, MESSAGE2_ID, null, null)
+  final val MESSAGE3: Message = Message(null, null, null, MESSAGE3_ID, null, null)
+  final val MESSAGE4: Message = Message(null, null, null, MESSAGE4_ID, null, null)
+  final val MESSAGE5: Message = Message(null, null, null, MESSAGE5_ID, null, null)
+
+  // defining a received heartbeat
+  final val RECEIVED_HEART_BEAT_PARAMS = Map(CHANNEL1 -> Set(MESSAGE1_ID, MESSAGE2_ID, MESSAGE3_ID), CHANNEL2 -> Set(MESSAGE4_ID, MESSAGE5_ID))
+  final val RECEIVED_HEARTBEAT: Heartbeat = Heartbeat(RECEIVED_HEART_BEAT_PARAMS)
+  final val VALID_RECEIVED_HEARTBEAT_RPC: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.HEARTBEAT, RECEIVED_HEARTBEAT, id)
+
+  // defining what the answer to the received heartbeat should be
+  final val EXPECTED_MISSING_MESSAGE_IDS = Map(CHANNEL1 -> Set(MESSAGE2_ID, MESSAGE3_ID), CHANNEL2 -> Set(MESSAGE5_ID))
+  final val EXPECTED_GET_MSGS_BY_ID_RESPONSE: GetMessagesById = GetMessagesById(EXPECTED_MISSING_MESSAGE_IDS)
+  final val EXPECTED_GET_MSGS_BY_ID_RPC: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.GET_MESSAGES_BY_ID, EXPECTED_GET_MSGS_BY_ID_RESPONSE, id)
+
+
+  test("sending a heartbeat correctly returns the missing ids") {
+    val input: List[GraphMessage] = List(Right(VALID_RECEIVED_HEARTBEAT_RPC))
+    val expectedOutput: List[GraphMessage] = List(Right(EXPECTED_GET_MSGS_BY_ID_RPC))
+    val source = Source(input)
+    val s = source.via(boxUnderTest).runWith(Sink.seq[GraphMessage])
+    Await.ready(s, duration).value match {
+      case Some(Success(seq)) => seq.toList should equal(expectedOutput)
+      case Some(Failure(_)) => 1 should equal(0)
+    }
+  }
+
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
@@ -16,7 +16,7 @@ import ch.epfl.pop.pubsub.graph.GraphMessage
 import ch.epfl.pop.pubsub.graph.validators.RpcValidator
 import org.scalatest.funsuite.{AnyFunSuite, AnyFunSuiteLike}
 import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, equal}
-
+import util.examples.JsonRpcRequestExample._
 import scala.collection.{immutable, mutable}
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success}
@@ -27,46 +27,9 @@ class ParamsWithMapHandlerSuite extends TestKit(ActorSystem("HbActorSuiteActorSy
   final val rpc: String = "rpc"
   final val id: Option[Int] = Some(0)
 
-  // defining the channels
-  final val CHANNEL1_NAME: String = "/root/wex/lao1Id"
-  final val CHANNEL2_NAME: String = "/root/wex/lao2Id"
-  final val CHANNEL1 = new Channel(CHANNEL1_NAME)
-  final val CHANNEL2 = new Channel(CHANNEL2_NAME)
-
-  // defining the messages
-  final val MESSAGE1_ID: Hash = Hash(Base64Data.encode("message1Id"))
-  final val MESSAGE2_ID: Hash = Hash(Base64Data.encode("message2Id"))
-  final val MESSAGE3_ID: Hash = Hash(Base64Data.encode("message3Id"))
-  final val MESSAGE4_ID: Hash = Hash(Base64Data.encode("message4Id"))
-  final val MESSAGE5_ID: Hash = Hash(Base64Data.encode("message5Id"))
-  final val MESSAGE1: Message = Message(null, null, null, MESSAGE1_ID, null, null)
-  final val MESSAGE2: Message = Message(null, null, null, MESSAGE2_ID, null, null)
-  final val MESSAGE3: Message = Message(null, null, null, MESSAGE3_ID, null, null)
-  final val MESSAGE4: Message = Message(null, null, null, MESSAGE4_ID, null, null)
-  final val MESSAGE5: Message = Message(null, null, null, MESSAGE5_ID, null, null)
-
-  // defining a received heartbeat
-  final val RECEIVED_HEART_BEAT_PARAMS = Map(CHANNEL1 -> Set(MESSAGE1_ID, MESSAGE2_ID, MESSAGE3_ID), CHANNEL2 -> Set(MESSAGE4_ID, MESSAGE5_ID))
-  final val RECEIVED_HEARTBEAT: Heartbeat = Heartbeat(RECEIVED_HEART_BEAT_PARAMS)
-  final val VALID_RECEIVED_HEARTBEAT_RPC: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.HEARTBEAT, RECEIVED_HEARTBEAT, id)
-
-  // defining what the answer to the received heartbeat should be
-  final val EXPECTED_MISSING_MESSAGE_IDS = Map(CHANNEL1 -> Set(MESSAGE2_ID, MESSAGE3_ID), CHANNEL2 -> Set(MESSAGE5_ID))
-  final val EXPECTED_GET_MSGS_BY_ID_RESPONSE: GetMessagesById = GetMessagesById(EXPECTED_MISSING_MESSAGE_IDS)
-  final val EXPECTED_GET_MSGS_BY_ID_RPC: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.GET_MESSAGES_BY_ID, EXPECTED_GET_MSGS_BY_ID_RESPONSE, id)
-
-  // defining a received getMsgsById
-  final val RECEIVED_GET_MSG_BY_ID_PARAMS = Map(CHANNEL1 -> Set(MESSAGE1_ID))
-  final val RECEIVED_GET_MSG_BY_ID: GetMessagesById = GetMessagesById(RECEIVED_GET_MSG_BY_ID_PARAMS)
-  final val VALID_RECEIVED_GET_MSG_BY_ID_RPC: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.GET_MESSAGES_BY_ID, RECEIVED_GET_MSG_BY_ID, id)
-
-  // defined what the answer to the received getMsgsById should be
-  final val EXPECTED_MISSING_MESSAGES = Map(CHANNEL1 -> Set(MESSAGE1))
-  final val EXPECTED_GET_MSGS_BY_ID_RPC_RESPONSE: JsonRpcResponse = JsonRpcResponse(RpcValidator.JSON_RPC_VERSION, Some(new ResultObject(EXPECTED_MISSING_MESSAGES)), None, None)
 
   test("sending a heartbeat correctly returns the missing ids") {
     val input: List[GraphMessage] = List(Right(VALID_RECEIVED_HEARTBEAT_RPC))
-    val expectedOutput: List[GraphMessage] = List(Right(EXPECTED_GET_MSGS_BY_ID_RPC))
     val source = Source(input)
     val s = source.via(boxUnderTest).runWith(Sink.seq[GraphMessage])
     Await.ready(s, duration).value match {
@@ -81,7 +44,6 @@ class ParamsWithMapHandlerSuite extends TestKit(ActorSystem("HbActorSuiteActorSy
 
   test("sending a getMessagesById correctly returns the missing messages") {
     val input: List[GraphMessage] = List(Right(VALID_RECEIVED_GET_MSG_BY_ID_RPC))
-    val expectedOutput: List[GraphMessage] = List(Right(EXPECTED_GET_MSGS_BY_ID_RPC_RESPONSE))
     val source = Source(input)
     val s = source.via(boxUnderTest).runWith(Sink.seq[GraphMessage])
     Await.ready(s, duration).value match {

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
@@ -61,9 +61,9 @@ class ParamsWithMapHandlerSuite extends TestKit(ActorSystem("HbActorSuiteActorSy
     val s = source.via(boxUnderTest).runWith(Sink.seq[GraphMessage])
     Await.ready(s, duration).value match {
       case Some(Success(seq)) => seq.toList.head match {
-        case Right(jsonRpcReq: JsonRpcRequest) => jsonRpcReq.getParams.asInstanceOf[GetMessagesById].channelsToMessageIds should equal(EXPECTED_UNKNOWN_CHANNEL_MISSING_MESSAGE_IDS)
-        case _ => 1 should equal(0)
-      }
+          case Right(jsonRpcReq: JsonRpcRequest) => jsonRpcReq.getParams.asInstanceOf[GetMessagesById].channelsToMessageIds should equal(EXPECTED_UNKNOWN_CHANNEL_MISSING_MESSAGE_IDS)
+          case _                                 => 1 should equal(0)
+        }
 
       case _ => 1 should equal(0)
     }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
@@ -61,8 +61,13 @@ class ParamsWithMapHandlerSuite extends TestKit(ActorSystem("HbActorSuiteActorSy
     val source = Source(input)
     val s = source.via(boxUnderTest).runWith(Sink.seq[GraphMessage])
     Await.ready(s, duration).value match {
-      case Some(Success(seq)) => seq.toList should equal(expectedOutput)
-      case Some(Failure(_)) => 1 should equal(0)
+      case Some(Success(seq)) => seq.toList.head match {
+        case Right(jsonRpcReq : JsonRpcRequest) => jsonRpcReq.getParams.asInstanceOf[GetMessagesById].channelsToMessageIds should equal(EXPECTED_MISSING_MESSAGE_IDS)
+        case _ => 1 should equal(0)
+      }
+
+
+      case _ => 1 should equal(0)
     }
   }
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
@@ -27,7 +27,6 @@ class ParamsWithMapHandlerSuite extends TestKit(ActorSystem("HbActorSuiteActorSy
   final val rpc: String = "rpc"
   final val id: Option[Int] = Some(0)
 
-
   test("sending a heartbeat correctly returns the missing ids") {
     val input: List[GraphMessage] = List(Right(VALID_RECEIVED_HEARTBEAT_RPC))
     val source = Source(input)

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
@@ -19,7 +19,7 @@ import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, equal}
 import scala.collection.{immutable, mutable}
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success}
-class ParamsWithMapHandlerSuite extends TestKit(ActorSystem("HbActorSuiteActorSystem")) with AnyFunSuiteLike with AskPatternConstants{
+class ParamsWithMapHandlerSuite extends TestKit(ActorSystem("HbActorSuiteActorSystem")) with AnyFunSuiteLike with AskPatternConstants {
 
   final val toyDbActorRef: AskableActorRef = system.actorOf(Props(new ToyDbActor))
   final val boxUnderTest: Flow[GraphMessage, GraphMessage, NotUsed] = ParamsWithMapHandler.graph(toyDbActorRef)
@@ -32,7 +32,7 @@ class ParamsWithMapHandlerSuite extends TestKit(ActorSystem("HbActorSuiteActorSy
   final val CHANNEL1 = new Channel(CHANNEL1_NAME)
   final val CHANNEL2 = new Channel(CHANNEL2_NAME)
 
-  //defining the messages
+  // defining the messages
   final val MESSAGE1_ID: Hash = Hash(Base64Data.encode("message1Id"))
   final val MESSAGE2_ID: Hash = Hash(Base64Data.encode("message2Id"))
   final val MESSAGE3_ID: Hash = Hash(Base64Data.encode("message3Id"))
@@ -54,7 +54,6 @@ class ParamsWithMapHandlerSuite extends TestKit(ActorSystem("HbActorSuiteActorSy
   final val EXPECTED_GET_MSGS_BY_ID_RESPONSE: GetMessagesById = GetMessagesById(EXPECTED_MISSING_MESSAGE_IDS)
   final val EXPECTED_GET_MSGS_BY_ID_RPC: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.GET_MESSAGES_BY_ID, EXPECTED_GET_MSGS_BY_ID_RESPONSE, id)
 
-
   test("sending a heartbeat correctly returns the missing ids") {
     val input: List[GraphMessage] = List(Right(VALID_RECEIVED_HEARTBEAT_RPC))
     val expectedOutput: List[GraphMessage] = List(Right(EXPECTED_GET_MSGS_BY_ID_RPC))
@@ -62,10 +61,9 @@ class ParamsWithMapHandlerSuite extends TestKit(ActorSystem("HbActorSuiteActorSy
     val s = source.via(boxUnderTest).runWith(Sink.seq[GraphMessage])
     Await.ready(s, duration).value match {
       case Some(Success(seq)) => seq.toList.head match {
-        case Right(jsonRpcReq : JsonRpcRequest) => jsonRpcReq.getParams.asInstanceOf[GetMessagesById].channelsToMessageIds should equal(EXPECTED_MISSING_MESSAGE_IDS)
-        case _ => 1 should equal(0)
-      }
-
+          case Right(jsonRpcReq: JsonRpcRequest) => jsonRpcReq.getParams.asInstanceOf[GetMessagesById].channelsToMessageIds should equal(EXPECTED_MISSING_MESSAGE_IDS)
+          case _                                 => 1 should equal(0)
+        }
 
       case _ => 1 should equal(0)
     }

--- a/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
+++ b/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
@@ -1,8 +1,10 @@
 package util.examples
 
-import ch.epfl.pop.model.network.method.{ParamsWithChannel, ParamsWithMessage}
-import ch.epfl.pop.model.network.{JsonRpcRequest, MethodType}
-import ch.epfl.pop.model.objects.{Base64Data, Channel}
+import ch.epfl.pop.model.network.method.message.Message
+import ch.epfl.pop.model.network.method.{GetMessagesById, Heartbeat, ParamsWithChannel, ParamsWithMessage}
+import ch.epfl.pop.model.network.{JsonRpcRequest, JsonRpcResponse, MethodType, ResultObject}
+import ch.epfl.pop.model.objects.{Base64Data, Channel, Hash}
+import ch.epfl.pop.pubsub.graph.validators.RpcValidator
 import util.examples.Election.CastVoteElectionExamples._
 import util.examples.Election.OpenElectionExamples._
 import util.examples.Election.SetupElectionExamples.{ELECTION_ID, _}
@@ -269,5 +271,44 @@ object JsonRpcRequestExample {
   final val subscribeRpcRequest: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.SUBSCRIBE, paramsWithChannel, id)
   final val unSubscribeRpcRequest: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.UNSUBSCRIBE, paramsWithChannel, id)
   final val catchupRpcRequest: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.CATCHUP, paramsWithChannel, id)
+
+  // paramsWithMap JsonRpcRequest
+  // defining the channels
+  final val CHANNEL1_NAME: String = "/root/wex/lao1Id"
+  final val CHANNEL2_NAME: String = "/root/wex/lao2Id"
+  final val CHANNEL1 = new Channel(CHANNEL1_NAME)
+  final val CHANNEL2 = new Channel(CHANNEL2_NAME)
+
+  // defining the messages
+  final val MESSAGE1_ID: Hash = Hash(Base64Data.encode("message1Id"))
+  final val MESSAGE2_ID: Hash = Hash(Base64Data.encode("message2Id"))
+  final val MESSAGE3_ID: Hash = Hash(Base64Data.encode("message3Id"))
+  final val MESSAGE4_ID: Hash = Hash(Base64Data.encode("message4Id"))
+  final val MESSAGE5_ID: Hash = Hash(Base64Data.encode("message5Id"))
+  final val MESSAGE1: Message = Message(null, null, null, MESSAGE1_ID, null, null)
+  final val MESSAGE2: Message = Message(null, null, null, MESSAGE2_ID, null, null)
+  final val MESSAGE3: Message = Message(null, null, null, MESSAGE3_ID, null, null)
+  final val MESSAGE4: Message = Message(null, null, null, MESSAGE4_ID, null, null)
+  final val MESSAGE5: Message = Message(null, null, null, MESSAGE5_ID, null, null)
+
+  // defining a received heartbeat
+  final val RECEIVED_HEART_BEAT_PARAMS = Map(CHANNEL1 -> Set(MESSAGE1_ID, MESSAGE2_ID, MESSAGE3_ID), CHANNEL2 -> Set(MESSAGE4_ID, MESSAGE5_ID))
+  final val RECEIVED_HEARTBEAT: Heartbeat = Heartbeat(RECEIVED_HEART_BEAT_PARAMS)
+  final val VALID_RECEIVED_HEARTBEAT_RPC: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.HEARTBEAT, RECEIVED_HEARTBEAT, id)
+
+  // defining what the answer to the received heartbeat should be
+  final val EXPECTED_MISSING_MESSAGE_IDS = Map(CHANNEL1 -> Set(MESSAGE2_ID, MESSAGE3_ID), CHANNEL2 -> Set(MESSAGE5_ID))
+  final val EXPECTED_GET_MSGS_BY_ID_RESPONSE: GetMessagesById = GetMessagesById(EXPECTED_MISSING_MESSAGE_IDS)
+  final val EXPECTED_GET_MSGS_BY_ID_RPC: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.GET_MESSAGES_BY_ID, EXPECTED_GET_MSGS_BY_ID_RESPONSE, id)
+
+  // defining a received getMsgsById
+  final val RECEIVED_GET_MSG_BY_ID_PARAMS = Map(CHANNEL1 -> Set(MESSAGE1_ID))
+  final val RECEIVED_GET_MSG_BY_ID: GetMessagesById = GetMessagesById(RECEIVED_GET_MSG_BY_ID_PARAMS)
+  final val VALID_RECEIVED_GET_MSG_BY_ID_RPC: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.GET_MESSAGES_BY_ID, RECEIVED_GET_MSG_BY_ID, id)
+
+  // defined what the answer to the received getMsgsById should be
+  final val EXPECTED_MISSING_MESSAGES = Map(CHANNEL1 -> Set(MESSAGE1))
+  final val EXPECTED_GET_MSGS_BY_ID_RPC_RESPONSE: JsonRpcResponse = JsonRpcResponse(RpcValidator.JSON_RPC_VERSION, Some(new ResultObject(EXPECTED_MISSING_MESSAGES)), None, None)
+
 
 }

--- a/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
+++ b/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
@@ -276,8 +276,10 @@ object JsonRpcRequestExample {
   // defining the channels
   final val CHANNEL1_NAME: String = "/root/wex/lao1Id"
   final val CHANNEL2_NAME: String = "/root/wex/lao2Id"
+  final val CHANNEL3_NAME: String = "/root/wex/lao3Id"
   final val CHANNEL1 = new Channel(CHANNEL1_NAME)
   final val CHANNEL2 = new Channel(CHANNEL2_NAME)
+  final val CHANNEL3 = new Channel(CHANNEL3_NAME)
 
   // defining the messages
   final val MESSAGE1_ID: Hash = Hash(Base64Data.encode("message1Id"))
@@ -285,12 +287,13 @@ object JsonRpcRequestExample {
   final val MESSAGE3_ID: Hash = Hash(Base64Data.encode("message3Id"))
   final val MESSAGE4_ID: Hash = Hash(Base64Data.encode("message4Id"))
   final val MESSAGE5_ID: Hash = Hash(Base64Data.encode("message5Id"))
+  final val MESSAGE6_ID: Hash = Hash(Base64Data.encode("message6Id"))
   final val MESSAGE1: Message = Message(null, null, null, MESSAGE1_ID, null, null)
   final val MESSAGE2: Message = Message(null, null, null, MESSAGE2_ID, null, null)
   final val MESSAGE3: Message = Message(null, null, null, MESSAGE3_ID, null, null)
   final val MESSAGE4: Message = Message(null, null, null, MESSAGE4_ID, null, null)
   final val MESSAGE5: Message = Message(null, null, null, MESSAGE5_ID, null, null)
-
+  final val MESSAGE6: Message = Message(null, null, null, MESSAGE6_ID, null, null)
   // defining a received heartbeat
   final val RECEIVED_HEARTBEAT_PARAMS = Map(CHANNEL1 -> Set(MESSAGE1_ID, MESSAGE2_ID, MESSAGE3_ID), CHANNEL2 -> Set(MESSAGE4_ID, MESSAGE5_ID))
   final val RECEIVED_HEARTBEAT: Heartbeat = Heartbeat(RECEIVED_HEARTBEAT_PARAMS)
@@ -310,4 +313,10 @@ object JsonRpcRequestExample {
   final val EXPECTED_MISSING_MESSAGES = Map(CHANNEL1 -> Set(MESSAGE1))
   final val EXPECTED_GET_MSGS_BY_ID_RPC_RESPONSE: JsonRpcResponse = JsonRpcResponse(RpcValidator.JSON_RPC_VERSION, Some(new ResultObject(EXPECTED_MISSING_MESSAGES)), None, None)
 
+  //defining a heartbeat on an unknown channel
+  final val RECEIVED_UNKNOWN_CHANNEL_HEARTBEAT_PARAMS = Map(CHANNEL3 -> Set(MESSAGE6_ID))
+  final val RECEIVED_UNKNOWN_CHANNEL_HEARTBEAT : Heartbeat = Heartbeat(RECEIVED_UNKNOWN_CHANNEL_HEARTBEAT_PARAMS)
+  final val VALID_RECEIVED_UNKNOWN_CHANNEL_HEARTBEAT_RPC: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.HEARTBEAT, RECEIVED_UNKNOWN_CHANNEL_HEARTBEAT, id)
+
+  final val EXPECTED_UNKNOWN_CHANNEL_MISSING_MESSAGE_IDS = Map(CHANNEL3 -> Set(MESSAGE6_ID))
 }

--- a/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
+++ b/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
@@ -313,9 +313,9 @@ object JsonRpcRequestExample {
   final val EXPECTED_MISSING_MESSAGES = Map(CHANNEL1 -> Set(MESSAGE1))
   final val EXPECTED_GET_MSGS_BY_ID_RPC_RESPONSE: JsonRpcResponse = JsonRpcResponse(RpcValidator.JSON_RPC_VERSION, Some(new ResultObject(EXPECTED_MISSING_MESSAGES)), None, None)
 
-  //defining a heartbeat on an unknown channel
+  // defining a heartbeat on an unknown channel
   final val RECEIVED_UNKNOWN_CHANNEL_HEARTBEAT_PARAMS = Map(CHANNEL3 -> Set(MESSAGE6_ID))
-  final val RECEIVED_UNKNOWN_CHANNEL_HEARTBEAT : Heartbeat = Heartbeat(RECEIVED_UNKNOWN_CHANNEL_HEARTBEAT_PARAMS)
+  final val RECEIVED_UNKNOWN_CHANNEL_HEARTBEAT: Heartbeat = Heartbeat(RECEIVED_UNKNOWN_CHANNEL_HEARTBEAT_PARAMS)
   final val VALID_RECEIVED_UNKNOWN_CHANNEL_HEARTBEAT_RPC: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.HEARTBEAT, RECEIVED_UNKNOWN_CHANNEL_HEARTBEAT, id)
 
   final val EXPECTED_UNKNOWN_CHANNEL_MISSING_MESSAGE_IDS = Map(CHANNEL3 -> Set(MESSAGE6_ID))

--- a/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
+++ b/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
@@ -292,8 +292,8 @@ object JsonRpcRequestExample {
   final val MESSAGE5: Message = Message(null, null, null, MESSAGE5_ID, null, null)
 
   // defining a received heartbeat
-  final val RECEIVED_HEART_BEAT_PARAMS = Map(CHANNEL1 -> Set(MESSAGE1_ID, MESSAGE2_ID, MESSAGE3_ID), CHANNEL2 -> Set(MESSAGE4_ID, MESSAGE5_ID))
-  final val RECEIVED_HEARTBEAT: Heartbeat = Heartbeat(RECEIVED_HEART_BEAT_PARAMS)
+  final val RECEIVED_HEARTBEAT_PARAMS = Map(CHANNEL1 -> Set(MESSAGE1_ID, MESSAGE2_ID, MESSAGE3_ID), CHANNEL2 -> Set(MESSAGE4_ID, MESSAGE5_ID))
+  final val RECEIVED_HEARTBEAT: Heartbeat = Heartbeat(RECEIVED_HEARTBEAT_PARAMS)
   final val VALID_RECEIVED_HEARTBEAT_RPC: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.HEARTBEAT, RECEIVED_HEARTBEAT, id)
 
   // defining what the answer to the received heartbeat should be
@@ -306,7 +306,7 @@ object JsonRpcRequestExample {
   final val RECEIVED_GET_MSG_BY_ID: GetMessagesById = GetMessagesById(RECEIVED_GET_MSG_BY_ID_PARAMS)
   final val VALID_RECEIVED_GET_MSG_BY_ID_RPC: JsonRpcRequest = JsonRpcRequest(rpc, MethodType.GET_MESSAGES_BY_ID, RECEIVED_GET_MSG_BY_ID, id)
 
-  // defined what the answer to the received getMsgsById should be
+  // defining what the answer to the received getMsgsById should be
   final val EXPECTED_MISSING_MESSAGES = Map(CHANNEL1 -> Set(MESSAGE1))
   final val EXPECTED_GET_MSGS_BY_ID_RPC_RESPONSE: JsonRpcResponse = JsonRpcResponse(RpcValidator.JSON_RPC_VERSION, Some(new ResultObject(EXPECTED_MISSING_MESSAGES)), None, None)
 

--- a/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
+++ b/be2-scala/src/test/scala/util/examples/JsonRpcRequestExample.scala
@@ -310,5 +310,4 @@ object JsonRpcRequestExample {
   final val EXPECTED_MISSING_MESSAGES = Map(CHANNEL1 -> Set(MESSAGE1))
   final val EXPECTED_GET_MSGS_BY_ID_RPC_RESPONSE: JsonRpcResponse = JsonRpcResponse(RpcValidator.JSON_RPC_VERSION, Some(new ResultObject(EXPECTED_MISSING_MESSAGES)), None, None)
 
-
 }

--- a/be2-scala/src/test/scala/util/examples/Lao/GreetLaoExamples.scala
+++ b/be2-scala/src/test/scala/util/examples/Lao/GreetLaoExamples.scala
@@ -1,6 +1,6 @@
 package util.examples.Lao
 
-import ch.epfl.pop.json.MessageDataProtocol.GreetLaoFormat
+import ch.epfl.pop.json.MessageDataProtocol._
 import ch.epfl.pop.model.network.method.message.Message
 import ch.epfl.pop.model.network.method.message.data.lao.GreetLao
 import ch.epfl.pop.model.objects._


### PR DESCRIPTION
This pull request modifies the global architecture of the scala backend in the following way : 

Since the new introduced set of messages to handle server to server communication (heartbeat, getMessagesById) contain map parameters, we had to think of a solution to handle such messages. 

In the new architecture, the getMessagesById and Heartbeat messages arriving to the server are treated separately with a specific set of handlers dedicated to them in ParamsWithMapHandler.scala.