### PR TITLE
No more Warnings from wrong processing of messages

### DIFF
--- a/fe1-web/src/__tests__/utils/TestUtils.ts
+++ b/fe1-web/src/__tests__/utils/TestUtils.ts
@@ -34,8 +34,10 @@ export const org = new PublicKey(mockPublicKey);
 
 // MOCK LAO
 export const mockLaoName = 'MyLao';
+export const mockLaoName2 = 'MySecondLao';
 export const mockLaoCreationTime = new Timestamp(1600000000);
 export const mockLaoId: Hash = Hash.fromArray(org, mockLaoCreationTime, mockLaoName);
+export const mockLaoId2: Hash = Hash.fromArray(org, mockLaoCreationTime, mockLaoName2);
 
 export const serializedMockLaoId: string = mockLaoId.valueOf();
 
@@ -74,6 +76,7 @@ export const mockKeyPairRegistry = {
 } as unknown as KeyPairRegistry;
 
 export const mockChannel: Channel = `${ROOT_CHANNEL}/${mockLaoId}`;
+export const mockChannel2: Channel = `${ROOT_CHANNEL}/${mockLaoId2}`;
 export const mockAddress = 'wss://some-address.com:8000/';
 
 export const mockJsonRequest: Partial<JsonRpcRequest> = {

--- a/fe1-web/src/core/components/QRCode.tsx
+++ b/fe1-web/src/core/components/QRCode.tsx
@@ -19,19 +19,22 @@ const styles = StyleSheet.create({
       error correction level H (https://www.qrcode.com/en/about/error_correction.html)
       assuming the qr code is a square, this means we can cover a width of 50%
       and a height of 50%. centering this gives us 25% margin on every side
+
+      The above computation might not take into account the area covered by the mouse
+      and some squares that are partially hidden by the overlay (MeKHell, 13.04.2023)
     */
     position: 'absolute',
     padding: '4',
-    top: '25%',
-    left: '25%',
-    right: '25%',
-    bottom: '25%',
+    top: '26%',
+    left: '26%',
+    right: '26%',
+    bottom: '26%',
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: Color.accent,
     overflow: 'hidden',
-    borderRadius: 1000,
+    borderRadius: 100,
   },
 });
 

--- a/fe1-web/src/features/witness/network/WitnessStoreWatcher.ts
+++ b/fe1-web/src/features/witness/network/WitnessStoreWatcher.ts
@@ -152,23 +152,20 @@ export const makeWitnessStoreWatcher = (
       return;
     }
 
+    const messagesToWitness = currentAllIds.filter(
+      (msgId) =>
+        !currentUnprocessedIds.includes(msgId) &&
+        (!previousAllIds.includes(msgId) || previousUnprocessedIds.includes(msgId)),
+    );
     // get all message ids that are part of currentAllIds
-    for (const msgId of currentAllIds) {
-      // and that are part of this lao and currently not part of unprocessedIds
-      if (!currentUnprocessedIds.includes(msgId)) {
-        // and that either have not been part of previousAllIds OR
-        // have been part of previousUnprocessedIds
-        if (!previousAllIds.includes(msgId) || previousUnprocessedIds.includes(msgId)) {
-          // i.e. all messages that have been processed
-          // since the last call of this function
-          const msg = ExtendedMessage.fromState(msgState.byId[msgId]);
-          // The message is witnessed only if it comes from the current lao
-          if (msg.laoId?.valueOf() === laoId.valueOf()) {
-            afterProcessingHandler(msg);
-          } else {
-            currentAllIds = currentAllIds.filter((id) => id !== msgId);
-          }
-        }
+
+    for (const msgId of messagesToWitness) {
+      const msg = ExtendedMessage.fromState(msgState.byId[msgId]);
+      // The message is witnessed only if it comes from the current lao
+      if (msg.laoId?.valueOf() === laoId.valueOf()) {
+        afterProcessingHandler(msg);
+      } else {
+        currentAllIds = currentAllIds.filter((id) => id !== msgId);
       }
     }
   };

--- a/fe1-web/src/features/witness/network/WitnessStoreWatcher.ts
+++ b/fe1-web/src/features/witness/network/WitnessStoreWatcher.ts
@@ -162,6 +162,7 @@ export const makeWitnessStoreWatcher = (
           // i.e. all messages that have been processed
           // since the last call of this function
           const msg = ExtendedMessage.fromState(msgState.byId[msgId]);
+          // The message is witnessed only if it comes from the current lao
           if (msg.laoId?.valueOf() === laoId.valueOf()) {
             afterProcessingHandler(msg);
           } else {


### PR DESCRIPTION
This PR mainly addresses #1451.
The problem was that the message were sent to be witnessed even if they were not from the LAO was connected in. The fix will now keep the message until the correct LAO is opened.

In addition, I fixed the scanning problem (at least what I could test on my own) : It was very hard (sometimes impossible) to scan some pop tokens during roll calls.
This is fixed by reducing the space used by the circle in the middle. The computation provided in the comment should have been sufficient, but maybe did not take into account the mouse or the square that were partially hidden...