### PR TITLE
Increase handler test coverage

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/PendingUpdate.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/PendingUpdate.java
@@ -3,6 +3,8 @@ package com.github.dedis.popstellar.model.objects;
 import com.github.dedis.popstellar.model.Immutable;
 import com.github.dedis.popstellar.model.objects.security.MessageID;
 
+import java.util.Objects;
+
 @Immutable
 public class PendingUpdate implements Comparable<PendingUpdate> {
 
@@ -25,5 +27,23 @@ public class PendingUpdate implements Comparable<PendingUpdate> {
   @Override
   public int compareTo(PendingUpdate o) {
     return Long.compare(modificationTime, o.modificationTime);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PendingUpdate that = (PendingUpdate) o;
+    return modificationTime == that.modificationTime &&
+        Objects.equals(messageId, that.messageId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(modificationTime, messageId);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/PendingUpdate.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/PendingUpdate.java
@@ -38,8 +38,7 @@ public class PendingUpdate implements Comparable<PendingUpdate> {
       return false;
     }
     PendingUpdate that = (PendingUpdate) o;
-    return modificationTime == that.modificationTime &&
-        Objects.equals(messageId, that.messageId);
+    return modificationTime == that.modificationTime && Objects.equals(messageId, that.messageId);
   }
 
   @Override

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
@@ -19,7 +19,9 @@ import javax.inject.Inject;
 
 import static com.github.dedis.popstellar.model.objects.event.EventState.*;
 
-/** Election messages handler class */
+/**
+ * Election messages handler class
+ */
 public final class ElectionHandler {
 
   public static final String TAG = ElectionHandler.class.getSimpleName();
@@ -39,7 +41,7 @@ public final class ElectionHandler {
   /**
    * Process an ElectionSetup message.
    *
-   * @param context the HandlerContext of the message
+   * @param context       the HandlerContext of the message
    * @param electionSetup the message that was received
    */
   public void handleElectionSetup(HandlerContext context, ElectionSetup electionSetup)
@@ -56,7 +58,7 @@ public final class ElectionHandler {
 
     Election election =
         new Election.ElectionBuilder(
-                laoView.getId(), electionSetup.getCreation(), electionSetup.getName())
+            laoView.getId(), electionSetup.getCreation(), electionSetup.getName())
             .setElectionVersion(electionSetup.getElectionVersion())
             .setElectionQuestions(electionSetup.getQuestions())
             .setStart(electionSetup.getStartTime())
@@ -85,11 +87,11 @@ public final class ElectionHandler {
   /**
    * Process an ElectionResult message.
    *
-   * @param context the HandlerContext of the message
+   * @param context        the HandlerContext of the message
    * @param electionResult the message that was received
    */
   public void handleElectionResult(HandlerContext context, ElectionResult electionResult)
-      throws DataHandlingException, UnknownElectionException {
+      throws UnknownElectionException {
     Channel channel = context.getChannel();
 
     Log.d(TAG, "handling election result");
@@ -124,7 +126,7 @@ public final class ElectionHandler {
   /**
    * Process an OpenElection message.
    *
-   * @param context the HandlerContext of the message
+   * @param context      the HandlerContext of the message
    * @param openElection the message that was received
    */
   @SuppressWarnings("unused")
@@ -152,7 +154,7 @@ public final class ElectionHandler {
   /**
    * Process an ElectionEnd message.
    *
-   * @param context the HandlerContext of the message
+   * @param context     the HandlerContext of the message
    * @param electionEnd the message that was received
    */
   @SuppressWarnings("unused")
@@ -170,7 +172,7 @@ public final class ElectionHandler {
   /**
    * Process a CastVote message.
    *
-   * @param context the HandlerContext of the message
+   * @param context  the HandlerContext of the message
    * @param castVote the message that was received
    */
   public void handleCastVote(HandlerContext context, CastVote castVote)
@@ -246,7 +248,7 @@ public final class ElectionHandler {
   /**
    * Simple way to handle a election key, add the given key to the given election
    *
-   * @param context context
+   * @param context     context
    * @param electionKey key to add
    */
   public void handleElectionKey(HandlerContext context, ElectionKey electionKey)

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
@@ -1,9 +1,9 @@
 package com.github.dedis.popstellar.utility.handler.data;
 
-import static com.github.dedis.popstellar.model.objects.event.EventState.*;
-
 import android.util.Log;
+
 import androidx.annotation.NonNull;
+
 import com.github.dedis.popstellar.model.network.method.message.data.Data;
 import com.github.dedis.popstellar.model.network.method.message.data.election.*;
 import com.github.dedis.popstellar.model.objects.*;
@@ -12,8 +12,12 @@ import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.repository.*;
 import com.github.dedis.popstellar.utility.error.*;
+
 import java.util.*;
+
 import javax.inject.Inject;
+
+import static com.github.dedis.popstellar.model.objects.event.EventState.*;
 
 /** Election messages handler class */
 public final class ElectionHandler {
@@ -67,7 +71,8 @@ public final class ElectionHandler {
     context
         .getMessageSender()
         .subscribe(election.getChannel())
-        .doOnError(err -> Log.e(TAG, "An error occurred while subscribing to election channel", err))
+        .doOnError(
+            err -> Log.e(TAG, "An error occurred while subscribing to election channel", err))
         .onErrorComplete()
         .subscribe();
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
@@ -4,6 +4,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
 import com.github.dedis.popstellar.model.network.method.message.data.Data;
 import com.github.dedis.popstellar.model.network.method.message.data.election.*;
 import com.github.dedis.popstellar.model.objects.*;
@@ -96,8 +97,7 @@ public final class ElectionHandler {
 
     List<ElectionResultQuestion> resultsQuestions = electionResult.getElectionQuestionResults();
     Log.d(TAG, "size of resultsQuestions is " + resultsQuestions.size());
-    if (resultsQuestions.isEmpty())
-      throw new DataHandlingException(electionResult, "the questions results is empty");
+    // No need to check here that resultsQuestions is not empty, as it is already done at the creation of the ElectionResult Data
 
     Election election =
         electionRepository

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
@@ -4,7 +4,6 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
-import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
 import com.github.dedis.popstellar.model.network.method.message.data.Data;
 import com.github.dedis.popstellar.model.network.method.message.data.election.*;
 import com.github.dedis.popstellar.model.objects.*;

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
@@ -1,9 +1,9 @@
 package com.github.dedis.popstellar.utility.handler.data;
 
+import static com.github.dedis.popstellar.model.objects.event.EventState.*;
+
 import android.util.Log;
-
 import androidx.annotation.NonNull;
-
 import com.github.dedis.popstellar.model.network.method.message.data.Data;
 import com.github.dedis.popstellar.model.network.method.message.data.election.*;
 import com.github.dedis.popstellar.model.objects.*;
@@ -12,16 +12,10 @@ import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.repository.*;
 import com.github.dedis.popstellar.utility.error.*;
-
 import java.util.*;
-
 import javax.inject.Inject;
 
-import static com.github.dedis.popstellar.model.objects.event.EventState.*;
-
-/**
- * Election messages handler class
- */
+/** Election messages handler class */
 public final class ElectionHandler {
 
   public static final String TAG = ElectionHandler.class.getSimpleName();
@@ -41,7 +35,7 @@ public final class ElectionHandler {
   /**
    * Process an ElectionSetup message.
    *
-   * @param context       the HandlerContext of the message
+   * @param context the HandlerContext of the message
    * @param electionSetup the message that was received
    */
   public void handleElectionSetup(HandlerContext context, ElectionSetup electionSetup)
@@ -58,7 +52,7 @@ public final class ElectionHandler {
 
     Election election =
         new Election.ElectionBuilder(
-            laoView.getId(), electionSetup.getCreation(), electionSetup.getName())
+                laoView.getId(), electionSetup.getCreation(), electionSetup.getName())
             .setElectionVersion(electionSetup.getElectionVersion())
             .setElectionQuestions(electionSetup.getQuestions())
             .setStart(electionSetup.getStartTime())
@@ -73,7 +67,7 @@ public final class ElectionHandler {
     context
         .getMessageSender()
         .subscribe(election.getChannel())
-        .doOnError(err -> Log.e(TAG, "On error occured while subscribing to election channel", err))
+        .doOnError(err -> Log.e(TAG, "An error occurred while subscribing to election channel", err))
         .onErrorComplete()
         .subscribe();
 
@@ -87,7 +81,7 @@ public final class ElectionHandler {
   /**
    * Process an ElectionResult message.
    *
-   * @param context        the HandlerContext of the message
+   * @param context the HandlerContext of the message
    * @param electionResult the message that was received
    */
   public void handleElectionResult(HandlerContext context, ElectionResult electionResult)
@@ -98,7 +92,8 @@ public final class ElectionHandler {
 
     List<ElectionResultQuestion> resultsQuestions = electionResult.getElectionQuestionResults();
     Log.d(TAG, "size of resultsQuestions is " + resultsQuestions.size());
-    // No need to check here that resultsQuestions is not empty, as it is already done at the creation of the ElectionResult Data
+    // No need to check here that resultsQuestions is not empty, as it is already done at the
+    // creation of the ElectionResult Data
 
     Election election =
         electionRepository
@@ -126,7 +121,7 @@ public final class ElectionHandler {
   /**
    * Process an OpenElection message.
    *
-   * @param context      the HandlerContext of the message
+   * @param context the HandlerContext of the message
    * @param openElection the message that was received
    */
   @SuppressWarnings("unused")
@@ -154,7 +149,7 @@ public final class ElectionHandler {
   /**
    * Process an ElectionEnd message.
    *
-   * @param context     the HandlerContext of the message
+   * @param context the HandlerContext of the message
    * @param electionEnd the message that was received
    */
   @SuppressWarnings("unused")
@@ -172,7 +167,7 @@ public final class ElectionHandler {
   /**
    * Process a CastVote message.
    *
-   * @param context  the HandlerContext of the message
+   * @param context the HandlerContext of the message
    * @param castVote the message that was received
    */
   public void handleCastVote(HandlerContext context, CastVote castVote)
@@ -248,7 +243,7 @@ public final class ElectionHandler {
   /**
    * Simple way to handle a election key, add the given key to the given election
    *
-   * @param context     context
+   * @param context context
    * @param electionKey key to add
    */
   public void handleElectionKey(HandlerContext context, ElectionKey electionKey)

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
@@ -48,7 +48,8 @@ public final class LaoHandler {
    * @param createLao the message that was received
    */
   @SuppressLint("CheckResult") // for now concerns Consensus which is not a priority this semester
-  public void handleCreateLao(HandlerContext context, CreateLao createLao) {
+  public void handleCreateLao(HandlerContext context, CreateLao createLao)
+      throws UnknownLaoException {
     Channel channel = context.getChannel();
 
     Log.d(TAG, "handleCreateLao: channel " + channel + ", msg=" + createLao);
@@ -62,9 +63,10 @@ public final class LaoHandler {
     lao.setWitnesses(new HashSet<>(createLao.getWitnesses()));
 
     laoRepo.updateLao(lao);
+    LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     PublicKey publicKey = keyManager.getMainPublicKey();
-    if (lao.getOrganizer().equals(publicKey) || lao.getWitnesses().contains(publicKey)) {
+    if (laoView.isOrganizer(publicKey) || laoView.isWitness(publicKey)) {
       context
           .getMessageSender()
           .subscribe(lao.getChannel().subChannel("consensus"))
@@ -168,7 +170,7 @@ public final class LaoHandler {
     lao.setModificationId(stateLao.getModificationId());
 
     PublicKey publicKey = keyManager.getMainPublicKey();
-    if (lao.getOrganizer().equals(publicKey) || lao.getWitnesses().contains(publicKey)) {
+    if (laoView.isOrganizer(publicKey) || laoView.isWitness(publicKey)) {
       context
           .getMessageSender()
           .subscribe(laoView.getChannel().subChannel("consensus"))

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
@@ -17,7 +17,9 @@ import java.util.*;
 
 import javax.inject.Inject;
 
-/** Lao messages handler class */
+/**
+ * Lao messages handler class
+ */
 public final class LaoHandler {
 
   public static final String TAG = LaoHandler.class.getSimpleName();
@@ -42,7 +44,7 @@ public final class LaoHandler {
   /**
    * Process a CreateLao message.
    *
-   * @param context the HandlerContext of the message
+   * @param context   the HandlerContext of the message
    * @param createLao the message that was received
    */
   @SuppressLint("CheckResult") // for now concerns Consensus which is not a priority this semester
@@ -86,7 +88,7 @@ public final class LaoHandler {
   /**
    * Process an UpdateLao message.
    *
-   * @param context the HandlerContext of the message
+   * @param context   the HandlerContext of the message
    * @param updateLao the message that was received
    */
   public void handleUpdateLao(HandlerContext context, UpdateLao updateLao)
@@ -129,7 +131,7 @@ public final class LaoHandler {
   /**
    * Process a StateLao message.
    *
-   * @param context the HandlerContext of the message
+   * @param context  the HandlerContext of the message
    * @param stateLao the message that was received
    */
   @SuppressLint("CheckResult")

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
@@ -166,7 +166,7 @@ public final class LaoHandler {
     lao.setModificationId(stateLao.getModificationId());
 
     PublicKey publicKey = keyManager.getMainPublicKey();
-    if (laoView.isOrganizer(publicKey) || laoView.isWitness(publicKey)) {
+    if (lao.getOrganizer().equals(publicKey) || lao.getWitnesses().contains(publicKey)) {
       context
           .getMessageSender()
           .subscribe(laoView.getChannel().subChannel("consensus"))

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
@@ -159,7 +159,6 @@ public final class LaoHandler {
     // TODO: verify if lao/state_lao is consistent with the lao/update message
 
     Lao lao = laoView.createLaoCopy();
-
     lao.setId(stateLao.getId());
     lao.setWitnesses(stateLao.getWitnesses());
     lao.setName(stateLao.getName());
@@ -201,7 +200,7 @@ public final class LaoHandler {
     return message;
   }
 
-  public WitnessMessage updateLaoWitnessesWitnessMessage(
+  public static WitnessMessage updateLaoWitnessesWitnessMessage(
       MessageID messageId, UpdateLao updateLao, LaoView laoView) {
     WitnessMessage message = new WitnessMessage(messageId);
     List<PublicKey> tempList = new ArrayList<>(updateLao.getWitnesses());

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
@@ -17,9 +17,7 @@ import java.util.*;
 
 import javax.inject.Inject;
 
-/**
- * Lao messages handler class
- */
+/** Lao messages handler class */
 public final class LaoHandler {
 
   public static final String TAG = LaoHandler.class.getSimpleName();
@@ -44,7 +42,7 @@ public final class LaoHandler {
   /**
    * Process a CreateLao message.
    *
-   * @param context   the HandlerContext of the message
+   * @param context the HandlerContext of the message
    * @param createLao the message that was received
    */
   @SuppressLint("CheckResult") // for now concerns Consensus which is not a priority this semester
@@ -90,7 +88,7 @@ public final class LaoHandler {
   /**
    * Process an UpdateLao message.
    *
-   * @param context   the HandlerContext of the message
+   * @param context the HandlerContext of the message
    * @param updateLao the message that was received
    */
   public void handleUpdateLao(HandlerContext context, UpdateLao updateLao)
@@ -133,7 +131,7 @@ public final class LaoHandler {
   /**
    * Process a StateLao message.
    *
-   * @param context  the HandlerContext of the message
+   * @param context the HandlerContext of the message
    * @param stateLao the message that was received
    */
   @SuppressLint("CheckResult")

--- a/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/di/DataRegistryModuleHelper.java
+++ b/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/di/DataRegistryModuleHelper.java
@@ -53,6 +53,19 @@ public class DataRegistryModuleHelper {
   }
 
   public static DataRegistry buildRegistry(
+      LAORepository laoRepository, ElectionRepository electionRepo, KeyManager keyManager, MessageRepository messageRepo) {
+    return buildRegistry(
+        laoRepository,
+        new SocialMediaRepository(),
+        electionRepo,
+        new RollCallRepository(),
+        new DigitalCashRepository(),
+        messageRepo,
+        keyManager,
+        new ServerRepository());
+  }
+
+  public static DataRegistry buildRegistry(
       LAORepository laoRepo,
       SocialMediaRepository socialMediaRepo,
       RollCallRepository rollCallRepo,

--- a/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/di/DataRegistryModuleHelper.java
+++ b/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/di/DataRegistryModuleHelper.java
@@ -53,7 +53,10 @@ public class DataRegistryModuleHelper {
   }
 
   public static DataRegistry buildRegistry(
-      LAORepository laoRepository, ElectionRepository electionRepo, KeyManager keyManager, MessageRepository messageRepo) {
+      LAORepository laoRepository,
+      ElectionRepository electionRepo,
+      KeyManager keyManager,
+      MessageRepository messageRepo) {
     return buildRegistry(
         laoRepository,
         new SocialMediaRepository(),

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/objects/PendingUpdateTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/objects/PendingUpdateTest.java
@@ -13,14 +13,14 @@ public class PendingUpdateTest {
   private static final MessageID MESSAGE_ID2 = Base64DataUtils.generateMessageID();
   private static final long MODIFICATION1 = 1000L;
   private static final long MODIFICATION2 = 2000L;
-  private static final PendingUpdate PENDING_UPDATE1 = new PendingUpdate(MODIFICATION1,
-      MESSAGE_ID1);
-  private static final PendingUpdate PENDING_UPDATE2 = new PendingUpdate(MODIFICATION1,
-      MESSAGE_ID1);
-  private static final PendingUpdate PENDING_UPDATE3 = new PendingUpdate(MODIFICATION2,
-      MESSAGE_ID1);
-  private static final PendingUpdate PENDING_UPDATE4 = new PendingUpdate(MODIFICATION1,
-      MESSAGE_ID2);
+  private static final PendingUpdate PENDING_UPDATE1 =
+      new PendingUpdate(MODIFICATION1, MESSAGE_ID1);
+  private static final PendingUpdate PENDING_UPDATE2 =
+      new PendingUpdate(MODIFICATION1, MESSAGE_ID1);
+  private static final PendingUpdate PENDING_UPDATE3 =
+      new PendingUpdate(MODIFICATION2, MESSAGE_ID1);
+  private static final PendingUpdate PENDING_UPDATE4 =
+      new PendingUpdate(MODIFICATION1, MESSAGE_ID2);
 
   @Test
   public void testGetModificationTime() {
@@ -52,5 +52,4 @@ public class PendingUpdateTest {
     assertTrue(PENDING_UPDATE3.compareTo(PENDING_UPDATE1) > 0);
     assertEquals(PENDING_UPDATE1.compareTo(PENDING_UPDATE2), 0);
   }
-
 }

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/objects/PendingUpdateTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/objects/PendingUpdateTest.java
@@ -1,0 +1,56 @@
+package com.github.dedis.popstellar.model.objects;
+
+import com.github.dedis.popstellar.model.objects.security.MessageID;
+import com.github.dedis.popstellar.testutils.Base64DataUtils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PendingUpdateTest {
+
+  private static final MessageID MESSAGE_ID1 = Base64DataUtils.generateMessageID();
+  private static final MessageID MESSAGE_ID2 = Base64DataUtils.generateMessageID();
+  private static final long MODIFICATION1 = 1000L;
+  private static final long MODIFICATION2 = 2000L;
+  private static final PendingUpdate PENDING_UPDATE1 = new PendingUpdate(MODIFICATION1,
+      MESSAGE_ID1);
+  private static final PendingUpdate PENDING_UPDATE2 = new PendingUpdate(MODIFICATION1,
+      MESSAGE_ID1);
+  private static final PendingUpdate PENDING_UPDATE3 = new PendingUpdate(MODIFICATION2,
+      MESSAGE_ID1);
+  private static final PendingUpdate PENDING_UPDATE4 = new PendingUpdate(MODIFICATION1,
+      MESSAGE_ID2);
+
+  @Test
+  public void testGetModificationTime() {
+    PendingUpdate pendingUpdate = new PendingUpdate(MODIFICATION1, MESSAGE_ID1);
+    assertEquals(MODIFICATION1, pendingUpdate.getModificationTime());
+  }
+
+  @Test
+  public void testGetMessageId() {
+    PendingUpdate pendingUpdate = new PendingUpdate(MODIFICATION1, MESSAGE_ID1);
+    assertEquals(MESSAGE_ID1, pendingUpdate.getMessageId());
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    assertEquals(PENDING_UPDATE1, PENDING_UPDATE2);
+    assertEquals(PENDING_UPDATE1.hashCode(), PENDING_UPDATE2.hashCode());
+
+    assertNotEquals(PENDING_UPDATE1, PENDING_UPDATE3);
+    assertNotEquals(PENDING_UPDATE1.hashCode(), PENDING_UPDATE3.hashCode());
+
+    assertNotEquals(PENDING_UPDATE1, PENDING_UPDATE4);
+    assertNotEquals(PENDING_UPDATE1.hashCode(), PENDING_UPDATE4.hashCode());
+  }
+
+  @Test
+  public void testCompareTo() {
+    assertTrue(PENDING_UPDATE1.compareTo(PENDING_UPDATE3) < 0);
+    assertTrue(PENDING_UPDATE3.compareTo(PENDING_UPDATE1) > 0);
+    assertTrue(PENDING_UPDATE1.compareTo(PENDING_UPDATE2) == 0);
+  }
+
+}

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/objects/PendingUpdateTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/objects/PendingUpdateTest.java
@@ -50,6 +50,6 @@ public class PendingUpdateTest {
   public void testCompareTo() {
     assertTrue(PENDING_UPDATE1.compareTo(PENDING_UPDATE3) < 0);
     assertTrue(PENDING_UPDATE3.compareTo(PENDING_UPDATE1) > 0);
-    assertEquals(PENDING_UPDATE1.compareTo(PENDING_UPDATE2), 0);
+    assertEquals(0, PENDING_UPDATE1.compareTo(PENDING_UPDATE2));
   }
 }

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/objects/PendingUpdateTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/objects/PendingUpdateTest.java
@@ -50,7 +50,7 @@ public class PendingUpdateTest {
   public void testCompareTo() {
     assertTrue(PENDING_UPDATE1.compareTo(PENDING_UPDATE3) < 0);
     assertTrue(PENDING_UPDATE3.compareTo(PENDING_UPDATE1) > 0);
-    assertTrue(PENDING_UPDATE1.compareTo(PENDING_UPDATE2) == 0);
+    assertEquals(PENDING_UPDATE1.compareTo(PENDING_UPDATE2), 0);
   }
 
 }

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ElectionHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ElectionHandlerTest.java
@@ -38,11 +38,9 @@ import io.reactivex.Completable;
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generateKeyPair;
 import static com.github.dedis.popstellar.utility.handler.data.ElectionHandler.electionSetupWitnessMessage;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ElectionHandlerTest {
@@ -86,6 +84,7 @@ public class ElectionHandlerTest {
   private LAORepository laoRepo;
   private ElectionRepository electionRepo;
   private MessageHandler messageHandler;
+  private MessageRepository messageRepo;
   private Gson gson;
 
   @Mock MessageSender messageSender;
@@ -103,9 +102,10 @@ public class ElectionHandlerTest {
     laoRepo = new LAORepository();
     electionRepo = new ElectionRepository();
 
+    messageRepo = new MessageRepository();
     DataRegistry dataRegistry =
-        DataRegistryModuleHelper.buildRegistry(laoRepo, electionRepo, keyManager);
-    MessageRepository messageRepo = new MessageRepository();
+        DataRegistryModuleHelper.buildRegistry(laoRepo, electionRepo, keyManager, messageRepo);
+
     gson = JsonModule.provideGson(dataRegistry);
     messageHandler = new MessageHandler(messageRepo, dataRegistry);
 
@@ -116,7 +116,7 @@ public class ElectionHandlerTest {
     messageRepo.addMessage(createLaoMessage);
   }
 
-  private MessageID handleElectionSetup(Election election)
+  private MessageID handleElectionSetup(Election election, Channel channel)
       throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
           DataHandlingException, NoRollCallException {
     List<Question> questions =
@@ -142,7 +142,7 @@ public class ElectionHandlerTest {
             questions);
 
     MessageGeneral message = new MessageGeneral(SENDER_KEY, electionSetupOpenBallot, gson);
-    messageHandler.handleMessage(messageSender, LAO_CHANNEL, message);
+    messageHandler.handleMessage(messageSender, channel, message);
     return message.getMessageId();
   }
 
@@ -165,12 +165,12 @@ public class ElectionHandlerTest {
     messageHandler.handleMessage(messageSender, election.getChannel(), message);
   }
 
-  private void handleCastVote(Vote vote, KeyPair senderKey)
+  private void handleCastVote(Vote vote, KeyPair senderKey, Long creation)
       throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
           DataHandlingException, NoRollCallException {
 
     CastVote castVote =
-        new CastVote(singletonList(vote), OPEN_BALLOT_ELECTION.getId(), CREATE_LAO.getId());
+        new CastVote(singletonList(vote), OPEN_BALLOT_ELECTION.getId(), CREATE_LAO.getId(), creation);
 
     MessageGeneral message = new MessageGeneral(senderKey, castVote, gson);
     messageHandler.handleMessage(messageSender, OPEN_BALLOT_ELECTION.getChannel(), message);
@@ -204,7 +204,7 @@ public class ElectionHandlerTest {
   public void testHandleElectionSetup()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
           UnknownElectionException, NoRollCallException {
-    MessageID messageID = handleElectionSetup(OPEN_BALLOT_ELECTION);
+    MessageID messageID = handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
 
     // Check the Election is present and has correct values
     Election election = electionRepo.getElectionByChannel(OPEN_BALLOT_ELECTION.getChannel());
@@ -228,11 +228,21 @@ public class ElectionHandlerTest {
   }
 
   @Test
+  public void testHandleElectionSetupInvalidChannel()
+      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
+      UnknownElectionException, NoRollCallException {
+    // Check that handling the message fails with an invalid channel (channel that is not a lao sub-channel)
+    assertThrows(
+        InvalidChannelException.class,
+        () -> handleElectionSetup(OPEN_BALLOT_ELECTION, Channel.ROOT));
+  }
+
+  @Test
   public void testElectionKey()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
           UnknownElectionException, NoRollCallException {
 
-    handleElectionSetup(OPEN_BALLOT_ELECTION);
+    handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
 
     Election election = electionRepo.getElectionByChannel(OPEN_BALLOT_ELECTION.getChannel());
@@ -245,10 +255,10 @@ public class ElectionHandlerTest {
           UnknownElectionException, NoRollCallException {
     Set<QuestionResult> results = Collections.singleton(new QuestionResult(OPTION_1, 1));
 
-    handleElectionSetup(OPEN_BALLOT_ELECTION);
+    handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
     handleElectionOpen(OPEN_BALLOT_ELECTION);
-    handleCastVote(new PlainVote(QUESTION.getId(), 0, false, null, ELECTION_ID), SENDER_KEY);
+    handleCastVote(new PlainVote(QUESTION.getId(), 0, false, null, ELECTION_ID), SENDER_KEY, OPENED_AT);
     handleElectionEnd();
     handleElectionResults(results, OPEN_BALLOT_ELECTION.getChannel());
 
@@ -261,7 +271,7 @@ public class ElectionHandlerTest {
   public void testHandleElectionOpen()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
           UnknownElectionException, NoRollCallException {
-    handleElectionSetup(OPEN_BALLOT_ELECTION);
+    handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
     handleElectionOpen(OPEN_BALLOT_ELECTION);
 
@@ -271,10 +281,39 @@ public class ElectionHandlerTest {
   }
 
   @Test
+  public void testHandleElectionOpenInvalidState()
+      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
+      UnknownElectionException, NoRollCallException {
+    handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
+    handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
+
+    // Set the election to a closed state and check that opening the election fails
+    Election closedElection = OPEN_BALLOT_ELECTION.builder().setState(EventState.CLOSED).build();
+    electionRepo.updateElection(closedElection);
+    assertThrows(
+        InvalidStateException.class,
+        () -> handleElectionOpen(closedElection));
+
+    // Set the election to an opened state and check that opening the election fails
+    Election openedElection = OPEN_BALLOT_ELECTION.builder().setState(EventState.OPENED).build();
+    electionRepo.updateElection(closedElection);
+    assertThrows(
+        InvalidStateException.class,
+        () -> handleElectionOpen(openedElection));
+
+    // Set the election to a result ready state and check that opening the election fails
+    Election resultsReadyElection = OPEN_BALLOT_ELECTION.builder().setState(EventState.RESULTS_READY).build();
+    electionRepo.updateElection(closedElection);
+    assertThrows(
+        InvalidStateException.class,
+        () -> handleElectionOpen(resultsReadyElection));
+  }
+
+  @Test
   public void testHandleElectionEnd()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
           UnknownElectionException, NoRollCallException {
-    handleElectionSetup(OPEN_BALLOT_ELECTION);
+    handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
     handleElectionOpen(OPEN_BALLOT_ELECTION);
     handleElectionEnd();
@@ -290,17 +329,123 @@ public class ElectionHandlerTest {
     PlainVote vote1 = new PlainVote(QUESTION.getId(), 0, false, null, ELECTION_ID);
     PlainVote vote2 = new PlainVote(QUESTION.getId(), 1, false, null, ELECTION_ID);
 
-    handleElectionSetup(OPEN_BALLOT_ELECTION);
+    handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
     handleElectionOpen(OPEN_BALLOT_ELECTION);
-    handleCastVote(vote1, SENDER_KEY);
-    handleCastVote(vote2, ATTENDEE_KEY);
+
+    // Handle the votes of two different senders
+    handleCastVote(vote1, SENDER_KEY, OPENED_AT);
+    handleCastVote(vote2, ATTENDEE_KEY, OPENED_AT);
 
     // The expected hash is made on the sorted vote ids
     String[] voteIds = Stream.of(vote1, vote2).map(Vote::getId).sorted().toArray(String[]::new);
     Election election = electionRepo.getElectionByChannel(OPEN_BALLOT_ELECTION.getChannel());
 
     assertEquals(Hash.hash(voteIds), election.computeRegisteredVotesHash());
+  }
+
+  @Test
+  public void castVoteOnlyKeepsLastVote()
+      throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
+      DataHandlingException, NoRollCallException {
+    PlainVote vote1 = new PlainVote(QUESTION.getId(), 0, false, null, ELECTION_ID);
+    PlainVote vote2 = new PlainVote(QUESTION.getId(), 1, false, null, ELECTION_ID);
+    PlainVote vote3 = new PlainVote(QUESTION.getId(), 0, false, null, ELECTION_ID);
+
+    handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
+    handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
+    handleElectionOpen(OPEN_BALLOT_ELECTION);
+
+    // Handle the votes of two different senders. One sender sends two votes, and the first should be discarded
+    handleCastVote(vote1, SENDER_KEY, OPENED_AT);
+    handleCastVote(vote2, ATTENDEE_KEY, OPENED_AT + 1);
+    handleCastVote(vote3, ATTENDEE_KEY, OPENED_AT + 2);
+
+    // The expected hash is made on the sorted vote ids (check that vote2 was discarded)
+    System.out.println("vote1: " + vote1.getId());
+    System.out.println("vote2: " + vote2.getId());
+    System.out.println("vote3: " + vote3.getId());
+    String[] voteIds = Stream.of(vote1, vote3).map(Vote::getId).sorted().toArray(String[]::new);
+    Election election = electionRepo.getElectionByChannel(OPEN_BALLOT_ELECTION.getChannel());
+
+    assertEquals(Hash.hash(voteIds), election.computeRegisteredVotesHash());
+  }
+
+  @Test
+  public void castVoteDiscardsStaleVote()
+      throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
+      DataHandlingException, NoRollCallException {
+    PlainVote vote1 = new PlainVote(QUESTION.getId(), 0, false, null, ELECTION_ID);
+    PlainVote vote2 = new PlainVote(QUESTION.getId(), 1, false, null, ELECTION_ID);
+    PlainVote vote3 = new PlainVote(QUESTION.getId(), 0, false, null, ELECTION_ID);
+
+    handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
+    handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
+    handleElectionOpen(OPEN_BALLOT_ELECTION);
+
+    // Handle the votes of two different senders. One sender sends two votes, and the first should be discarded
+    // Vote3 arrives after vote2, but it has an older creation date and should be discarded
+    handleCastVote(vote1, SENDER_KEY, OPENED_AT);
+    handleCastVote(vote2, ATTENDEE_KEY, OPENED_AT + 2);
+    handleCastVote(vote3, ATTENDEE_KEY, OPENED_AT + 1);
+
+    // The expected hash is made on the sorted vote ids (check that vote2 was discarded)
+    String[] voteIds = Stream.of(vote1, vote2).map(Vote::getId).sorted().toArray(String[]::new);
+    Election election = electionRepo.getElectionByChannel(OPEN_BALLOT_ELECTION.getChannel());
+
+    assertEquals(Hash.hash(voteIds), election.computeRegisteredVotesHash());
+  }
+
+  @Test
+  public void castVoteFailsOnPreviousDataNull()
+      throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
+      DataHandlingException, NoRollCallException {
+    PlainVote vote1 = new PlainVote(QUESTION.getId(), 0, false, null, ELECTION_ID);
+    PlainVote vote2 = new PlainVote(QUESTION.getId(), 1, false, null, ELECTION_ID);
+
+    handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
+    handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
+    handleElectionOpen(OPEN_BALLOT_ELECTION);
+
+    // TODO: refactor this
+    MessageGeneral nullData = new MessageGeneral(SENDER_KEY, null, gson);
+    messageRepo = mock(MessageRepository.class);
+    when(messageRepo.getMessage(any())).thenReturn(nullData);
+    DataRegistry dataRegistry =
+        DataRegistryModuleHelper.buildRegistry(laoRepo, electionRepo, keyManager, messageRepo);
+    gson = JsonModule.provideGson(dataRegistry);
+    messageHandler = new MessageHandler(messageRepo, dataRegistry);
+
+    handleCastVote(vote1, SENDER_KEY, OPENED_AT);
+    assertThrows(
+        IllegalStateException.class,
+        () ->  handleCastVote(vote2, SENDER_KEY, OPENED_AT + 1));
+  }
+
+  @Test
+  public void castVoteFailsOnPreviousDataInvalid()
+      throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
+      DataHandlingException, NoRollCallException {
+    PlainVote vote1 = new PlainVote(QUESTION.getId(), 0, false, null, ELECTION_ID);
+    PlainVote vote2 = new PlainVote(QUESTION.getId(), 1, false, null, ELECTION_ID);
+
+    handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
+    handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
+    handleElectionOpen(OPEN_BALLOT_ELECTION);
+
+    // TODO: refactor this
+    MessageGeneral invalidData = new MessageGeneral(SENDER_KEY, CREATE_LAO, gson);
+    messageRepo = mock(MessageRepository.class);
+    when(messageRepo.getMessage(any())).thenReturn(invalidData);
+    DataRegistry dataRegistry =
+        DataRegistryModuleHelper.buildRegistry(laoRepo, electionRepo, keyManager, messageRepo);
+    gson = JsonModule.provideGson(dataRegistry);
+    messageHandler = new MessageHandler(messageRepo, dataRegistry);
+
+    handleCastVote(vote1, SENDER_KEY, OPENED_AT);
+    assertThrows(
+        DataHandlingException.class,
+        () ->  handleCastVote(vote2, SENDER_KEY, OPENED_AT + 1));
   }
 
   @Test
@@ -314,12 +459,12 @@ public class ElectionHandlerTest {
     EncryptedVote vote1 = new EncryptedVote(QUESTION.getId(), "0", false, null, ELECTION_ID);
     EncryptedVote vote2 = new EncryptedVote(QUESTION.getId(), "1", false, null, ELECTION_ID);
 
-    handleElectionSetup(SECRET_BALLOT_ELECTION);
+    handleElectionSetup(SECRET_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(SECRET_BALLOT_ELECTION, encodedKey.getEncoded());
     handleElectionOpen(SECRET_BALLOT_ELECTION);
 
-    handleCastVote(vote1, SENDER_KEY);
-    handleCastVote(vote2, ATTENDEE_KEY);
+    handleCastVote(vote1, SENDER_KEY, OPENED_AT);
+    handleCastVote(vote2, ATTENDEE_KEY, OPENED_AT);
 
     // The expected hash is made on the sorted vote ids
     String[] voteIds = Stream.of(vote1, vote2).map(Vote::getId).sorted().toArray(String[]::new);

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ElectionHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ElectionHandlerTest.java
@@ -362,9 +362,6 @@ public class ElectionHandlerTest {
     handleCastVote(vote3, ATTENDEE_KEY, OPENED_AT + 2);
 
     // The expected hash is made on the sorted vote ids (check that vote2 was discarded)
-    System.out.println("vote1: " + vote1.getId());
-    System.out.println("vote2: " + vote2.getId());
-    System.out.println("vote3: " + vote3.getId());
     String[] voteIds = Stream.of(vote1, vote3).map(Vote::getId).sorted().toArray(String[]::new);
     Election election = electionRepo.getElectionByChannel(OPEN_BALLOT_ELECTION.getChannel());
 
@@ -383,13 +380,12 @@ public class ElectionHandlerTest {
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
     handleElectionOpen(OPEN_BALLOT_ELECTION);
 
-    // Handle the votes of two different senders. One sender sends two votes, and the first should be discarded
-    // Vote3 arrives after vote2, but it has an older creation date and should be discarded
+    // Handle the votes of two different senders. One sender sends two votes, and the second should be discarded as it has an older creation date
     handleCastVote(vote1, SENDER_KEY, OPENED_AT);
     handleCastVote(vote2, ATTENDEE_KEY, OPENED_AT + 2);
     handleCastVote(vote3, ATTENDEE_KEY, OPENED_AT + 1);
 
-    // The expected hash is made on the sorted vote ids (check that vote2 was discarded)
+    // The expected hash is made on the sorted vote ids (check that vote3 was discarded)
     String[] voteIds = Stream.of(vote1, vote2).map(Vote::getId).sorted().toArray(String[]::new);
     Election election = electionRepo.getElectionByChannel(OPEN_BALLOT_ELECTION.getChannel());
 

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ElectionHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ElectionHandlerTest.java
@@ -40,7 +40,8 @@ import static com.github.dedis.popstellar.utility.handler.data.ElectionHandler.e
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ElectionHandlerTest {
@@ -206,15 +207,6 @@ public class ElectionHandlerTest {
 
     // Call the message handler
     messageHandler.handleMessage(messageSender, electionChannel, message);
-  }
-
-  private void setMessageRepoReturns(MessageGeneral message) {
-    messageRepo = mock(MessageRepository.class);
-    when(messageRepo.getMessage(any())).thenReturn(message);
-    DataRegistry dataRegistry =
-        DataRegistryModuleHelper.buildRegistry(laoRepo, electionRepo, keyManager, messageRepo);
-    gson = JsonModule.provideGson(dataRegistry);
-    messageHandler = new MessageHandler(messageRepo, dataRegistry);
   }
 
   @Test

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ElectionHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ElectionHandlerTest.java
@@ -69,12 +69,12 @@ public class ElectionHandlerTest {
       new ElectionQuestion(
           ELECTION_ID,
           new Question("Does this work ?", "Plurality", Arrays.asList(OPTION_1, OPTION_2), false));
-  private static final PlainVote VOTE1 = new PlainVote(QUESTION.getId(), 0, false, null,
-      ELECTION_ID);
-  private static final PlainVote VOTE2 = new PlainVote(QUESTION.getId(), 1, false, null,
-      ELECTION_ID);
-  private static final PlainVote VOTE3 = new PlainVote(QUESTION.getId(), 0, false, null,
-      ELECTION_ID);
+  private static final PlainVote VOTE1 =
+      new PlainVote(QUESTION.getId(), 0, false, null, ELECTION_ID);
+  private static final PlainVote VOTE2 =
+      new PlainVote(QUESTION.getId(), 1, false, null, ELECTION_ID);
+  private static final PlainVote VOTE3 =
+      new PlainVote(QUESTION.getId(), 0, false, null, ELECTION_ID);
   private static final String ELECTION_KEY = "JsS0bXJU8yMT9jvIeTfoS6RJPZ8YopuAUPkxssHaoTQ";
   private static final Election OPEN_BALLOT_ELECTION =
       new Election.ElectionBuilder(LAO.getId(), CREATED_AT, ELECTION_NAME)
@@ -93,13 +93,10 @@ public class ElectionHandlerTest {
   private MessageRepository messageRepo;
   private Gson gson;
 
-  @Mock
-  MessageSender messageSender;
-  @Mock
-  KeyManager keyManager;
+  @Mock MessageSender messageSender;
+  @Mock KeyManager keyManager;
 
-  @Rule
-  public InstantTaskExecutorRule rule = new InstantTaskExecutorRule();
+  @Rule public InstantTaskExecutorRule rule = new InstantTaskExecutorRule();
 
   @Before
   public void setup() throws GeneralSecurityException, IOException {
@@ -127,7 +124,7 @@ public class ElectionHandlerTest {
 
   private MessageID handleElectionSetup(Election election, Channel channel)
       throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
-      DataHandlingException, NoRollCallException {
+          DataHandlingException, NoRollCallException {
     List<Question> questions =
         election.getElectionQuestions().stream()
             .map(
@@ -157,7 +154,7 @@ public class ElectionHandlerTest {
 
   private void handleElectionKey(Election election, String key)
       throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
-      DataHandlingException, NoRollCallException {
+          DataHandlingException, NoRollCallException {
     // Create the election key message
     ElectionKey electionKey = new ElectionKey(election.getId(), key);
 
@@ -167,7 +164,7 @@ public class ElectionHandlerTest {
 
   private void handleElectionOpen(Election election)
       throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
-      DataHandlingException, NoRollCallException {
+          DataHandlingException, NoRollCallException {
     OpenElection openElection = new OpenElection(LAO.getId(), election.getId(), OPENED_AT);
 
     MessageGeneral message = new MessageGeneral(SENDER_KEY, openElection, gson);
@@ -176,11 +173,11 @@ public class ElectionHandlerTest {
 
   private MessageID handleCastVote(Vote vote, KeyPair senderKey, Long creation)
       throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
-      DataHandlingException, NoRollCallException {
+          DataHandlingException, NoRollCallException {
 
     CastVote castVote =
-        new CastVote(singletonList(vote), OPEN_BALLOT_ELECTION.getId(), CREATE_LAO.getId(),
-            creation);
+        new CastVote(
+            singletonList(vote), OPEN_BALLOT_ELECTION.getId(), CREATE_LAO.getId(), creation);
 
     MessageGeneral message = new MessageGeneral(senderKey, castVote, gson);
     messageHandler.handleMessage(messageSender, OPEN_BALLOT_ELECTION.getChannel(), message);
@@ -189,7 +186,7 @@ public class ElectionHandlerTest {
 
   private void handleElectionEnd()
       throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
-      DataHandlingException, NoRollCallException {
+          DataHandlingException, NoRollCallException {
     // Retrieve current election to use the correct vote hash
     Election current = electionRepo.getElection(LAO.getId(), ELECTION_ID);
     ElectionEnd endElection =
@@ -201,7 +198,7 @@ public class ElectionHandlerTest {
 
   private void handleElectionResults(Set<QuestionResult> results, Channel electionChannel)
       throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
-      DataHandlingException, NoRollCallException {
+          DataHandlingException, NoRollCallException {
     ElectionResultQuestion electionResultQuestion =
         new ElectionResultQuestion(QUESTION.getId(), results);
     ElectionResult electionResult = new ElectionResult(singletonList(electionResultQuestion));
@@ -223,7 +220,7 @@ public class ElectionHandlerTest {
   @Test
   public void testHandleElectionSetup()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-      UnknownElectionException, NoRollCallException {
+          UnknownElectionException, NoRollCallException {
     MessageID messageID = handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
 
     // Check the Election is present and has correct values
@@ -249,7 +246,8 @@ public class ElectionHandlerTest {
 
   @Test
   public void testHandleElectionSetupInvalidChannel() {
-    // Check that handling the message fails with an invalid channel (channel that is not a lao sub-channel)
+    // Check that handling the message fails with an invalid channel (channel that is not a lao
+    // sub-channel)
     assertThrows(
         InvalidChannelException.class,
         () -> handleElectionSetup(OPEN_BALLOT_ELECTION, Channel.ROOT));
@@ -258,7 +256,7 @@ public class ElectionHandlerTest {
   @Test
   public void testElectionKey()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-      UnknownElectionException, NoRollCallException {
+          UnknownElectionException, NoRollCallException {
 
     handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
@@ -270,14 +268,14 @@ public class ElectionHandlerTest {
   @Test
   public void testHandleElectionResult()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-      UnknownElectionException, NoRollCallException {
+          UnknownElectionException, NoRollCallException {
     Set<QuestionResult> results = Collections.singleton(new QuestionResult(OPTION_1, 1));
 
     handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
     handleElectionOpen(OPEN_BALLOT_ELECTION);
-    handleCastVote(new PlainVote(QUESTION.getId(), 0, false, null, ELECTION_ID), SENDER_KEY,
-        OPENED_AT);
+    handleCastVote(
+        new PlainVote(QUESTION.getId(), 0, false, null, ELECTION_ID), SENDER_KEY, OPENED_AT);
     handleElectionEnd();
     handleElectionResults(results, OPEN_BALLOT_ELECTION.getChannel());
 
@@ -289,7 +287,7 @@ public class ElectionHandlerTest {
   @Test
   public void testHandleElectionOpen()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-      UnknownElectionException, NoRollCallException {
+          UnknownElectionException, NoRollCallException {
     handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
     handleElectionOpen(OPEN_BALLOT_ELECTION);
@@ -302,37 +300,31 @@ public class ElectionHandlerTest {
   @Test
   public void testHandleElectionOpenInvalidState()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-      UnknownElectionException, NoRollCallException {
+          UnknownElectionException, NoRollCallException {
     handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
 
     // Set the election to a closed state and check that opening the election fails
     Election closedElection = OPEN_BALLOT_ELECTION.builder().setState(EventState.CLOSED).build();
     electionRepo.updateElection(closedElection);
-    assertThrows(
-        InvalidStateException.class,
-        () -> handleElectionOpen(closedElection));
+    assertThrows(InvalidStateException.class, () -> handleElectionOpen(closedElection));
 
     // Set the election to an opened state and check that opening the election fails
     Election openedElection = OPEN_BALLOT_ELECTION.builder().setState(EventState.OPENED).build();
     electionRepo.updateElection(closedElection);
-    assertThrows(
-        InvalidStateException.class,
-        () -> handleElectionOpen(openedElection));
+    assertThrows(InvalidStateException.class, () -> handleElectionOpen(openedElection));
 
     // Set the election to a result ready state and check that opening the election fails
-    Election resultsReadyElection = OPEN_BALLOT_ELECTION.builder()
-        .setState(EventState.RESULTS_READY).build();
+    Election resultsReadyElection =
+        OPEN_BALLOT_ELECTION.builder().setState(EventState.RESULTS_READY).build();
     electionRepo.updateElection(closedElection);
-    assertThrows(
-        InvalidStateException.class,
-        () -> handleElectionOpen(resultsReadyElection));
+    assertThrows(InvalidStateException.class, () -> handleElectionOpen(resultsReadyElection));
   }
 
   @Test
   public void testHandleElectionEnd()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-      UnknownElectionException, NoRollCallException {
+          UnknownElectionException, NoRollCallException {
     handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
     handleElectionOpen(OPEN_BALLOT_ELECTION);
@@ -345,7 +337,7 @@ public class ElectionHandlerTest {
   @Test
   public void castVoteWithOpenBallotScenario()
       throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
-      DataHandlingException, NoRollCallException {
+          DataHandlingException, NoRollCallException {
     handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
     handleElectionOpen(OPEN_BALLOT_ELECTION);
@@ -364,12 +356,13 @@ public class ElectionHandlerTest {
   @Test
   public void castVoteOnlyKeepsLastVote()
       throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
-      DataHandlingException, NoRollCallException {
+          DataHandlingException, NoRollCallException {
     handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
     handleElectionOpen(OPEN_BALLOT_ELECTION);
 
-    // Handle the votes of two different senders. One sender sends two votes, and the first should be discarded
+    // Handle the votes of two different senders. One sender sends two votes, and the first should
+    // be discarded
     handleCastVote(VOTE1, SENDER_KEY, OPENED_AT);
     handleCastVote(VOTE2, ATTENDEE_KEY, OPENED_AT + 1);
     handleCastVote(VOTE3, ATTENDEE_KEY, OPENED_AT + 2);
@@ -384,12 +377,13 @@ public class ElectionHandlerTest {
   @Test
   public void castVoteDiscardsStaleVote()
       throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
-      DataHandlingException, NoRollCallException {
+          DataHandlingException, NoRollCallException {
     handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
     handleElectionOpen(OPEN_BALLOT_ELECTION);
 
-    // Handle the votes of two different senders. One sender sends two votes, and the second should be discarded as it has an older creation date
+    // Handle the votes of two different senders. One sender sends two votes, and the second should
+    // be discarded as it has an older creation date
     handleCastVote(VOTE1, SENDER_KEY, OPENED_AT);
     handleCastVote(VOTE2, ATTENDEE_KEY, OPENED_AT + 2);
     handleCastVote(VOTE3, ATTENDEE_KEY, OPENED_AT + 1);
@@ -404,7 +398,7 @@ public class ElectionHandlerTest {
   @Test
   public void castVoteFailsOnPreviousDataNull()
       throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
-      DataHandlingException, NoRollCallException {
+          DataHandlingException, NoRollCallException {
     handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
     handleElectionOpen(OPEN_BALLOT_ELECTION);
@@ -414,14 +408,13 @@ public class ElectionHandlerTest {
 
     handleCastVote(VOTE1, SENDER_KEY, OPENED_AT);
     assertThrows(
-        IllegalStateException.class,
-        () -> handleCastVote(VOTE1, SENDER_KEY, OPENED_AT + 1));
+        IllegalStateException.class, () -> handleCastVote(VOTE1, SENDER_KEY, OPENED_AT + 1));
   }
 
   @Test
   public void castVoteFailsOnPreviousDataInvalid()
       throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
-      DataHandlingException, NoRollCallException {
+          DataHandlingException, NoRollCallException {
     handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
     handleElectionOpen(OPEN_BALLOT_ELECTION);
@@ -431,14 +424,13 @@ public class ElectionHandlerTest {
 
     handleCastVote(VOTE1, SENDER_KEY, OPENED_AT);
     assertThrows(
-        DataHandlingException.class,
-        () -> handleCastVote(VOTE1, SENDER_KEY, OPENED_AT + 1));
+        DataHandlingException.class, () -> handleCastVote(VOTE1, SENDER_KEY, OPENED_AT + 1));
   }
 
   @Test
   public void castVoteIgnoresVoteOnClosedElection()
       throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
-      DataHandlingException, NoRollCallException {
+          DataHandlingException, NoRollCallException {
     handleElectionSetup(OPEN_BALLOT_ELECTION, LAO_CHANNEL);
     handleElectionKey(OPEN_BALLOT_ELECTION, ELECTION_KEY);
     handleElectionOpen(OPEN_BALLOT_ELECTION);
@@ -457,7 +449,7 @@ public class ElectionHandlerTest {
   @Test
   public void castVoteWithSecretBallotScenario()
       throws UnknownElectionException, UnknownRollCallException, UnknownLaoException,
-      DataHandlingException, NoRollCallException {
+          DataHandlingException, NoRollCallException {
     ElectionKeyPair keys = ElectionKeyPair.generateKeyPair();
     ElectionPublicKey pubKey = keys.getEncryptionScheme();
     Base64URLData encodedKey = new Base64URLData(pubKey.getPublicKey().toBytes());

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/LaoHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/LaoHandlerTest.java
@@ -51,8 +51,8 @@ public class LaoHandlerTest {
   private static final String ID1 = Lao.generateLaoId(SENDER1, CREATION, NAME1);
   private static final String ID2 = Lao.generateLaoId(SENDER1, CREATION, NAME2);
   private static final String ID3 = Lao.generateLaoId(SENDER1, CREATION, NAME3);
-  private static final List<PublicKey> WITNESS = new ArrayList<>(
-      Collections.singletonList(SENDER2));
+  private static final List<PublicKey> WITNESS =
+      new ArrayList<>(Collections.singletonList(SENDER2));
   private static final List<PublicKey> WITNESSES = new ArrayList<>(Arrays.asList(SENDER1, SENDER2));
   private static final CreateLao CREATE_LAO1 =
       new CreateLao(ID1, NAME1, CREATION, SENDER1, new ArrayList<>());
@@ -76,10 +76,8 @@ public class LaoHandlerTest {
   private Lao lao;
   private MessageGeneral createLaoMessage;
 
-  @Mock
-  MessageSender messageSender;
-  @Mock
-  KeyManager keyManager;
+  @Mock MessageSender messageSender;
+  @Mock KeyManager keyManager;
 
   @Before
   public void setup() throws GeneralSecurityException, IOException {
@@ -110,7 +108,7 @@ public class LaoHandlerTest {
   @Test
   public void testHandleCreateLaoOrganizer()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-      UnknownElectionException, NoRollCallException {
+          UnknownElectionException, NoRollCallException {
     // Create the message (new CreateLao) and call the message handler
     MessageGeneral message = new MessageGeneral(SENDER_KEY1, CREATE_LAO2, gson);
     messageHandler.handleMessage(messageSender, LAO_CHANNEL2, message);
@@ -137,7 +135,7 @@ public class LaoHandlerTest {
   @Test
   public void testHandleCreateLaoWitness()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-      UnknownElectionException, NoRollCallException {
+          UnknownElectionException, NoRollCallException {
     // Main public key is a witness now, and not the organizer
     lenient().when(keyManager.getMainPublicKey()).thenReturn(SENDER2);
 
@@ -167,7 +165,7 @@ public class LaoHandlerTest {
   @Test
   public void testHandleUpdateLaoNewName()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-      UnknownElectionException, NoRollCallException {
+          UnknownElectionException, NoRollCallException {
     // Create the update LAO message with new LAO name
     UpdateLao updateLao =
         new UpdateLao(
@@ -196,7 +194,7 @@ public class LaoHandlerTest {
   @Test
   public void testHandleUpdateLaoNewWitness()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-      UnknownElectionException, NoRollCallException {
+          UnknownElectionException, NoRollCallException {
     // Set LAO to have one witness
     lao.setWitnesses(new HashSet<>(WITNESS));
 
@@ -213,8 +211,8 @@ public class LaoHandlerTest {
     // Create the expected WitnessMessage and PendingUpdate
     WitnessMessage expectedMessage =
         updateLaoWitnessesWitnessMessage(message.getMessageId(), updateLao, new LaoView(lao));
-    PendingUpdate pendingUpdate = new PendingUpdate(updateLao.getLastModified(),
-        message.getMessageId());
+    PendingUpdate pendingUpdate =
+        new PendingUpdate(updateLao.getLastModified(), message.getMessageId());
     HashSet<PendingUpdate> expectedPendingUpdateSet = new HashSet<>();
     expectedPendingUpdateSet.add(pendingUpdate);
 
@@ -229,8 +227,8 @@ public class LaoHandlerTest {
     assertEquals(expectedMessage.getDescription(), witnessMessage.get().getDescription());
 
     // Check the PendingUpdate has been added
-    assertEquals(expectedPendingUpdateSet,
-        laoRepo.getLaoByChannel(LAO_CHANNEL1).getPendingUpdates());
+    assertEquals(
+        expectedPendingUpdateSet, laoRepo.getLaoByChannel(LAO_CHANNEL1).getPendingUpdates());
   }
 
   @Test
@@ -273,10 +271,10 @@ public class LaoHandlerTest {
   @Test
   public void testHandleStateLaoOrganizer()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-      UnknownElectionException, NoRollCallException {
+          UnknownElectionException, NoRollCallException {
     // Create a valid list of modification signatures
-    List<PublicKeySignaturePair> modificationSignatures = getValidModificationSignatures(
-        createLaoMessage);
+    List<PublicKeySignaturePair> modificationSignatures =
+        getValidModificationSignatures(createLaoMessage);
 
     // Create the state LAO message
     StateLao stateLao =
@@ -304,7 +302,7 @@ public class LaoHandlerTest {
   @Test
   public void testHandleStateLaoWitness()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-      UnknownElectionException, NoRollCallException {
+          UnknownElectionException, NoRollCallException {
     // Main public key is a witness now, and not the organizer
     lenient().when(keyManager.getMainPublicKey()).thenReturn(SENDER2);
 
@@ -334,15 +332,15 @@ public class LaoHandlerTest {
   @Test
   public void testHandleStateLaoRemovesStalePendingUpdates()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-      UnknownElectionException, NoRollCallException {
+          UnknownElectionException, NoRollCallException {
     // Create a list of 2 pending updates: one newer and one older than the stateLao message
     long targetTime = CREATE_LAO1.getCreation() + 5;
     PendingUpdate oldPendingUpdate = mock(PendingUpdate.class);
     PendingUpdate newPendingUpdate = mock(PendingUpdate.class);
     when(oldPendingUpdate.getModificationTime()).thenReturn(targetTime - 1);
     when(newPendingUpdate.getModificationTime()).thenReturn(targetTime + 1);
-    Set<PendingUpdate> pendingUpdates = new HashSet<>(
-        Arrays.asList(oldPendingUpdate, newPendingUpdate));
+    Set<PendingUpdate> pendingUpdates =
+        new HashSet<>(Arrays.asList(oldPendingUpdate, newPendingUpdate));
 
     // Add the list of pending updates to the LAO
     Lao createdLao = laoRepo.getLaoByChannel(LAO_CHANNEL1);
@@ -420,7 +418,7 @@ public class LaoHandlerTest {
   @Test()
   public void testGreetLao()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-      UnknownElectionException, NoRollCallException {
+          UnknownElectionException, NoRollCallException {
     // Create the Greet Lao
     GreetLao greetLao =
         new GreetLao(
@@ -449,8 +447,8 @@ public class LaoHandlerTest {
       MessageGeneral messageGeneral) {
     PublicKeySignaturePair validKeyPair;
     try {
-      validKeyPair = new PublicKeySignaturePair(SENDER1,
-          SENDER_KEY1.sign(messageGeneral.getMessageId()));
+      validKeyPair =
+          new PublicKeySignaturePair(SENDER1, SENDER_KEY1.sign(messageGeneral.getMessageId()));
     } catch (GeneralSecurityException e) {
       throw new RuntimeException(e);
     }

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/LaoHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/LaoHandlerTest.java
@@ -51,7 +51,8 @@ public class LaoHandlerTest {
   private static final String ID1 = Lao.generateLaoId(SENDER1, CREATION, NAME1);
   private static final String ID2 = Lao.generateLaoId(SENDER1, CREATION, NAME2);
   private static final String ID3 = Lao.generateLaoId(SENDER1, CREATION, NAME3);
-  private static final List<PublicKey> WITNESS = new ArrayList<>(Arrays.asList(SENDER2));
+  private static final List<PublicKey> WITNESS = new ArrayList<>(
+      Collections.singletonList(SENDER2));
   private static final List<PublicKey> WITNESSES = new ArrayList<>(Arrays.asList(SENDER1, SENDER2));
   private static final CreateLao CREATE_LAO1 =
       new CreateLao(ID1, NAME1, CREATION, SENDER1, new ArrayList<>());
@@ -226,6 +227,8 @@ public class LaoHandlerTest {
     assertTrue(witnessMessage.isPresent());
     assertEquals(expectedMessage.getTitle(), witnessMessage.get().getTitle());
     assertEquals(expectedMessage.getDescription(), witnessMessage.get().getDescription());
+
+    // Check the PendingUpdate has been added
     assertEquals(expectedPendingUpdateSet,
         laoRepo.getLaoByChannel(LAO_CHANNEL1).getPendingUpdates());
   }
@@ -362,7 +365,7 @@ public class LaoHandlerTest {
     messageHandler.handleMessage(messageSender, LAO_CHANNEL1, stateMessage);
 
     // The old pending update is removed in the expected pending list
-    Set<PendingUpdate> expectedPending = new HashSet<>(Arrays.asList(newPendingUpdate));
+    Set<PendingUpdate> expectedPending = new HashSet<>(Collections.singletonList(newPendingUpdate));
     assertEquals(expectedPending, laoRepo.getLaoByChannel(LAO_CHANNEL1).getPendingUpdates());
   }
 
@@ -444,19 +447,19 @@ public class LaoHandlerTest {
 
   private static List<PublicKeySignaturePair> getValidModificationSignatures(
       MessageGeneral messageGeneral) {
-    PublicKeySignaturePair validKeyPair = null;
+    PublicKeySignaturePair validKeyPair;
     try {
       validKeyPair = new PublicKeySignaturePair(SENDER1,
           SENDER_KEY1.sign(messageGeneral.getMessageId()));
     } catch (GeneralSecurityException e) {
       throw new RuntimeException(e);
     }
-    return Arrays.asList(validKeyPair);
+    return Collections.singletonList(validKeyPair);
   }
 
   private static List<PublicKeySignaturePair> getInvalidModificationSignatures() {
     PublicKeySignaturePair invalidKeyPair =
         new PublicKeySignaturePair(generatePublicKey(), generateSignature());
-    return new ArrayList<>(Arrays.asList(invalidKeyPair));
+    return new ArrayList<>(Collections.singletonList(invalidKeyPair));
   }
 }

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/LaoHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/LaoHandlerTest.java
@@ -127,6 +127,7 @@ public class LaoHandlerTest {
     assertTrue(resultLao.getWitnessMessages().isEmpty());
     assertNull(resultLao.getModificationId());
   }
+
   @Test
   public void testHandleCreateLaoWitness()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/LaoHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/LaoHandlerTest.java
@@ -32,6 +32,7 @@ import io.reactivex.Completable;
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generateKeyPair;
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generatePublicKey;
 import static com.github.dedis.popstellar.utility.handler.data.LaoHandler.updateLaoNameWitnessMessage;
+import static com.github.dedis.popstellar.utility.handler.data.LaoHandler.updateLaoWitnessesWitnessMessage;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
@@ -44,9 +45,18 @@ public class LaoHandlerTest {
   private static final PublicKey WITNESS1_KEY = generatePublicKey();
   private static final PublicKey WITNESS2_KEY = generatePublicKey();
   private static final PublicKey SENDER = SENDER_KEY.getPublicKey();
+  private static final long CREATION = Instant.now().getEpochSecond();
+  private static final String NAME1 = "lao1";
+  private static final String NAME2 = "lao2";
+  private static final String ID1 = Lao.generateLaoId(SENDER, CREATION, NAME1);
+  private static final String ID2 = Lao.generateLaoId(SENDER, CREATION, NAME2);
+  private static final CreateLao CREATE_LAO1 =
+      new CreateLao(ID1, NAME1, CREATION, SENDER, new ArrayList<>());
+  private static final CreateLao CREATE_LAO2 =
+      new CreateLao(ID2, NAME2, CREATION, SENDER, new ArrayList<>());
 
-  private static final CreateLao CREATE_LAO = new CreateLao("lao", SENDER);
-  private static final Channel LAO_CHANNEL = Channel.getLaoChannel(CREATE_LAO.getId());
+  private static final Channel LAO_CHANNEL1 = Channel.getLaoChannel(CREATE_LAO1.getId());
+  private static final Channel LAO_CHANNEL2 = Channel.getLaoChannel(CREATE_LAO2.getId());
 
   private LAORepository laoRepo;
   private MessageHandler messageHandler;
@@ -80,24 +90,52 @@ public class LaoHandlerTest {
     messageHandler = new MessageHandler(messageRepo, dataRegistry);
 
     // Create one LAO and add it to the LAORepository
-    lao = new Lao(CREATE_LAO.getName(), CREATE_LAO.getOrganizer(), CREATE_LAO.getCreation());
+    lao = new Lao(CREATE_LAO1.getName(), CREATE_LAO1.getOrganizer(), CREATE_LAO1.getCreation());
     lao.setLastModified(lao.getCreation());
     laoRepo.updateLao(lao);
 
     // Add the CreateLao message to the LAORepository
-    createLaoMessage = new MessageGeneral(SENDER_KEY, CREATE_LAO, gson);
+    createLaoMessage = new MessageGeneral(SENDER_KEY, CREATE_LAO1, gson);
     messageRepo.addMessage(createLaoMessage);
   }
 
   @Test
-  public void testHandleUpdateLao()
+  public void testHandleCreateLao()
+      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
+          UnknownElectionException, NoRollCallException {
+
+    // Create the message and call the message handler
+    MessageGeneral message = new MessageGeneral(SENDER_KEY, CREATE_LAO2, gson);
+    messageHandler.handleMessage(messageSender, LAO_CHANNEL2, message);
+
+    // Get expected results
+    Lao resultLao = laoRepo.getLaoByChannel(LAO_CHANNEL2);
+    String expectedName = CREATE_LAO2.getName();
+    PublicKey expectedOrganizer = CREATE_LAO2.getOrganizer();
+    long expectedCreation = CREATE_LAO2.getCreation();
+    String expectedID = Lao.generateLaoId(expectedOrganizer, expectedCreation, expectedName);
+
+    // Check that the expected LAO was created in the LAO repo
+    assertEquals(LAO_CHANNEL2, resultLao.getChannel());
+    assertEquals(expectedID, resultLao.getId());
+    assertEquals(expectedName, resultLao.getName());
+    assertEquals(expectedCreation, (long) resultLao.getLastModified());
+    assertEquals(expectedCreation, (long) resultLao.getCreation());
+    assertEquals(expectedOrganizer, resultLao.getOrganizer());
+    assertTrue(resultLao.getWitnesses().isEmpty());
+    assertTrue(resultLao.getWitnessMessages().isEmpty());
+    assertNull(resultLao.getModificationId());
+  }
+
+  @Test
+  public void testHandleUpdateLaoNewName()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
           UnknownElectionException, NoRollCallException {
     // Create the update LAO message
     UpdateLao updateLao =
         new UpdateLao(
             SENDER,
-            CREATE_LAO.getCreation(),
+            CREATE_LAO1.getCreation(),
             "new name",
             Instant.now().getEpochSecond(),
             new HashSet<>());
@@ -108,14 +146,87 @@ public class LaoHandlerTest {
         updateLaoNameWitnessMessage(message.getMessageId(), updateLao, new LaoView(lao));
 
     // Call the message handler
-    messageHandler.handleMessage(messageSender, LAO_CHANNEL, message);
+    messageHandler.handleMessage(messageSender, LAO_CHANNEL1, message);
 
     // Check the WitnessMessage has been created
     Optional<WitnessMessage> witnessMessage =
-        laoRepo.getLaoByChannel(LAO_CHANNEL).getWitnessMessage(message.getMessageId());
+        laoRepo.getLaoByChannel(LAO_CHANNEL1).getWitnessMessage(message.getMessageId());
     assertTrue(witnessMessage.isPresent());
     assertEquals(expectedMessage.getTitle(), witnessMessage.get().getTitle());
     assertEquals(expectedMessage.getDescription(), witnessMessage.get().getDescription());
+  }
+
+  @Test
+  public void testHandleUpdateLaoNewWitness()
+      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
+          UnknownElectionException, NoRollCallException {
+    lao.setWitnesses(new HashSet<>(Arrays.asList(WITNESS1_KEY)));
+
+    // Create UpdateLao with different witness set
+    UpdateLao updateLao =
+        new UpdateLao(
+            SENDER,
+            CREATE_LAO1.getCreation(),
+            CREATE_LAO1.getName(),
+            Instant.now().getEpochSecond(),
+            new HashSet<>(Arrays.asList(WITNESS1_KEY, WITNESS2_KEY)));
+    MessageGeneral message = new MessageGeneral(SENDER_KEY, updateLao, gson);
+
+    // Create the expected WitnessMessage
+    WitnessMessage expectedMessage =
+        updateLaoWitnessesWitnessMessage(message.getMessageId(), updateLao, new LaoView(lao));
+
+    // Call the handler
+    messageHandler.handleMessage(messageSender, LAO_CHANNEL1, message);
+
+    // Check the WitnessMessage has been created
+    Optional<WitnessMessage> witnessMessage =
+        laoRepo.getLaoByChannel(LAO_CHANNEL1).getWitnessMessage(message.getMessageId());
+    assertTrue(witnessMessage.isPresent());
+    assertEquals(expectedMessage.getTitle(), witnessMessage.get().getTitle());
+    assertEquals(expectedMessage.getDescription(), witnessMessage.get().getDescription());
+  }
+
+  @Test
+  public void testHandleUpdateLaoOldInfo()
+      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
+          UnknownElectionException, NoRollCallException {
+    // Create UpdateLao with no new name or witness
+    UpdateLao updateLao =
+        new UpdateLao(
+            SENDER,
+            CREATE_LAO1.getCreation(),
+            CREATE_LAO1.getName(),
+            Instant.now().getEpochSecond(),
+            new HashSet<>());
+    MessageGeneral message = new MessageGeneral(SENDER_KEY, updateLao, gson);
+
+    // Check that handling the message fails
+    assertThrows(
+        DataHandlingException.class,
+        () -> messageHandler.handleMessage(messageSender, LAO_CHANNEL1, message));
+  }
+
+  @Test
+  public void testHandleStaleUpdateLao()
+      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
+          UnknownElectionException, NoRollCallException {
+    // Create a LAO update message with last modified time older than the current LAO last modified
+    // time (was creation)
+    UpdateLao updateLao1 =
+        new UpdateLao(
+            SENDER,
+            CREATE_LAO1.getCreation() - 5,
+            "new lao name",
+            CREATE_LAO1.getCreation() - 10,
+            new HashSet<>());
+
+    MessageGeneral message = new MessageGeneral(SENDER_KEY, updateLao1, gson);
+
+    // Check that handling the older message fails
+    assertThrows(
+        DataHandlingException.class,
+        () -> messageHandler.handleMessage(messageSender, LAO_CHANNEL1, message));
   }
 
   @Test
@@ -125,24 +236,24 @@ public class LaoHandlerTest {
     // Create the state LAO message
     StateLao stateLao =
         new StateLao(
-            CREATE_LAO.getId(),
-            CREATE_LAO.getName(),
-            CREATE_LAO.getCreation(),
+            CREATE_LAO1.getId(),
+            CREATE_LAO1.getName(),
+            CREATE_LAO1.getCreation(),
             Instant.now().getEpochSecond(),
-            CREATE_LAO.getOrganizer(),
+            CREATE_LAO1.getOrganizer(),
             createLaoMessage.getMessageId(),
             new HashSet<>(),
             new ArrayList<>());
     MessageGeneral message = new MessageGeneral(SENDER_KEY, stateLao, gson);
 
     // Call the message handler
-    messageHandler.handleMessage(messageSender, LAO_CHANNEL, message);
+    messageHandler.handleMessage(messageSender, LAO_CHANNEL1, message);
 
     // Check the LAO last modification time and ID was updated
     assertEquals(
-        (Long) stateLao.getLastModified(), laoRepo.getLaoByChannel(LAO_CHANNEL).getLastModified());
+        (Long) stateLao.getLastModified(), laoRepo.getLaoByChannel(LAO_CHANNEL1).getLastModified());
     assertEquals(
-        stateLao.getModificationId(), laoRepo.getLaoByChannel(LAO_CHANNEL).getModificationId());
+        stateLao.getModificationId(), laoRepo.getLaoByChannel(LAO_CHANNEL1).getModificationId());
   }
 
   @Test()
@@ -157,7 +268,7 @@ public class LaoHandlerTest {
     MessageGeneral message = new MessageGeneral(SENDER_KEY, greetLao, gson);
 
     // Call the handler
-    messageHandler.handleMessage(messageSender, LAO_CHANNEL, message);
+    messageHandler.handleMessage(messageSender, LAO_CHANNEL1, message);
 
     // Check that the server repository contains the key of the server
     assertEquals(RANDOM_ADDRESS, serverRepository.getServerByLaoId(lao.getId()).getServerAddress());
@@ -171,39 +282,6 @@ public class LaoHandlerTest {
     MessageGeneral message_invalid = new MessageGeneral(SENDER_KEY, greetLao_invalid, gson);
     assertThrows(
         IllegalArgumentException.class,
-        () -> messageHandler.handleMessage(messageSender, LAO_CHANNEL, message_invalid));
-  }
-
-  @Test
-  public void testHandleUpdateLaoWitnessSetsNotEqual()
-      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-          UnknownElectionException, NoRollCallException {
-    lao.setWitnesses(new HashSet<>(Arrays.asList(WITNESS1_KEY)));
-
-    // Create UpdateLao with different witness set
-    UpdateLao updateLao =
-        new UpdateLao(
-            SENDER,
-            CREATE_LAO.getCreation(),
-            CREATE_LAO.getName(),
-            Instant.now().getEpochSecond(),
-            new HashSet<>(Arrays.asList(WITNESS1_KEY, WITNESS2_KEY)));
-    MessageGeneral message = new MessageGeneral(SENDER_KEY, updateLao, gson);
-
-    // Call the handler
-    messageHandler.handleMessage(messageSender, LAO_CHANNEL, message);
-
-    // Check the WitnessMessage has been created with the expected title and description
-    Optional<WitnessMessage> witnessMessage =
-        laoRepo.getLaoByChannel(LAO_CHANNEL).getWitnessMessage(message.getMessageId());
-    assertTrue(witnessMessage.isPresent());
-    assertEquals("Update Lao Witnesses", witnessMessage.get().getTitle());
-    System.out.println("check " + message.getMessageId().toString());
-
-    String expectedDescription =
-        String.format(
-            "Lao Name : %s\nMessage ID : %s\nNew Witness ID : %s",
-            lao.getName(), message.getMessageId(), WITNESS2_KEY);
-    assertEquals(expectedDescription, witnessMessage.get().getDescription());
+        () -> messageHandler.handleMessage(messageSender, LAO_CHANNEL1, message_invalid));
   }
 }


### PR DESCRIPTION
This PR addresses issue [#1378](https://github.com/dedis/popstellar/issues/1378) and increases the test coverage of `LaoHandler` and `ElectionHandler`. Because I needed `PendingUpdate` in my tests, I also added an `equals` and `hashCode` method there, and created the corresponding test class `PendingUpdateTest`.