### PR TITLE
Add server and client specific path 

### DIFF
--- a/be2-scala/README.md
+++ b/be2-scala/README.md
@@ -43,11 +43,12 @@ where the configuration lives. This can be updated if needed.
 # Snapshot of application.config
 
 ch_epfl_pop_Server {
-	http {
-		interface = "127.0.0.1"
-		port = "8000"
-		path = "client"
-	}
+  http {
+      interface = "127.0.0.1"
+      port = "8000"
+      client-path = "client"
+      server-path = "server"
+    }
 }
  ```
 

--- a/be2-scala/README.md
+++ b/be2-scala/README.md
@@ -46,7 +46,7 @@ ch_epfl_pop_Server {
 	http {
 		interface = "127.0.0.1"
 		port = "8000"
-		path = ""
+		path = "client"
 	}
 }
  ```
@@ -93,7 +93,7 @@ environment:
 
 ```sh
 # install sdkman
-curl -s "https://get.sdkman.io" | bash 
+curl -s "https://get.sdkman.io" | bash
 # install java zulu 11
 sdk install java 11.0.18-zulu
 # install sbt
@@ -115,5 +115,5 @@ Run by specifying the configuration file:
 
 ```sh
 java -Dscala.config="src/main/scala/ch/epfl/pop/config" -jar target/scala-2.13/pop-assembly-<version>-SNAPSHOT.jar
-> ch.epfl.pop.Server online at ws://127.0.0.1:8000/
+> ch.epfl.pop.Server online at ws://127.0.0.1:8000/client
 ```

--- a/be2-scala/docs/README.md
+++ b/be2-scala/docs/README.md
@@ -431,7 +431,7 @@ You can then set a title and description to your PR as well as set a label (e.g.
 
 The best way to "intercept" a `GraphMessage` being processed in the graph is to launch the server in debug mode, and then sending an isolated message to the server triggering the bug.
 
-:information_source: [Hoppscotch](https://hoppscotch.io/realtime/) (Realtime => WebSocket => `ws://localhost:8000/`) is a useful tool to achieve this result
+:information_source: [Hoppscotch](https://hoppscotch.io/realtime/) (Realtime => WebSocket => `ws://localhost:8000/client`) is a useful tool to achieve this result
 
 
 ## 6.	Coding Styles

--- a/be2-scala/src/main/scala/ch/epfl/pop/config/ServerConf.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/config/ServerConf.scala
@@ -15,12 +15,14 @@ object ServerConf {
     val serverConf = appConf.getConfig("ch_epfl_pop_Server").getConfig("http")
     val serverInterface = serverConf.getString("interface")
     val serverPort = serverConf.getInt("port")
-    val path = serverConf.getString("path")
+    val clientPath = serverConf.getString("client-path")
+    val serverPath = serverConf.getString("server-path")
 
-    new ServerConf(serverInterface, serverPort, path)
+
+    new ServerConf(serverInterface, serverPort, clientPath, serverPath)
   }
 
 }
 
 /* Note: Can be upgraded for future configs :) */
-final case class ServerConf(interface: String, port: Int, path: String)
+final case class ServerConf(interface: String, port: Int, clientPath: String, serverPath: String)

--- a/be2-scala/src/main/scala/ch/epfl/pop/config/ServerConf.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/config/ServerConf.scala
@@ -18,7 +18,6 @@ object ServerConf {
     val clientPath = serverConf.getString("client-path")
     val serverPath = serverConf.getString("server-path")
 
-
     new ServerConf(serverInterface, serverPort, clientPath, serverPath)
   }
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/config/application.conf
+++ b/be2-scala/src/main/scala/ch/epfl/pop/config/application.conf
@@ -21,6 +21,7 @@ ch_epfl_pop_Server {
   http {
     interface = "127.0.0.1"
     port = "8000"
-    path = ""
+    client-path = "client"
+    server-path = "server"
   }
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/LaoHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/LaoHandler.scala
@@ -4,7 +4,6 @@ import ch.epfl.pop.config.RuntimeEnvironment.appConf
 import ch.epfl.pop.config.ServerConf
 import ch.epfl.pop.json.MessageDataProtocol.GreetLaoFormat
 import ch.epfl.pop.model.network.JsonRpcRequest
-import ch.epfl.pop.model.network.method.message.Message
 import ch.epfl.pop.model.network.method.message.data.ObjectType
 import ch.epfl.pop.model.network.method.message.data.lao.{CreateLao, GreetLao, StateLao}
 import ch.epfl.pop.model.objects.{Channel, DbActorNAckException, Hash}
@@ -29,7 +28,7 @@ case object LaoHandler extends MessageHandler {
         reactionChannel: Channel = Channel(s"$laoChannel${Channel.REACTIONS_CHANNEL_PREFIX}")
         // we get access to the canonical address of the server
         config = ServerConf(appConf)
-        address: Option[String] = Some(f"ws://${config.interface}:${config.port}/${config.path}")
+        address: Option[String] = Some(f"ws://${config.interface}:${config.port}/${config.clientPath}")
 
         // check whether the lao already exists in db
         _ <- dbActor ? DbActor.AssertChannelMissing(laoChannel)

--- a/tests/karate/src/test/java/karate-config.js
+++ b/tests/karate/src/test/java/karate-config.js
@@ -24,7 +24,7 @@ function fn() {
     // customize
     config.host = '127.0.0.1';
     config.port = 8000;
-    config.path = '';
+    config.path = 'client';
     config.wsURL = `ws://${config.host}:${config.port}/${config.path}`;
   } else {
     config.port = 9005;


### PR DESCRIPTION
This pr introduces change to the path clients use to connect. 
With this pr, the following paths are available: 

`/server`: For servers to connect to
`/client`: For clients, this path replaces `/` we had until now. 

For now, client and servers are treated the same way no matter the path used to connect, this will change in the future.