### PR TITLE
Redefine sendResult method 

### DIFF
--- a/be1-go/channel/chirp/mod_test.go
+++ b/be1-go/channel/chirp/mod_test.go
@@ -665,7 +665,7 @@ func (f *fakeSocket) Send(msg []byte) {
 }
 
 // SendResult implements socket.Socket
-func (f *fakeSocket) SendResult(id int, res []message.Message) {
+func (f *fakeSocket) SendResult(id int, res []message.Message, missingMsgs map[string][]message.Message) {
 	f.resultID = id
 	f.res = res
 }

--- a/be1-go/channel/coin/mod_test.go
+++ b/be1-go/channel/coin/mod_test.go
@@ -843,7 +843,7 @@ func (f *fakeSocket) Send(msg []byte) {
 }
 
 // SendResult implements socket.Socket
-func (f *fakeSocket) SendResult(id int, res []message.Message) {
+func (f *fakeSocket) SendResult(id int, res []message.Message, missingMsgs map[string][]message.Message) {
 	f.resultID = id
 	f.res = res
 }

--- a/be1-go/channel/consensus/mod_test.go
+++ b/be1-go/channel/consensus/mod_test.go
@@ -2066,7 +2066,7 @@ func (f *fakeSocket) Send(msg []byte) {
 }
 
 // SendResult implements socket.Socket
-func (f *fakeSocket) SendResult(id int, res []message.Message) {
+func (f *fakeSocket) SendResult(id int, res []message.Message, missingMsgs map[string][]message.Message) {
 	f.resultID = id
 	f.res = res
 }

--- a/be1-go/channel/election/mod_test.go
+++ b/be1-go/channel/election/mod_test.go
@@ -791,7 +791,7 @@ func (f *fakeSocket) Send(msg []byte) {
 }
 
 // SendResult implements socket.Socket
-func (f *fakeSocket) SendResult(id int, res []message.Message) {
+func (f *fakeSocket) SendResult(id int, res []message.Message, missingMsgs map[string][]message.Message) {
 	f.resultID = id
 	f.res = res
 }

--- a/be1-go/channel/generalChirping/mod_test.go
+++ b/be1-go/channel/generalChirping/mod_test.go
@@ -310,7 +310,7 @@ func (f *fakeSocket) Send(msg []byte) {
 }
 
 // SendResult implements socket.Socket
-func (f *fakeSocket) SendResult(id int, res []message.Message) {
+func (f *fakeSocket) SendResult(id int, res []message.Message, missingMsgs map[string][]message.Message) {
 	f.resultID = id
 	f.res = res
 }

--- a/be1-go/channel/lao/mod_test.go
+++ b/be1-go/channel/lao/mod_test.go
@@ -704,7 +704,7 @@ func (f *fakeSocket) Send(msg []byte) {
 }
 
 // SendResult implements socket.Socket
-func (f *fakeSocket) SendResult(id int, res []message.Message) {
+func (f *fakeSocket) SendResult(id int, res []message.Message, missingMsgs map[string][]message.Message) {
 	f.resultID = id
 	f.res = res
 }

--- a/be1-go/channel/reaction/mod_test.go
+++ b/be1-go/channel/reaction/mod_test.go
@@ -702,7 +702,7 @@ func (f *fakeSocket) Send(msg []byte) {
 }
 
 // SendResult implements socket.Socket
-func (f *fakeSocket) SendResult(id int, res []message.Message) {
+func (f *fakeSocket) SendResult(id int, res []message.Message, missingMsgs map[string][]message.Message) {
 	f.resultID = id
 	f.res = res
 }

--- a/be1-go/docs/README.md
+++ b/be1-go/docs/README.md
@@ -112,7 +112,7 @@ implementations:
 
 The `ReadPump` and `WritePump` are low-level methods which allow reading/writing
 data over the wire. Most users would instead use the `Send(msg []byte)`,
-`SendError(id int, err error)` and `SendResult(id int, res message.Result)`
+`SendError(id *int, err error)` and `SendResult(id int, res []message.Message, missingMessagesByChannel map[string][]message.Message)`
 APIs.
 
 Each incoming message read by `ReadPump` is passed to the Hub for processing.

--- a/be1-go/hub/standard_hub/mod.go
+++ b/be1-go/hub/standard_hub/mod.go
@@ -345,11 +345,11 @@ func (h *Hub) handleMessageFromClient(incomingMessage *socket.IncomingMessage) e
 	}
 
 	if queryBase.Method == query.MethodCatchUp {
-		socket.SendResult(id, msgs)
+		socket.SendResult(id, msgs, nil)
 		return nil
 	}
 
-	socket.SendResult(id, nil)
+	socket.SendResult(id, nil, nil)
 
 	return nil
 }
@@ -429,11 +429,11 @@ func (h *Hub) handleMessageFromServer(incomingMessage *socket.IncomingMessage) e
 	}
 
 	if queryBase.Method == query.MethodCatchUp {
-		socket.SendResult(id, msgs)
+		socket.SendResult(id, msgs, nil)
 		return nil
 	}
 
-	socket.SendResult(id, nil)
+	socket.SendResult(id, nil, nil)
 
 	return nil
 }

--- a/be1-go/hub/standard_hub/mod_test.go
+++ b/be1-go/hub/standard_hub/mod_test.go
@@ -1765,7 +1765,7 @@ func (f *fakeSocket) Send(msg []byte) {
 }
 
 // SendResult implements socket.Socket
-func (f *fakeSocket) SendResult(id int, res []message.Message) {
+func (f *fakeSocket) SendResult(id int, res []message.Message, missingMsgs map[string][]message.Message) {
 	f.Lock()
 	defer f.Unlock()
 

--- a/be1-go/hub/standard_hub/mod_test.go
+++ b/be1-go/hub/standard_hub/mod_test.go
@@ -1746,9 +1746,10 @@ type fakeSocket struct {
 	sync.Mutex
 	socket.Socket
 
-	resultID int
-	res      []message.Message
-	msg      []byte
+	resultID    int
+	res         []message.Message
+	missingMsgs map[string][]message.Message
+	msg         []byte
 
 	err error
 
@@ -1771,6 +1772,7 @@ func (f *fakeSocket) SendResult(id int, res []message.Message, missingMsgs map[s
 
 	f.resultID = id
 	f.res = res
+	f.missingMsgs = missingMsgs
 }
 
 // SendError implements socket.Socket

--- a/be1-go/message/answer/answer.go
+++ b/be1-go/message/answer/answer.go
@@ -15,7 +15,7 @@ type Answer struct {
 	Error  *Error  `json:"error,omitempty"`
 }
 
-// Result can be either a 0 int, a slice of messages or an array of MessageIdsByChannelId objects
+// Result can be either a 0 int, a slice of messages or a map of messages associated to a channel ID
 type Result struct {
 	isEmpty           bool
 	data              []json.RawMessage
@@ -32,14 +32,16 @@ func (r *Result) UnmarshalJSON(buf []byte) error {
 	}
 
 	err := json.Unmarshal(buf, &r.data)
-	if err != nil {
-		err = json.Unmarshal(buf, &r.MessagesByChannel)
+	if err == nil {
+		return nil
 	}
 
-	if err != nil {
-		return xerrors.Errorf("failed to unmarshal data: %v", err)
+	err = json.Unmarshal(buf, &r.MessagesByChannel)
+	if err == nil {
+		return nil
 	}
-	return nil
+
+	return xerrors.Errorf("failed to unmarshal data: %v", err)
 }
 
 // IsEmpty tells if there are potentially 0 or more messages in the result.

--- a/be1-go/message/answer/answer.go
+++ b/be1-go/message/answer/answer.go
@@ -2,6 +2,7 @@ package answer
 
 import (
 	"encoding/json"
+	"fmt"
 	"golang.org/x/xerrors"
 	message "popstellar/message"
 )
@@ -31,17 +32,21 @@ func (r *Result) UnmarshalJSON(buf []byte) error {
 		return nil
 	}
 
-	err := json.Unmarshal(buf, &r.data)
-	if err == nil {
+	errData := json.Unmarshal(buf, &r.data)
+	if errData == nil {
 		return nil
 	}
 
-	err = json.Unmarshal(buf, &r.MessagesByChannel)
-	if err == nil {
+	errMsg := fmt.Sprintf("failed to unmarshal into r.data: %v", errData)
+
+	errMessagesByChannel := json.Unmarshal(buf, &r.MessagesByChannel)
+	if errMessagesByChannel == nil {
 		return nil
 	}
 
-	return xerrors.Errorf("failed to unmarshal data: %v", err)
+	errMsg += fmt.Sprintf("failed to unmarshal into r.MessagesByChannel: %v", errMessagesByChannel)
+
+	return xerrors.Errorf("failed to unmarshal result: %s", errMsg)
 }
 
 // IsEmpty tells if there are potentially 0 or more messages in the result.

--- a/be1-go/network/socket/mod.go
+++ b/be1-go/network/socket/mod.go
@@ -54,7 +54,7 @@ type Socket interface {
 	// nil, empty, or filled if the result is a slice of messages.
 	// MissingMessagesByChannel can be nil or filled if the result is a map
 	// associating a channel to a slice of messages. In case both are nil
-	// it sends the "0" return value.
+	// it sends the "0" return value. You can either send res or missingMessagesByChannel, not both.
 	SendResult(id int, res []message.Message, missingMessagesByChannel map[string][]message.Message)
 }
 

--- a/be1-go/network/socket/mod.go
+++ b/be1-go/network/socket/mod.go
@@ -51,8 +51,11 @@ type Socket interface {
 	SendError(id *int, err error)
 
 	// SendResult is used to send a result message to the client. Res can be
-	// nil, empty, or filled. In case it is nil it sends the "0" return value.
-	SendResult(id int, res []message.Message)
+	// nil, empty, or filled if the result is a slice of messages.
+	// MissingMessagesByChannel can be nil or filled if the result is a map
+	// associating a channel to a slice of messages. In case both are nil
+	// it sends the "0" return value.
+	SendResult(id int, res []message.Message, missingMessagesByChannel map[string][]message.Message)
 }
 
 // IncomingMessage wraps the raw message from the websocket connection and pairs

--- a/be1-go/network/socket/socket.go
+++ b/be1-go/network/socket/socket.go
@@ -243,7 +243,7 @@ func (s *baseSocket) SendResult(id int, res []message.Message, missingMessagesBy
 	}
 
 	s.log.Info().
-		//Str("to", s.conn.RemoteAddr().String()).
+		Str("to", s.id).
 		Str("msg", string(answerBuf)).
 		Msg("send result")
 	s.send <- answerBuf

--- a/be1-go/network/socket/socket.go
+++ b/be1-go/network/socket/socket.go
@@ -197,10 +197,10 @@ func (s *baseSocket) SendError(id *int, err error) {
 
 // SendResult is a utility method that allows sending a `message.Result` to the
 // socket.
-func (s *baseSocket) SendResult(id int, res []message.Message) {
+func (s *baseSocket) SendResult(id int, res []message.Message, missingMessagesByChannel map[string][]message.Message) {
 	var answer interface{}
 
-	if res == nil {
+	if res == nil && missingMessagesByChannel == nil {
 		answer = struct {
 			JSONRPC string `json:"jsonrpc"`
 			ID      int    `json:"id"`
@@ -208,7 +208,7 @@ func (s *baseSocket) SendResult(id int, res []message.Message) {
 		}{
 			"2.0", id, 0,
 		}
-	} else {
+	} else if res != nil {
 		for _, r := range res {
 			if r.WitnessSignatures == nil {
 				r.WitnessSignatures = []message.WitnessSignature{}
@@ -220,6 +220,14 @@ func (s *baseSocket) SendResult(id int, res []message.Message) {
 			Result  []message.Message `json:"result"`
 		}{
 			"2.0", id, res,
+		}
+	} else if missingMessagesByChannel != nil {
+		answer = struct {
+			JSONRPC string                       `json:"jsonrpc"`
+			ID      int                          `json:"id"`
+			Result  map[string][]message.Message `json:"result"`
+		}{
+			"2.0", id, missingMessagesByChannel,
 		}
 	}
 

--- a/be1-go/network/socket/socket.go
+++ b/be1-go/network/socket/socket.go
@@ -200,6 +200,11 @@ func (s *baseSocket) SendError(id *int, err error) {
 func (s *baseSocket) SendResult(id int, res []message.Message, missingMessagesByChannel map[string][]message.Message) {
 	var answer interface{}
 
+	if res != nil && missingMessagesByChannel != nil {
+		s.log.Error().Msg("The result must be either a slice or a map of messages, not both.")
+		return
+	}
+
 	if res == nil && missingMessagesByChannel == nil {
 		answer = struct {
 			JSONRPC string `json:"jsonrpc"`
@@ -238,7 +243,7 @@ func (s *baseSocket) SendResult(id int, res []message.Message, missingMessagesBy
 	}
 
 	s.log.Info().
-		Str("to", s.conn.RemoteAddr().String()).
+		//Str("to", s.conn.RemoteAddr().String()).
 		Str("msg", string(answerBuf)).
 		Msg("send result")
 	s.send <- answerBuf

--- a/be1-go/network/socket/socket_test.go
+++ b/be1-go/network/socket/socket_test.go
@@ -12,6 +12,76 @@ import (
 	"testing"
 )
 
+// Tests that SendResult works when sending a slice of messages
+func Test_SendResult_Messages_Slice(t *testing.T) {
+	socket.SendResult(1, res1, nil)
+
+	var receivedAnswer answer.Answer
+
+	ans := <-socket.send
+
+	err := json.Unmarshal(ans, &receivedAnswer)
+	require.NoError(t, err)
+
+	require.False(t, receivedAnswer.Result.IsEmpty())
+
+	require.Equal(t, 1, *receivedAnswer.ID)
+
+	messages := receivedAnswer.Result.GetData()
+	for msg := range messages {
+		var messageData message.Message
+		err = json.Unmarshal(messages[msg], &messageData)
+		require.NoError(t, err)
+
+		require.Contains(t, res1, messageData)
+	}
+}
+
+// Tests that SendResult works when sending a map of messages associated to a channel ID
+func Test_SendResult_Messages_By_Channel_Id(t *testing.T) {
+	msgsByChannelId := make(map[string][]message.Message)
+	msgsByChannelId["channel1"] = res1
+	msgsByChannelId["channel2"] = res2
+
+	socket.SendResult(1, nil, msgsByChannelId)
+
+	var receivedAnswer answer.Answer
+
+	ans := <-socket.send
+
+	err := json.Unmarshal(ans, &receivedAnswer)
+	require.NoError(t, err)
+
+	require.False(t, receivedAnswer.Result.IsEmpty())
+
+	messagesByChannel := receivedAnswer.Result.GetMessagesByChannel()
+	for channelId, msgs := range messagesByChannel {
+		for _, msg := range msgs {
+			var messageData message.Message
+			err = json.Unmarshal(msg, &messageData)
+			require.NoError(t, err)
+
+			require.Contains(t, msgsByChannelId[channelId], messageData)
+		}
+	}
+}
+
+// Tests that SendResult works when sending an empty answer
+func Test_SendResult_Empty_Answer(t *testing.T) {
+	socket.SendResult(0, nil, nil)
+	var receivedAnswer answer.Answer
+
+	ans := <-socket.send
+
+	err := json.Unmarshal(ans, &receivedAnswer)
+	require.NoError(t, err)
+
+	require.True(t, receivedAnswer.Result.IsEmpty())
+}
+
+// -------------------------------------
+// Test variables definition
+
 var socket = *newBaseSocket(
 	ServerSocketType,
 	make(chan IncomingMessage),
@@ -21,6 +91,7 @@ var socket = *newBaseSocket(
 	make(chan struct{}),
 	zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout}).With().Timestamp().Logger(),
 )
+
 var msg1 = message.Message{
 	Data:              "data1",
 	Sender:            "sender1",
@@ -46,66 +117,3 @@ var msg3 = message.Message{
 
 var res1 = []message.Message{msg1, msg2}
 var res2 = []message.Message{msg3}
-
-func Test_SendResult_Res(t *testing.T) {
-	socket.SendResult(1, res1, nil)
-
-	var receivedAnswer answer.Answer
-
-	ans := <-socket.send
-
-	err := json.Unmarshal(ans, &receivedAnswer)
-	require.NoError(t, err)
-
-	require.False(t, receivedAnswer.Result.IsEmpty())
-
-	require.Equal(t, 1, *receivedAnswer.ID)
-
-	messages := receivedAnswer.Result.GetData()
-	for msg := range messages {
-		var messageData message.Message
-		err = json.Unmarshal(messages[msg], &messageData)
-		require.NoError(t, err)
-
-		require.Contains(t, res1, messageData)
-	}
-}
-
-func Test_SendResult_Messages_By_Channel_Id(t *testing.T) {
-	msgsByChannelId := make(map[string][]message.Message)
-	msgsByChannelId["channel1"] = res1
-	msgsByChannelId["channel2"] = res2
-
-	socket.SendResult(1, nil, msgsByChannelId)
-
-	var receivedAnswer answer.Answer
-
-	ans := <-socket.send
-
-	err := json.Unmarshal(ans, &receivedAnswer)
-	require.NoError(t, err)
-
-	require.False(t, receivedAnswer.Result.IsEmpty())
-
-	messagesByChannel := receivedAnswer.Result.GetMessagesByChannel()
-	for channelId, msgs := range messagesByChannel {
-		for _, msg := range msgs {
-			var messageData message.Message
-			err = json.Unmarshal(msg, &messageData)
-			require.NoError(t, err)
-			require.Contains(t, msgsByChannelId[channelId], messageData)
-		}
-	}
-}
-
-func Test_SendResult_Empty_Answer(t *testing.T) {
-	socket.SendResult(0, nil, nil)
-	var receivedAnswer answer.Answer
-
-	ans := <-socket.send
-
-	err := json.Unmarshal(ans, &receivedAnswer)
-	require.NoError(t, err)
-
-	require.True(t, receivedAnswer.Result.IsEmpty())
-}

--- a/be1-go/network/socket/socket_test.go
+++ b/be1-go/network/socket/socket_test.go
@@ -54,6 +54,8 @@ func Test_SendResult_Messages_By_Channel_Id(t *testing.T) {
 
 	require.False(t, receivedAnswer.Result.IsEmpty())
 
+	require.Equal(t, 1, *receivedAnswer.ID)
+
 	messagesByChannel := receivedAnswer.Result.GetMessagesByChannel()
 	for channelId, msgs := range messagesByChannel {
 		for _, msg := range msgs {

--- a/be1-go/network/socket/socket_test.go
+++ b/be1-go/network/socket/socket_test.go
@@ -1,0 +1,111 @@
+package socket
+
+import (
+	"encoding/json"
+	"github.com/gorilla/websocket"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"os"
+	"popstellar/message/answer"
+	"popstellar/message/query/method/message"
+	"sync"
+	"testing"
+)
+
+var socket = *newBaseSocket(
+	ServerSocketType,
+	make(chan IncomingMessage),
+	make(chan string),
+	&websocket.Conn{},
+	&sync.WaitGroup{},
+	make(chan struct{}),
+	zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout}).With().Timestamp().Logger(),
+)
+var msg1 = message.Message{
+	Data:              "data1",
+	Sender:            "sender1",
+	Signature:         "signature1",
+	MessageID:         "message1",
+	WitnessSignatures: nil,
+}
+var msg2 = message.Message{
+	Data:              "data2",
+	Sender:            "sender2",
+	Signature:         "signature2",
+	MessageID:         "message2",
+	WitnessSignatures: nil,
+}
+
+var msg3 = message.Message{
+	Data:              "data3",
+	Sender:            "sender3",
+	Signature:         "signature3",
+	MessageID:         "message3",
+	WitnessSignatures: nil,
+}
+
+var res1 = []message.Message{msg1, msg2}
+var res2 = []message.Message{msg3}
+
+func Test_SendResult_Res(t *testing.T) {
+	socket.SendResult(1, res1, nil)
+
+	var receivedAnswer answer.Answer
+
+	ans := <-socket.send
+
+	err := json.Unmarshal(ans, &receivedAnswer)
+	require.NoError(t, err)
+
+	require.False(t, receivedAnswer.Result.IsEmpty())
+
+	require.Equal(t, 1, *receivedAnswer.ID)
+
+	messages := receivedAnswer.Result.GetData()
+	for msg := range messages {
+		var messageData message.Message
+		err = json.Unmarshal(messages[msg], &messageData)
+		require.NoError(t, err)
+
+		require.Contains(t, res1, messageData)
+	}
+}
+
+func Test_SendResult_Messages_By_Channel_Id(t *testing.T) {
+	msgsByChannelId := make(map[string][]message.Message)
+	msgsByChannelId["channel1"] = res1
+	msgsByChannelId["channel2"] = res2
+
+	socket.SendResult(1, nil, msgsByChannelId)
+
+	var receivedAnswer answer.Answer
+
+	ans := <-socket.send
+
+	err := json.Unmarshal(ans, &receivedAnswer)
+	require.NoError(t, err)
+
+	require.False(t, receivedAnswer.Result.IsEmpty())
+
+	messagesByChannel := receivedAnswer.Result.GetMessagesByChannel()
+	for channelId, msgs := range messagesByChannel {
+		for _, msg := range msgs {
+			var messageData message.Message
+			err = json.Unmarshal(msg, &messageData)
+			require.NoError(t, err)
+			require.Contains(t, msgsByChannelId[channelId], messageData)
+		}
+	}
+}
+
+func Test_SendResult_Empty_Answer(t *testing.T) {
+	socket.SendResult(0, nil, nil)
+	var receivedAnswer answer.Answer
+
+	ans := <-socket.send
+
+	err := json.Unmarshal(ans, &receivedAnswer)
+	require.NoError(t, err)
+
+	require.True(t, receivedAnswer.Result.IsEmpty())
+}


### PR DESCRIPTION
This is a small PR that redefines the sendResult method to support sending a map associating a channel to a slice of messages as preparation work for the implementation of the heartbeat and getMessagesById methods. 
In that direction, it fixes previous tests that use sendResult by adding the new argument which will not be used but is necessary since fakeSockets implement Socket. 