### PR TITLE
Add ConnectionMediator

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/decentralized/ConnectionMediator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/decentralized/ConnectionMediator.scala
@@ -48,7 +48,7 @@ final case class ConnectionMediator(
       serverSet -= serverRef
       // Tell monitor to stop scheduling heartbeats since there is no one to receive them
       if (serverSet.isEmpty)
-        sender() ! Monitor.NoServerConnected
+        monitorRef ! Monitor.NoServerConnected
 
     case Heartbeat(map) =>
       log.info("sending to some hearbeat to the clients")

--- a/be2-scala/src/main/scala/ch/epfl/pop/decentralized/ConnectionMediator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/decentralized/ConnectionMediator.scala
@@ -51,7 +51,7 @@ final case class ConnectionMediator(
         monitorRef ! Monitor.NoServerConnected
 
     case Heartbeat(map) =>
-      log.info("sending to some hearbeat to the clients")
+      log.info("Sending a heartbeat to the servers")
       serverSet.map(server =>
         server ! ClientAnswer(
           Right(JsonRpcRequest(
@@ -71,7 +71,6 @@ object ConnectionMediator {
     Props(new ConnectionMediator(monitorRef, mediatorRef, dbActorRef, messageRegistry))
 
   sealed trait Event
-
   final case class ConnectTo(urlList: List[String]) extends Event
   final case class NewServerConnected(serverRef: ActorRef) extends Event
   final case class ServerLeft(serverRef: ActorRef) extends Event

--- a/be2-scala/src/main/scala/ch/epfl/pop/decentralized/ConnectionMediator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/decentralized/ConnectionMediator.scala
@@ -1,0 +1,78 @@
+package ch.epfl.pop.decentralized
+
+import akka.actor.{Actor, ActorLogging, ActorRef, ActorSystem, Props}
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.ws.WebSocketRequest
+import akka.pattern.AskableActorRef
+
+import ch.epfl.pop.model.network.method.{Heartbeat, ParamsWithMap}
+import ch.epfl.pop.model.network.{JsonRpcRequest, MethodType}
+import ch.epfl.pop.pubsub.ClientActor.ClientAnswer
+import ch.epfl.pop.pubsub.graph.validators.RpcValidator
+import ch.epfl.pop.pubsub.{AskPatternConstants, MessageRegistry, PublishSubscribe}
+final case class ConnectionMediator(
+    monitorRef: ActorRef,
+    mediatorRef: ActorRef,
+    dbActorRef: AskableActorRef,
+    messageRegistry: MessageRegistry
+) extends Actor with ActorLogging with AskPatternConstants {
+  implicit val system: ActorSystem = ActorSystem()
+
+  // List of servers connected
+  private var serverSet: Set[ActorRef] = Set()
+
+  override def receive: Receive = {
+
+    // Connect to some servers
+    case ConnectionMediator.ConnectTo(urlList) =>
+      urlList.map(url =>
+        Http().singleWebSocketRequest(
+          WebSocketRequest(url),
+          PublishSubscribe.buildGraph(
+            mediatorRef,
+            dbActorRef,
+            messageRegistry
+          )
+        )
+      )
+
+    case ConnectionMediator.NewServerConnected(serverRef) =>
+      log.info("Received new server")
+      if (serverSet.isEmpty)
+        monitorRef ! Monitor.AtLeastOneServerConnected
+
+      serverSet += serverRef
+
+    case ConnectionMediator.ServerLeft(serverRef) =>
+      log.info("Server left")
+      serverSet -= serverRef
+      // Tell monitor to stop scheduling heartbeats since there is no one to receive them
+      if (serverSet.isEmpty)
+        sender() ! Monitor.NoServerConnected
+
+    case Heartbeat(map) =>
+      log.info("sending to some hearbeat to the clients")
+      serverSet.map(server =>
+        server ! ClientAnswer(
+          Right(JsonRpcRequest(
+            RpcValidator.JSON_RPC_VERSION,
+            MethodType.HEARTBEAT,
+            new ParamsWithMap(map),
+            None
+          ))
+        )
+      )
+  }
+}
+
+object ConnectionMediator {
+
+  def props(monitorRef: ActorRef, mediatorRef: ActorRef, dbActorRef: AskableActorRef, messageRegistry: MessageRegistry): Props =
+    Props(new ConnectionMediator(monitorRef, mediatorRef, dbActorRef, messageRegistry))
+
+  sealed trait Event
+
+  final case class ConnectTo(urlList: List[String]) extends Event
+  final case class NewServerConnected(serverRef: ActorRef) extends Event
+  final case class ServerLeft(serverRef: ActorRef) extends Event
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/decentralized/ConnectionMediatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/decentralized/ConnectionMediatorSuite.scala
@@ -1,10 +1,13 @@
 package ch.epfl.pop.decentralized
 
-import akka.actor.ActorSystem
-import akka.testkit.TestKit
+import akka.actor.{ActorRef, ActorSystem}
+import akka.testkit.{TestKit, TestProbe}
+import ch.epfl.pop.model.network.method.Heartbeat
+import ch.epfl.pop.pubsub.ClientActor.ClientActorMessage
+import ch.epfl.pop.pubsub.MessageRegistry
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.matchers.should.Matchers
 import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+import org.scalatest.matchers.should.Matchers
 
 class ConnectionMediatorSuite extends TestKit(ActorSystem("ConnectionMediatorSuiteActorSystem")) with FunSuiteLike with Matchers with BeforeAndAfterAll {
   override def afterAll(): Unit = {
@@ -12,4 +15,65 @@ class ConnectionMediatorSuite extends TestKit(ActorSystem("ConnectionMediatorSui
     TestKit.shutdownActorSystem(system)
   }
 
+  test("ConnectionMediator tells monitor if some or no server are connected") {
+    val mockMonitor = TestProbe()
+    val server = TestProbe()
+
+    val connectionMediatorRef = system.actorOf(
+      ConnectionMediator.props(mockMonitor.ref, ActorRef.noSender, ActorRef.noSender, MessageRegistry())
+    )
+
+    // Register server
+    connectionMediatorRef ! ConnectionMediator.NewServerConnected(server.ref)
+
+    mockMonitor.expectMsg(Monitor.AtLeastOneServerConnected)
+
+    // Unregister server
+    connectionMediatorRef ! ConnectionMediator.ServerLeft(server.ref)
+
+    mockMonitor.expectMsg(Monitor.NoServerConnected)
+  }
+
+  test("ConnectionMediator broadcasts heartbeat only to the expected servers") {
+
+    val mockMonitor = TestProbe()
+    val server1 = TestProbe()
+    val server2 = TestProbe()
+    val server3 = TestProbe()
+
+    val connectionMediatorRef = system.actorOf(
+      ConnectionMediator.props(mockMonitor.ref, ActorRef.noSender, ActorRef.noSender, MessageRegistry())
+    )
+
+    // Register servers
+    connectionMediatorRef ! ConnectionMediator.NewServerConnected(server1.ref)
+    connectionMediatorRef ! ConnectionMediator.NewServerConnected(server2.ref)
+    connectionMediatorRef ! ConnectionMediator.NewServerConnected(server3.ref)
+
+    // Monitor expect a single message
+    mockMonitor.expectMsg(Monitor.AtLeastOneServerConnected)
+    mockMonitor.expectNoMessage()
+
+    // Ask to broadcast Heartbeat
+    connectionMediatorRef ! new Heartbeat(Map.empty)
+
+    server1.expectMsgType[ClientActorMessage]
+    server2.expectMsgType[ClientActorMessage]
+    server3.expectMsgType[ClientActorMessage]
+
+    // Some server leaves
+    connectionMediatorRef ! ConnectionMediator.ServerLeft(server1.ref)
+    connectionMediatorRef ! ConnectionMediator.ServerLeft(server2.ref)
+
+    // Ask to broadcast Heartbeat
+    connectionMediatorRef ! new Heartbeat(Map.empty)
+
+    server1.expectNoMessage()
+    server2.expectNoMessage()
+    server3.expectMsgType[ClientActorMessage]
+
+    // Everybody leaves
+    connectionMediatorRef ! ConnectionMediator.ServerLeft(server3.ref)
+    mockMonitor.expectMsg(Monitor.NoServerConnected)
+  }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/decentralized/ConnectionMediatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/decentralized/ConnectionMediatorSuite.scala
@@ -1,0 +1,15 @@
+package ch.epfl.pop.decentralized
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuiteLike}
+
+class ConnectionMediatorSuite extends TestKit(ActorSystem("ConnectionMediatorSuiteActorSystem")) with FunSuiteLike with Matchers with BeforeAndAfterAll {
+  override def afterAll(): Unit = {
+    // Stops the test actor system
+    TestKit.shutdownActorSystem(system)
+  }
+
+}


### PR DESCRIPTION
This pr introduces ConnectionMediator, the actor tasked with initializing websocket connections and broadcasting heartbeats to all connected server. 

ClientActor themselves will send `ConnectionMediator.NewServerConnected()` to it, this behavior will be set based on the path they used to connect (see pr #1501) or if ConnectionMediator was to one to initiate the connection, same pattern for a server disconnecting.