### PR TITLE
Implementing settings and remote logging

### DIFF
--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -219,6 +219,7 @@ dependencies {
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'me.relex:circleindicator:2.1.6'
+    implementation 'com.takisoft.fix:preference-v7:27.0.0.0'
 
     // ================ Rx Java =================
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'

--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -274,9 +274,9 @@ dependencies {
     implementation "androidx.room:room-runtime:$room_version"
     annotationProcessor "androidx.room:room-compiler:$room_version"
 
-    // ================= SLF4J =================
-    testImplementation "org.slf4j:slf4j-api:$slf4j_version"
-    testImplementation "org.slf4j:slf4j-simple:$slf4j_version"
+    // ================= Log4j ====================
+    implementation 'org.apache.logging.log4j:log4j-api:2.20.0'
+    annotationProcessor 'org.apache.logging.log4j:log4j-core:2.20.0'
 
     // ================= Pretty Time =================
     implementation 'org.ocpsoft.prettytime:prettytime:5.0.4.Final'

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/di/KeysetModule.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/di/KeysetModule.java
@@ -2,7 +2,6 @@ package com.github.dedis.popstellar.di;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.util.Log;
 
 import com.google.crypto.tink.KeyTemplates;
 import com.google.crypto.tink.aead.AeadConfig;
@@ -10,6 +9,9 @@ import com.google.crypto.tink.aead.AesGcmKeyManager;
 import com.google.crypto.tink.integration.android.AndroidKeysetManager;
 import com.google.crypto.tink.signature.Ed25519PrivateKeyManager;
 import com.google.crypto.tink.signature.PublicKeySignWrapper;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.lang.annotation.Retention;
@@ -31,7 +33,7 @@ import dagger.hilt.components.SingletonComponent;
 @InstallIn(SingletonComponent.class)
 public class KeysetModule {
 
-  private static final String TAG = KeysetModule.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(KeysetModule.class);
 
   private static final String DEVICE_KEYSET_NAME = "POP_KEYSET";
   private static final String DEVICE_SHARED_PREF_FILE_NAME = "POP_KEYSET_SP";
@@ -76,7 +78,7 @@ public class KeysetModule {
 
       return future.join();
     } catch (GeneralSecurityException e) {
-      Log.e(TAG, "Could not retrieve the device keyset from the app", e);
+      logger.error("Could not retrieve the device keyset from the app", e);
       throw new SecurityException("Could not retrieve the device keyset from the app", e);
     }
   }
@@ -108,7 +110,7 @@ public class KeysetModule {
 
       return future.join();
     } catch (GeneralSecurityException e) {
-      Log.e(TAG, "Could not retrieve the wallet keyset from the app", e);
+      logger.error("Could not retrieve the wallet keyset from the app", e);
       throw new SecurityException("Could not retrieve the wallet keyset from the app", e);
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/MessageGeneral.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/MessageGeneral.java
@@ -1,14 +1,16 @@
 package com.github.dedis.popstellar.model.network.method.message;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 
 import com.github.dedis.popstellar.model.Immutable;
+import com.github.dedis.popstellar.model.network.method.Message;
 import com.github.dedis.popstellar.model.network.method.message.data.Data;
 import com.github.dedis.popstellar.model.network.method.message.data.message.WitnessMessageSignature;
 import com.github.dedis.popstellar.model.objects.security.*;
 import com.google.gson.Gson;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
@@ -22,7 +24,7 @@ import java.util.*;
 @Immutable
 public final class MessageGeneral {
 
-  private static final String TAG = MessageGeneral.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(Message.class);
 
   private final PublicKey sender;
   private final Base64URLData dataBuf;
@@ -51,7 +53,8 @@ public final class MessageGeneral {
     sender = keyPair.getPublicKey();
     this.data = data;
     String dataJson = gson.toJson(data, Data.class);
-    Log.d(TAG, dataJson);
+
+    logger.debug(dataJson);
     dataBuf = new Base64URLData(dataJson.getBytes(StandardCharsets.UTF_8));
 
     generateSignature(keyPair.getPrivateKey());
@@ -68,7 +71,7 @@ public final class MessageGeneral {
     try {
       signature = signer.sign(dataBuf);
     } catch (GeneralSecurityException e) {
-      Log.d(TAG, "failed to generate signature", e);
+      logger.debug("failed to generate signature", e);
     }
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/DataRegistry.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/DataRegistry.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.model.network.method.message.data;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -10,10 +8,15 @@ import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
 import com.github.dedis.popstellar.utility.handler.data.DataHandler;
 import com.github.dedis.popstellar.utility.handler.data.HandlerContext;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.*;
 
 /** A registry of Data classes and handlers */
 public final class DataRegistry {
+
+  private static final Logger logger = LogManager.getLogger(DataRegistry.class);
 
   /** A mapping of (object, action) -> (class, handler) */
   private final Map<EntryPair, Entry<? extends Data>> mapping;
@@ -30,7 +33,7 @@ public final class DataRegistry {
    * @return the class assigned to the pair or empty if none are defined
    */
   public Optional<Class<? extends Data>> getType(Objects obj, Action action) {
-    Log.d("data", "getting data type");
+    logger.debug("getting data type");
     return Optional.ofNullable(mapping.get(pair(obj, action))).map(Entry::getDataClass);
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonGenericMessageDeserializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonGenericMessageDeserializer.java
@@ -1,24 +1,25 @@
 package com.github.dedis.popstellar.model.network.serializer;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.network.GenericMessage;
 import com.github.dedis.popstellar.model.network.answer.Answer;
 import com.github.dedis.popstellar.model.network.method.Message;
 import com.google.gson.*;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.lang.reflect.Type;
 
 /** Json deserializer for the generic messages */
 public class JsonGenericMessageDeserializer implements JsonDeserializer<GenericMessage> {
-  public static final String TAG = JsonGenericMessageDeserializer.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(JsonGenericMessageDeserializer.class);
   private static final String METHOD = "method";
 
   @Override
   public GenericMessage deserialize(
       JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
-    Log.d(TAG, "deserializing generic message");
+    logger.debug("deserializing generic message");
     if (json.getAsJsonObject().has(METHOD)) {
       return context.deserialize(json, Message.class);
     } else {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonMessageSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonMessageSerializer.java
@@ -1,19 +1,22 @@
 package com.github.dedis.popstellar.model.network.serializer;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.network.method.*;
 import com.google.gson.*;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.lang.reflect.Type;
 
 /** Json serializer and deserializer for the low level messages */
 public class JsonMessageSerializer implements JsonSerializer<Message>, JsonDeserializer<Message> {
 
+  private static final Logger logger = LogManager.getLogger(JsonMessageSerializer.class);
+
   @Override
   public Message deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
-    Log.d("deserializer", "deserializing message");
+    logger.debug("deserializing message");
     JSONRPCRequest container = context.deserialize(json, JSONRPCRequest.class);
     JsonUtils.testRPCVersion(container.getJsonrpc());
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonUtils.java
@@ -1,12 +1,13 @@
 package com.github.dedis.popstellar.model.network.serializer;
 
-import android.util.Log;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.networknt.schema.*;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.net.URI;
 import java.util.*;
@@ -20,7 +21,7 @@ public final class JsonUtils {
 
   public static final String JSON_REQUEST_ID = "id";
 
-  private static final String TAG = JsonUtils.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(JsonUtils.class);
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final JsonSchemaFactory FACTORY =
       JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
@@ -71,7 +72,7 @@ public final class JsonUtils {
    * @throws JsonParseException if the json is invalid or cannot be parsed
    */
   public static void verifyJson(String schemaPath, String json) throws JsonParseException {
-    Log.d(TAG, "verifyJson for : " + json);
+    logger.debug("verifyJson for : " + json);
 
     JsonSchema schema = loadSchema(schemaPath);
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Wallet.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Wallet.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.model.objects;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 
 import com.github.dedis.popstellar.di.KeysetModule.WalletKeyset;
@@ -12,6 +10,8 @@ import com.github.dedis.popstellar.utility.error.keys.*;
 import com.google.crypto.tink.Aead;
 import com.google.crypto.tink.integration.android.AndroidKeysetManager;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
 
@@ -34,7 +34,7 @@ import io.github.novacrypto.bip39.wordlists.English;
 @Singleton
 public class Wallet {
 
-  private static final String TAG = Wallet.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(Wallet.class);
   private static final String PURPOSE = "888";
   private static final String ACCOUNT = "0";
   private byte[] encryptedSeed;
@@ -47,7 +47,7 @@ public class Wallet {
     try {
       aead = keysetManager.getKeysetHandle().getPrimitive(Aead.class);
     } catch (GeneralSecurityException e) {
-      Log.e(TAG, "Failed to initialize the Wallet", e);
+      logger.error("Failed to initialize the Wallet", e);
       throw new IllegalStateException("Failed to initialize the Wallet", e);
     }
   }
@@ -73,7 +73,7 @@ public class Wallet {
             convertDataToPath(laoID),
             convertDataToPath(rollCallID));
 
-    Log.d(TAG, "Generated path: " + res);
+    logger.debug("Generated path: " + res);
 
     return generateKeyFromPath(res);
   }
@@ -111,7 +111,7 @@ public class Wallet {
     }
     byte[] decryptedBytes = aead.decrypt(encryptedMnemonic, new byte[0]);
     String words = new String(decryptedBytes, StandardCharsets.UTF_8);
-    Log.d(TAG, "Mnemonic words successfully decrypted for export");
+    logger.debug("Mnemonic words successfully decrypted for export");
     return words.split(" ");
   }
 
@@ -131,7 +131,7 @@ public class Wallet {
       throw new SeedValidationException(e);
     }
     storeEncrypted(words);
-    Log.d(TAG, "Mnemonic words were successfully imported");
+    logger.debug("Mnemonic words were successfully imported");
   }
 
   /**
@@ -145,7 +145,7 @@ public class Wallet {
 
   /** Logout the wallet by replacing the seed by a random one */
   public void logout() {
-    Log.d(TAG, "Logged out of wallet");
+    logger.debug("Logged out of wallet");
     encryptedSeed = null;
     encryptedMnemonic = null;
   }
@@ -165,7 +165,7 @@ public class Wallet {
     encryptedSeed =
         aead.encrypt(
             new SeedCalculator().calculateSeed(String.join("", mnemonicWords), ""), new byte[0]);
-    Log.d(TAG, "Mnemonic words and seed successfully encrypted");
+    logger.debug("Mnemonic words and seed successfully encrypted");
   }
 
   /**

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/PublicKey.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/PublicKey.java
@@ -1,10 +1,11 @@
 package com.github.dedis.popstellar.model.objects.security;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.Immutable;
 import com.google.crypto.tink.PublicKeyVerify;
 import com.google.crypto.tink.subtle.Ed25519Verify;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.security.*;
 import java.util.Arrays;
@@ -14,7 +15,7 @@ import java.util.Base64;
 @Immutable
 public class PublicKey extends Base64URLData {
 
-  private static final String TAG = PublicKey.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(PublicKey.class);
 
   private final PublicKeyVerify verifier;
 
@@ -33,7 +34,7 @@ public class PublicKey extends Base64URLData {
       verifier.verify(signature.getData(), data.getData());
       return true;
     } catch (GeneralSecurityException e) {
-      Log.d(TAG, "failed to verify witness signature " + e.getMessage());
+      logger.error("failed to verify witness signature", e);
       return false;
     }
   }
@@ -50,7 +51,7 @@ public class PublicKey extends Base64URLData {
       byte[] hash = digest.digest(this.getData());
       return Base64.getUrlEncoder().encodeToString(Arrays.copyOf(hash, 20));
     } catch (NoSuchAlgorithmException e) {
-      Log.e(TAG, "Something is wrong by hashing the String element ");
+      logger.error("Something is wrong by hashing the String element", e);
       throw new IllegalArgumentException("Error in computing the hash in public key");
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/elGamal/ElectionPublicKey.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/elGamal/ElectionPublicKey.java
@@ -1,8 +1,9 @@
 package com.github.dedis.popstellar.model.objects.security.elGamal;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.objects.security.Base64URLData;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -15,6 +16,8 @@ import io.reactivex.annotations.NonNull;
 
 /** Represents a private key meant for El-Gam */
 public class ElectionPublicKey {
+
+  private static final Logger logger = LogManager.getLogger(ElectionPublicKey.class);
 
   // Point is generate with given public key
   private final Point publicKey;
@@ -106,8 +109,7 @@ public class ElectionPublicKey {
       output.write(C.toBytes());
       result = output.toByteArray();
     } catch (IOException e) {
-      Log.d(
-          "Encryption: ",
+      logger.debug(
           "Something happened during the encryption, could concatenate the final result into a byte array");
       result = null;
     }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/DigitalCashRepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/DigitalCashRepository.java
@@ -1,11 +1,12 @@
 package com.github.dedis.popstellar.repository;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.objects.OutputObject;
 import com.github.dedis.popstellar.model.objects.digitalcash.TransactionObject;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -21,7 +22,7 @@ import io.reactivex.subjects.Subject;
 @Singleton
 public class DigitalCashRepository {
 
-  public static final String TAG = DigitalCashRepository.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(DigitalCashRepository.class);
 
   private final Map<String, LaoTransactions> transactionsByLao = new HashMap<>();
 
@@ -45,7 +46,7 @@ public class DigitalCashRepository {
 
   public void updateTransactions(String laoId, TransactionObject transaction)
       throws NoRollCallException {
-    Log.d(TAG, "updating transactions on Lao " + laoId + " and transaction " + transaction);
+    logger.debug("updating transactions on Lao " + laoId + " and transaction " + transaction);
     getLaoTransactions(laoId).updateTransactions(transaction);
   }
 
@@ -76,7 +77,7 @@ public class DigitalCashRepository {
       transactionsSubject.values().forEach(Observer::onComplete);
       transactionsSubject.clear();
       attendees.forEach(publicKey -> hashDictionary.put(publicKey.computeHash(), publicKey));
-      Log.d(TAG, "initializing digital cash with attendees " + attendees);
+      logger.debug("initializing digital cash with attendees " + attendees);
     }
 
     public synchronized void updateTransactions(TransactionObject transaction)

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
@@ -1,10 +1,11 @@
 package com.github.dedis.popstellar.repository;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.objects.*;
 import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.*;
 
@@ -18,7 +19,7 @@ import io.reactivex.subjects.Subject;
 @Singleton
 public class LAORepository {
 
-  private static final String TAG = LAORepository.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(LAORepository.class);
 
   private final Map<String, Lao> laoById = new HashMap<>();
   private final Map<String, Subject<LaoView>> subjectById = new HashMap<>();
@@ -42,7 +43,7 @@ public class LAORepository {
    * @return the Lao corresponding to this channel
    */
   public Lao getLaoByChannel(Channel channel) {
-    Log.d(TAG, "querying lao for channel " + channel);
+    logger.debug("querying lao for channel " + channel);
     return laoById.get(channel.extractLaoId());
   }
 
@@ -69,7 +70,7 @@ public class LAORepository {
   }
 
   public synchronized void updateLao(Lao lao) {
-    Log.d(TAG, "updating Lao " + lao);
+    logger.debug("updating Lao " + lao);
     if (lao == null) {
       throw new IllegalArgumentException();
     }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/RollCallRepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/RollCallRepository.java
@@ -1,13 +1,14 @@
 package com.github.dedis.popstellar.repository;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 
 import com.github.dedis.popstellar.model.objects.RollCall;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.utility.error.UnknownRollCallException;
 import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -29,7 +30,7 @@ import static java.util.Collections.unmodifiableSet;
  */
 @Singleton
 public class RollCallRepository {
-  public static final String TAG = RollCallRepository.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(RollCallRepository.class);
   private final Map<String, LaoRollCalls> rollCallsByLao = new HashMap<>();
 
   @Inject
@@ -49,7 +50,8 @@ public class RollCallRepository {
     if (rollCall == null) {
       throw new IllegalArgumentException("Roll call is null");
     }
-    Log.d(TAG, "Updating roll call on lao " + laoId + " : " + rollCall);
+
+    logger.debug("Updating roll call on lao " + laoId + " : " + rollCall);
 
     // Retrieve Lao data and add the roll call to it
     getLaoRollCalls(laoId).update(rollCall);
@@ -150,11 +152,11 @@ public class RollCallRepository {
       // Publish new values on subjects
       if (rollCallSubjects.containsKey(persistentId)) {
         // If it exist we update the subject
-        Log.d(TAG, "Updating existing roll call " + rollCall.getName());
+        logger.debug("Updating existing roll call " + rollCall.getName());
         rollCallSubjects.get(persistentId).onNext(rollCall);
       } else {
         // If it does not, we create a new subject
-        Log.d(TAG, "New roll call, subject created for " + rollCall.getName());
+        logger.debug("New roll call, subject created for " + rollCall.getName());
         rollCallSubjects.put(persistentId, BehaviorSubject.createDefault(rollCall));
       }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/SocialMediaRepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/SocialMediaRepository.java
@@ -1,12 +1,13 @@
 package com.github.dedis.popstellar.repository;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 
 import com.github.dedis.popstellar.model.objects.Chirp;
 import com.github.dedis.popstellar.model.objects.security.MessageID;
 import com.github.dedis.popstellar.utility.error.UnknownChirpException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.*;
 
@@ -25,7 +26,7 @@ import io.reactivex.subjects.Subject;
 @Singleton
 public class SocialMediaRepository {
 
-  private static final String TAG = SocialMediaRepository.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(SocialMediaRepository.class);
 
   private final Map<String, LaoChirps> chirpsByLao = new HashMap<>();
 
@@ -43,7 +44,7 @@ public class SocialMediaRepository {
    * @param chirp to add
    */
   public void addChirp(String laoId, Chirp chirp) {
-    Log.d(TAG, "Adding new chirp on lao " + laoId + " : " + chirp);
+    logger.debug("Adding new chirp on lao " + laoId + " : " + chirp);
     // Retrieve Lao data and add the chirp to it
     getLaoChirps(laoId).add(chirp);
   }
@@ -55,7 +56,7 @@ public class SocialMediaRepository {
    * @return true if a chirp with given id existed
    */
   public boolean deleteChirp(String laoId, MessageID id) {
-    Log.d(TAG, "Deleting chirp on lao " + laoId + " with id " + id);
+    logger.debug("Deleting chirp on lao " + laoId + " with id " + id);
     return getLaoChirps(laoId).delete(id);
   }
 
@@ -100,7 +101,7 @@ public class SocialMediaRepository {
       MessageID id = chirp.getId();
       Chirp old = chirps.get(id);
       if (old != null) {
-        Log.w(TAG, "A chirp with id " + id + " already exist : " + old);
+        logger.warn("A chirp with id " + id + " already exist : " + old);
         return;
       }
 
@@ -119,7 +120,7 @@ public class SocialMediaRepository {
       }
 
       if (chirp.isDeleted()) {
-        Log.d(TAG, "The chirp with id " + id + " is already deleted");
+        logger.debug("The chirp with id " + id + " is already deleted");
       } else {
         Subject<Chirp> subject = chirpSubjects.get(id);
         if (subject == null) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/Connection.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/Connection.java
@@ -1,11 +1,12 @@
 package com.github.dedis.popstellar.repository.remote;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.network.GenericMessage;
 import com.github.dedis.popstellar.model.network.method.Message;
 import com.tinder.scarlet.*;
 import com.tinder.scarlet.WebSocket.Event.*;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import io.reactivex.Observable;
 import io.reactivex.disposables.CompositeDisposable;
@@ -14,7 +15,7 @@ import io.reactivex.subjects.BehaviorSubject;
 /** Represents a single websocket connection that can be closed */
 public class Connection {
 
-  public static final String TAG = Connection.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(Connection.class);
 
   // Create a new subject whose purpose is to dispatch incoming messages to all subscribers
   private final BehaviorSubject<GenericMessage> messagesSubject;
@@ -33,7 +34,7 @@ public class Connection {
     disposables.add(
         laoService
             .observeMessage()
-            .doOnNext(msg -> Log.d(TAG, "Received a new message from remote: " + msg))
+            .doOnNext(msg -> logger.debug("Received a new message from remote: " + msg))
             .subscribe(messagesSubject::onNext, messagesSubject::onError));
 
     // Add logs on connection state events
@@ -42,7 +43,7 @@ public class Connection {
             .observeWebsocket()
             .subscribe(
                 event -> logEvent(event, url),
-                err -> Log.d(TAG, "Error in connection " + url, err)));
+                err -> logger.debug("Error in connection " + url, err)));
   }
 
   protected Connection(Connection connection) {
@@ -56,16 +57,16 @@ public class Connection {
     String baseMsg = "Connection to " + url;
 
     if (event instanceof OnConnectionOpened) {
-      Log.i(TAG, baseMsg + " opened");
+      logger.info(baseMsg + " opened");
     } else if (event instanceof OnConnectionClosed) {
       ShutdownReason reason = ((OnConnectionClosed) event).getShutdownReason();
-      Log.i(TAG, baseMsg + " closed: " + reason);
+      logger.info(baseMsg + " closed: " + reason);
     } else if (event instanceof OnConnectionFailed) {
       Throwable error = ((OnConnectionFailed) event).getThrowable();
-      Log.d(TAG, baseMsg + " failed", error);
+      logger.debug(baseMsg + " failed", error);
     } else if (event instanceof OnConnectionClosing) {
       ShutdownReason reason = ((OnConnectionClosing) event).getShutdownReason();
-      Log.d(TAG, baseMsg + " is closing: " + reason);
+      logger.debug(baseMsg + " is closing: " + reason);
     }
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/ConnectingActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/ConnectingActivity.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.ui.home;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.widget.Button;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -20,6 +19,9 @@ import com.github.dedis.popstellar.utility.error.ErrorUtils;
 import com.github.dedis.popstellar.utility.security.KeyManager;
 import com.tinder.scarlet.WebSocket;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import javax.inject.Inject;
 
 import dagger.hilt.android.AndroidEntryPoint;
@@ -30,7 +32,7 @@ import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
 
 @AndroidEntryPoint
 public class ConnectingActivity extends AppCompatActivity {
-  public static final String TAG = ConnectingActivity.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(ConnectingActivity.class);
 
   private final CompositeDisposable disposables = new CompositeDisposable();
   private ConnectingActivityBinding binding;
@@ -85,9 +87,9 @@ public class ConnectingActivity extends AppCompatActivity {
     disposables.add(
         replay.subscribe(
             v -> {
-              Log.d(TAG, "connect message is " + v);
+              logger.debug("connect message is " + v);
               if (v instanceof WebSocket.Event.OnConnectionOpened) {
-                Log.d(TAG, "connection opened with new server address");
+                logger.debug("connection opened with new server address");
                 handleConnecting(isDestinationHome);
               } else if (v instanceof WebSocket.Event.OnConnectionFailed) {
                 startActivity(HomeActivity.newIntent(this));
@@ -95,7 +97,7 @@ public class ConnectingActivity extends AppCompatActivity {
                 finish();
               }
             },
-            e -> Log.e(TAG, "error on subscription to connection events")));
+            e -> logger.error("error on subscription to connection events")));
 
     // Now that we observe the events we let the observable know it can begin to emit events
     replay.connect();
@@ -105,7 +107,7 @@ public class ConnectingActivity extends AppCompatActivity {
   private void handleConnecting(boolean isDestinationHome) {
     if (isDestinationHome) {
       // This is when we reconnect to laos, therefore returning home
-      Log.d(TAG, "Opening Home activity");
+      logger.debug("Opening Home activity");
       startActivity(HomeActivity.newIntent(this));
       finish();
       return;
@@ -122,14 +124,14 @@ public class ConnectingActivity extends AppCompatActivity {
       String laoName = getIntent().getExtras().getString(Constants.LAO_NAME);
       CreateLao createLao = new CreateLao(laoName, keyManager.getMainPublicKey());
       Lao lao = new Lao(createLao.getId());
-      Log.d(TAG, "Creating Lao " + lao.getId());
+      logger.debug("Creating Lao " + lao.getId());
       disposables.add(
           networkManager
               .getMessageSender()
               .publish(keyManager.getMainKeyPair(), Channel.ROOT, createLao)
               .subscribe(
                   () -> {
-                    Log.d(TAG, "got success result for create lao with id " + lao.getId());
+                    logger.debug("got success result for create lao with id " + lao.getId());
                     subscribeToLao(lao); // Subscribe to the newly created Lao
                   }));
     } else { // Joining an existing lao
@@ -140,20 +142,21 @@ public class ConnectingActivity extends AppCompatActivity {
   }
 
   private void subscribeToLao(Lao lao) {
-    Log.d(TAG, "connecting to lao " + lao.getChannel());
+    logger.debug("connecting to lao " + lao.getChannel());
     disposables.add(
         networkManager
             .getMessageSender()
             .subscribe(lao.getChannel())
             .subscribe(
                 () -> {
-                  Log.d(TAG, "subscribing to LAO with id " + lao.getId());
+                  logger.debug("subscribing to LAO with id " + lao.getId());
                   startActivity(LaoActivity.newIntentForLao(this, lao.getId()));
                   finish();
                 },
                 error -> {
                   // In case of error, log it and go to home activity
-                  ErrorUtils.logAndShow(getApplication(), TAG, error, R.string.error_subscribe_lao);
+                  ErrorUtils.logAndShow(
+                      getApplication(), logger, error, R.string.error_subscribe_lao);
                   startActivity(HomeActivity.newIntent(this));
                   finish();
                 }));

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
@@ -78,6 +78,8 @@ public class HomeActivity extends AppCompatActivity {
             handleWalletSettings();
           } else if (item.getItemId() == R.id.clear_storage) {
             handleClearing();
+          } else if (item.getItemId() == R.id.home_settings) {
+            handleSettings();
           }
           return true;
         });
@@ -168,6 +170,10 @@ public class HomeActivity extends AppCompatActivity {
         .show();
   }
 
+  private void handleSettings() {
+    setCurrentFragment(getSupportFragmentManager(), R.id.fragment_settings, SettingsFragment::new);
+  }
+
   private void restoreStoredState() {
     PersistentData data = ActivityUtils.loadPersistentData(this);
     viewModel.restoreConnections(data);
@@ -175,6 +181,10 @@ public class HomeActivity extends AppCompatActivity {
 
   public static HomeViewModel obtainViewModel(FragmentActivity activity) {
     return new ViewModelProvider(activity).get(HomeViewModel.class);
+  }
+
+  public static SettingsViewModel obtainSettingsViewModel(FragmentActivity activity) {
+    return new ViewModelProvider(activity).get(SettingsViewModel.class);
   }
 
   /** Factory method to create a fresh Intent that opens an HomeActivity */

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.IdRes;
@@ -21,6 +20,9 @@ import com.github.dedis.popstellar.ui.home.wallet.SeedWalletFragment;
 import com.github.dedis.popstellar.utility.ActivityUtils;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.security.GeneralSecurityException;
 import java.util.function.Supplier;
 
@@ -30,7 +32,7 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public class HomeActivity extends AppCompatActivity {
 
-  private final String TAG = HomeActivity.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(HomeActivity.class);
 
   private HomeViewModel viewModel;
   private HomeActivityBinding binding;
@@ -147,7 +149,7 @@ public class HomeActivity extends AppCompatActivity {
       viewModel.savePersistentData();
     } catch (GeneralSecurityException e) {
       // We do not display the security error to the user
-      Log.d(TAG, "Storage was unsuccessful due to wallet error " + e);
+      logger.debug("Storage was unsuccessful due to wallet error " + e);
       Toast.makeText(this, R.string.error_storage_wallet, Toast.LENGTH_SHORT).show();
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.ui.home;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
@@ -69,15 +68,8 @@ public class HomeActivity extends AppCompatActivity {
     }
   }
 
-  @Override
-  public void onResume() {
-    super.onResume();
-  }
-
   private void handleTopAppBar() {
     viewModel.getPageTitle().observe(this, binding.topAppBar::setTitle);
-
-    Drawable overflowMenuIcon = binding.topAppBar.getOverflowIcon();
 
     // Observe whether the home icon or back arrow should be displayed
     viewModel
@@ -87,10 +79,18 @@ public class HomeActivity extends AppCompatActivity {
             isHome -> {
               if (Boolean.TRUE.equals(isHome)) {
                 binding.topAppBar.setNavigationIcon(R.drawable.home_icon);
-                binding.topAppBar.setOverflowIcon(overflowMenuIcon);
+                binding.topAppBar.getMenu().setGroupVisible(0, true);
               } else {
-                binding.topAppBar.setNavigationIcon(R.drawable.back_arrow_icon);
-                binding.topAppBar.setOverflowIcon(null);
+                Fragment fragment =
+                    getSupportFragmentManager().findFragmentById(R.id.fragment_container_home);
+                // If the fragment is not the seed wallet then make the back arrow appear
+                if (!(fragment instanceof SeedWalletFragment)) {
+                  binding.topAppBar.setNavigationIcon(R.drawable.back_arrow_icon);
+                } else {
+                  binding.topAppBar.setNavigationIcon(null);
+                }
+                // Disable the overflow menu
+                binding.topAppBar.getMenu().setGroupVisible(0, false);
               }
             });
 
@@ -100,6 +100,13 @@ public class HomeActivity extends AppCompatActivity {
           if (Boolean.FALSE.equals(viewModel.isHome().getValue())) {
             // Press back arrow
             onBackPressed();
+          } else {
+            // If the user presses on the home button display the general info about the app
+            new MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.app_name)
+                .setMessage(R.string.app_info)
+                .setPositiveButton(R.string.ok, null)
+                .show();
           }
         });
 
@@ -151,7 +158,6 @@ public class HomeActivity extends AppCompatActivity {
     if (!(fragment instanceof SeedWalletFragment)) {
       setCurrentFragment(
           getSupportFragmentManager(), R.id.fragment_home, HomeFragment::newInstance);
-      viewModel.setIsHome(true);
     }
     // Move the application to background if back button is pressed on home
     if (fragment instanceof HomeFragment) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
@@ -3,6 +3,7 @@ package com.github.dedis.popstellar.ui.home;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
@@ -68,8 +69,39 @@ public class HomeActivity extends AppCompatActivity {
     }
   }
 
+  @Override
+  public void onResume() {
+    super.onResume();
+  }
+
   private void handleTopAppBar() {
     viewModel.getPageTitle().observe(this, binding.topAppBar::setTitle);
+
+    Drawable overflowMenuIcon = binding.topAppBar.getOverflowIcon();
+
+    // Observe whether the home icon or back arrow should be displayed
+    viewModel
+        .isHome()
+        .observe(
+            this,
+            isHome -> {
+              if (Boolean.TRUE.equals(isHome)) {
+                binding.topAppBar.setNavigationIcon(R.drawable.home_icon);
+                binding.topAppBar.setOverflowIcon(overflowMenuIcon);
+              } else {
+                binding.topAppBar.setNavigationIcon(R.drawable.back_arrow_icon);
+                binding.topAppBar.setOverflowIcon(null);
+              }
+            });
+
+    // Listen to click on left icon of toolbar
+    binding.topAppBar.setNavigationOnClickListener(
+        view -> {
+          if (Boolean.FALSE.equals(viewModel.isHome().getValue())) {
+            // Press back arrow
+            onBackPressed();
+          }
+        });
 
     // Set menu items behaviour
     binding.topAppBar.setOnMenuItemClickListener(
@@ -117,7 +149,9 @@ public class HomeActivity extends AppCompatActivity {
   public void onBackPressed() {
     Fragment fragment = getSupportFragmentManager().findFragmentById(R.id.fragment_container_home);
     if (!(fragment instanceof SeedWalletFragment)) {
-      setCurrentFragment(getSupportFragmentManager(), R.id.fragment_home, HomeFragment::new);
+      setCurrentFragment(
+          getSupportFragmentManager(), R.id.fragment_home, HomeFragment::newInstance);
+      viewModel.setIsHome(true);
     }
     // Move the application to background if back button is pressed on home
     if (fragment instanceof HomeFragment) {
@@ -137,13 +171,13 @@ public class HomeActivity extends AppCompatActivity {
                 setCurrentFragment(
                     getSupportFragmentManager(),
                     R.id.fragment_seed_wallet,
-                    SeedWalletFragment::new);
+                    SeedWalletFragment::newInstance);
               })
           .setNegativeButton(R.string.cancel, (dialog, which) -> dialog.dismiss())
           .show();
     } else {
       setCurrentFragment(
-          getSupportFragmentManager(), R.id.fragment_seed_wallet, SeedWalletFragment::new);
+          getSupportFragmentManager(), R.id.fragment_seed_wallet, SeedWalletFragment::newInstance);
     }
   }
 
@@ -171,7 +205,8 @@ public class HomeActivity extends AppCompatActivity {
   }
 
   private void handleSettings() {
-    setCurrentFragment(getSupportFragmentManager(), R.id.fragment_settings, SettingsFragment::new);
+    setCurrentFragment(
+        getSupportFragmentManager(), R.id.fragment_settings, SettingsFragment::newInstance);
   }
 
   private void restoreStoredState() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.home;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 
 import androidx.annotation.NonNull;
@@ -14,13 +13,16 @@ import com.github.dedis.popstellar.databinding.HomeFragmentBinding;
 import com.github.dedis.popstellar.ui.qrcode.QrScannerFragment;
 import com.github.dedis.popstellar.ui.qrcode.ScanningAction;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import dagger.hilt.android.AndroidEntryPoint;
 
 /** Fragment used to display the Home UI */
 @AndroidEntryPoint
 public final class HomeFragment extends Fragment {
 
-  public static final String TAG = HomeFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(HomeFragment.class);
 
   private HomeFragmentBinding binding;
   private HomeViewModel viewModel;
@@ -57,14 +59,14 @@ public final class HomeFragment extends Fragment {
   private void setupButtonsActions() {
     binding.homeCreateButton.setOnClickListener(
         v -> {
-          Log.d(TAG, "Opening Create fragment");
+          logger.debug("Opening Create fragment");
           HomeActivity.setCurrentFragment(
               getParentFragmentManager(), R.id.fragment_lao_create, LaoCreateFragment::newInstance);
         });
 
     binding.homeJoinButton.setOnClickListener(
         v -> {
-          Log.d(TAG, "Opening join fragment");
+          logger.debug("Opening join fragment");
           HomeActivity.setCurrentFragment(
               getParentFragmentManager(),
               R.id.fragment_qr_scanner,
@@ -79,7 +81,7 @@ public final class HomeFragment extends Fragment {
         .observe(
             requireActivity(),
             laoIds -> {
-              Log.d(TAG, "Got a list update");
+              logger.debug("Got a list update");
               laoListAdapter.setList(laoIds);
 
               if (!laoIds.isEmpty()) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeFragment.java
@@ -51,6 +51,7 @@ public final class HomeFragment extends Fragment {
   public void onResume() {
     super.onResume();
     viewModel.setPageTitle(R.string.home_title);
+    viewModel.setIsHome(true);
   }
 
   private void setupButtonsActions() {
@@ -68,6 +69,7 @@ public final class HomeFragment extends Fragment {
               getParentFragmentManager(),
               R.id.fragment_qr_scanner,
               () -> QrScannerFragment.newInstance(ScanningAction.ADD_LAO_PARTICIPANT));
+          viewModel.setIsHome(false);
         });
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeFragment.java
@@ -39,7 +39,6 @@ public final class HomeFragment extends Fragment {
     binding = HomeFragmentBinding.inflate(inflater, container, false);
     binding.setLifecycleOwner(getActivity());
     viewModel = HomeActivity.obtainViewModel(requireActivity());
-    binding.setViewmodel(viewModel);
 
     setupListAdapter();
     setupListUpdates();

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
@@ -45,6 +45,7 @@ public class HomeViewModel extends AndroidViewModel
 
   private final LiveData<List<String>> laoIdList;
   private final MutableLiveData<Integer> mPageTitle = new MutableLiveData<>();
+  private final MutableLiveData<Boolean> isHome = new MutableLiveData<>(Boolean.TRUE);
 
   /** Dependencies for this class */
   private final Gson gson;
@@ -183,6 +184,16 @@ public class HomeViewModel extends AndroidViewModel
   @Override
   public void setPageTitle(int titleId) {
     mPageTitle.postValue(titleId);
+  }
+
+  public MutableLiveData<Boolean> isHome() {
+    return isHome;
+  }
+
+  public void setIsHome(boolean isHome) {
+    if (!Boolean.valueOf(isHome).equals(this.isHome.getValue())) {
+      this.isHome.setValue(isHome);
+    }
   }
 
   public boolean isWalletSetUp() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LAOListAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LAOListAdapter.java
@@ -2,7 +2,6 @@ package com.github.dedis.popstellar.ui.home;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.util.Log;
 import android.view.*;
 import android.widget.TextView;
 
@@ -15,11 +14,14 @@ import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.List;
 
 public class LAOListAdapter extends RecyclerView.Adapter<LAOListAdapter.LAOListItemViewHolder> {
 
-  private static final String TAG = LAOListAdapter.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(LAOListAdapter.class);
 
   private final Activity activity;
 
@@ -54,7 +56,7 @@ public class LAOListAdapter extends RecyclerView.Adapter<LAOListAdapter.LAOListI
     CardView cardView = holder.cardView;
     cardView.setOnClickListener(
         v -> {
-          Log.d(TAG, "Opening lao detail activity on the home tab for lao " + laoId);
+          logger.debug("Opening lao detail activity on the home tab for lao " + laoId);
           activity.startActivity(LaoActivity.newIntentForLao(activity, laoId));
         });
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
@@ -58,6 +58,7 @@ public final class LaoCreateFragment extends Fragment {
   public void onResume() {
     super.onResume();
     viewModel.setPageTitle(R.string.lao_create_title);
+    viewModel.setIsHome(false);
   }
 
   TextWatcher launchWatcher =

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.ui.home;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.*;
 
 import androidx.annotation.NonNull;
@@ -13,6 +12,9 @@ import androidx.fragment.app.Fragment;
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.LaoCreateFragmentBinding;
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Objects;
 
@@ -24,7 +26,7 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public final class LaoCreateFragment extends Fragment {
 
-  public static final String TAG = LaoCreateFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(LaoCreateFragment.class);
 
   @Inject GlobalNetworkManager networkManager;
 
@@ -104,7 +106,7 @@ public final class LaoCreateFragment extends Fragment {
               Objects.requireNonNull(binding.serverUrlEntryEditText.getText()).toString();
           String laoName =
               Objects.requireNonNull(binding.laoNameEntryEditText.getText()).toString();
-          Log.d(TAG, "creating lao with name " + laoName);
+          logger.debug("creating lao with name " + laoName);
 
           networkManager.connect(serverAddress);
           requireActivity()

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
@@ -1,6 +1,5 @@
 package com.github.dedis.popstellar.ui.home;
 
-import android.app.AlertDialog;
 import android.os.Bundle;
 import android.view.*;
 
@@ -8,7 +7,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.github.dedis.popstellar.R;
-import com.github.dedis.popstellar.databinding.SettingsFragmentBinding;
 import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat;
 
 import dagger.hilt.android.AndroidEntryPoint;
@@ -22,12 +20,18 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     return new SettingsFragment();
   }
 
-  private SettingsViewModel viewModel;
+  private SettingsViewModel settingsViewModel;
+  private HomeViewModel homeViewModel;
+
+  public SettingsFragment() {}
 
   @Override
   public void onCreatePreferencesFix(@Nullable Bundle savedInstanceState, String rootKey) {
     // Load the preferences from an XML resource
     setPreferencesFromResource(R.xml.settings_preferences, rootKey);
+
+    // Set callbacks for debugging section
+    setDebuggingPreferences();
   }
 
   @Override
@@ -35,39 +39,34 @@ public class SettingsFragment extends PreferenceFragmentCompat {
       @NonNull LayoutInflater inflater,
       @Nullable ViewGroup container,
       @Nullable Bundle savedInstanceState) {
-    SettingsFragmentBinding binding = SettingsFragmentBinding.inflate(inflater, container, false);
-    binding.setLifecycleOwner(getActivity());
-    viewModel = HomeActivity.obtainSettingsViewModel(requireActivity());
 
-    setDebuggingPreferences();
+    homeViewModel = HomeActivity.obtainViewModel(requireActivity());
+    settingsViewModel = HomeActivity.obtainSettingsViewModel(requireActivity());
 
-    return binding.getRoot();
+    return super.onCreateView(inflater, container, savedInstanceState);
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    homeViewModel.setPageTitle(R.string.settings);
+    homeViewModel.setIsHome(false);
   }
 
   /** Function that sets the callback for switching the preferences in the section "Debugging" */
   private void setDebuggingPreferences() {
+    // Set the callback for managing the logging
     getPreferenceManager()
         .findPreference("enable_logging")
         .setOnPreferenceChangeListener(
             ((preference, newValue) -> {
               boolean selected = (boolean) newValue;
               if (selected) {
-                final boolean[] confirmation = {false};
-                // confirmation screen
-                new AlertDialog.Builder(getContext())
-                    .setTitle(R.string.confirm_title)
-                    .setMessage(R.string.settings_enable_logging_confirmation)
-                    .setPositiveButton(R.string.yes, (dialogInterface, i) -> confirmation[0] = true)
-                    .setNegativeButton(R.string.no, null)
-                    .show();
-                if (confirmation[0]) {
-                  viewModel.enableLogging();
-                }
-                return confirmation[0];
+                settingsViewModel.enableLogging();
               } else {
-                viewModel.disableLogging();
-                return true;
+                settingsViewModel.disableLogging();
               }
+              return true;
             }));
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
@@ -14,8 +14,6 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public class SettingsFragment extends PreferenceFragmentCompat {
 
-  public static final String TAG = SettingsFragment.class.getSimpleName();
-
   public static SettingsFragment newInstance() {
     return new SettingsFragment();
   }
@@ -62,9 +60,9 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             ((preference, newValue) -> {
               boolean selected = (boolean) newValue;
               if (selected) {
-                settingsViewModel.enableLogging();
+                settingsViewModel.enableServerLogging();
               } else {
-                settingsViewModel.disableLogging();
+                settingsViewModel.disableServerLogging();
               }
               return true;
             }));

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
@@ -1,0 +1,73 @@
+package com.github.dedis.popstellar.ui.home;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.view.*;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.github.dedis.popstellar.R;
+import com.github.dedis.popstellar.databinding.SettingsFragmentBinding;
+import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat;
+
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
+public class SettingsFragment extends PreferenceFragmentCompat {
+
+  public static final String TAG = SettingsFragment.class.getSimpleName();
+
+  public static SettingsFragment newInstance() {
+    return new SettingsFragment();
+  }
+
+  private SettingsViewModel viewModel;
+
+  @Override
+  public void onCreatePreferencesFix(@Nullable Bundle savedInstanceState, String rootKey) {
+    // Load the preferences from an XML resource
+    setPreferencesFromResource(R.xml.settings_preferences, rootKey);
+  }
+
+  @Override
+  public View onCreateView(
+      @NonNull LayoutInflater inflater,
+      @Nullable ViewGroup container,
+      @Nullable Bundle savedInstanceState) {
+    SettingsFragmentBinding binding = SettingsFragmentBinding.inflate(inflater, container, false);
+    binding.setLifecycleOwner(getActivity());
+    viewModel = HomeActivity.obtainSettingsViewModel(requireActivity());
+
+    setDebuggingPreferences();
+
+    return binding.getRoot();
+  }
+
+  /** Function that sets the callback for switching the preferences in the section "Debugging" */
+  private void setDebuggingPreferences() {
+    getPreferenceManager()
+        .findPreference("enable_logging")
+        .setOnPreferenceChangeListener(
+            ((preference, newValue) -> {
+              boolean selected = (boolean) newValue;
+              if (selected) {
+                final boolean[] confirmation = {false};
+                // confirmation screen
+                new AlertDialog.Builder(getContext())
+                    .setTitle(R.string.confirm_title)
+                    .setMessage(R.string.settings_enable_logging_confirmation)
+                    .setPositiveButton(R.string.yes, (dialogInterface, i) -> confirmation[0] = true)
+                    .setNegativeButton(R.string.no, null)
+                    .show();
+                if (confirmation[0]) {
+                  viewModel.enableLogging();
+                }
+                return confirmation[0];
+              } else {
+                viewModel.disableLogging();
+                return true;
+              }
+            }));
+  }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
@@ -1,12 +1,12 @@
 package com.github.dedis.popstellar.ui.home;
 
 import android.app.Application;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
 
-import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.inject.Inject;
 
@@ -15,21 +15,20 @@ import dagger.hilt.android.lifecycle.HiltViewModel;
 @HiltViewModel
 public class SettingsViewModel extends AndroidViewModel {
 
-  public static final String TAG = SettingsViewModel.class.getSimpleName();
-
-  private final GlobalNetworkManager networkManager;
+  private static final Logger logger = LogManager.getLogger(SettingsViewModel.class);
 
   @Inject
-  public SettingsViewModel(@NonNull Application application, GlobalNetworkManager networkManager) {
+  public SettingsViewModel(@NonNull Application application) {
     super(application);
-    this.networkManager = networkManager;
   }
 
-  public void enableLogging() {
-    Log.d(TAG, "Enabling logging");
+  public void enableServerLogging() {
+    logger.info("Enabling the logging to the server");
+    System.setProperty("enableRemoteLogging", "true");
   }
 
-  public void disableLogging() {
-    Log.d(TAG, "Disabling logging");
+  public void disableServerLogging() {
+    logger.info("Disabling the logging to the server");
+    System.setProperty("enableRemoteLogging", "false");
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
@@ -1,9 +1,12 @@
 package com.github.dedis.popstellar.ui.home;
 
 import android.app.Application;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
+
+import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 
 import javax.inject.Inject;
 
@@ -14,12 +17,19 @@ public class SettingsViewModel extends AndroidViewModel {
 
   public static final String TAG = SettingsViewModel.class.getSimpleName();
 
+  private final GlobalNetworkManager networkManager;
+
   @Inject
-  public SettingsViewModel(@NonNull Application application) {
+  public SettingsViewModel(@NonNull Application application, GlobalNetworkManager networkManager) {
     super(application);
+    this.networkManager = networkManager;
   }
 
-  public void enableLogging() {}
+  public void enableLogging() {
+    Log.d(TAG, "Enabling logging");
+  }
 
-  public void disableLogging() {}
+  public void disableLogging() {
+    Log.d(TAG, "Disabling logging");
+  }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
@@ -1,0 +1,25 @@
+package com.github.dedis.popstellar.ui.home;
+
+import android.app.Application;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.AndroidViewModel;
+
+import javax.inject.Inject;
+
+import dagger.hilt.android.lifecycle.HiltViewModel;
+
+@HiltViewModel
+public class SettingsViewModel extends AndroidViewModel {
+
+  public static final String TAG = SettingsViewModel.class.getSimpleName();
+
+  @Inject
+  public SettingsViewModel(@NonNull Application application) {
+    super(application);
+  }
+
+  public void enableLogging() {}
+
+  public void disableLogging() {}
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/wallet/SeedWalletFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/wallet/SeedWalletFragment.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.ui.home.wallet;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.*;
 import android.widget.Toast;
 
@@ -19,6 +18,9 @@ import com.github.dedis.popstellar.ui.home.*;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 import com.github.dedis.popstellar.utility.error.keys.SeedValidationException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.security.GeneralSecurityException;
 import java.util.Objects;
 
@@ -30,7 +32,7 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public class SeedWalletFragment extends Fragment {
 
-  public static final String TAG = SeedWalletFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(SeedWalletFragment.class);
   private WalletSeedFragmentBinding binding;
   private HomeViewModel viewModel;
 
@@ -87,7 +89,7 @@ public class SeedWalletFragment extends Fragment {
                   HomeActivity.setCurrentFragment(
                       getParentFragmentManager(), R.id.fragment_home, HomeFragment::newInstance);
                 } catch (GeneralSecurityException | SeedValidationException e) {
-                  Log.e(TAG, "Error importing key", e);
+                  logger.error("Error importing key", e);
                   Toast.makeText(
                           requireContext().getApplicationContext(),
                           String.format(
@@ -130,7 +132,7 @@ public class SeedWalletFragment extends Fragment {
             viewModel.importSeed(
                 Objects.requireNonNull(binding.importSeedEntryEditText.getText()).toString());
           } catch (GeneralSecurityException | SeedValidationException e) {
-            ErrorUtils.logAndShow(requireContext(), TAG, e, R.string.seed_validation_exception);
+            ErrorUtils.logAndShow(requireContext(), logger, e, R.string.seed_validation_exception);
             return;
           }
           Toast.makeText(requireContext(), R.string.seed_import_success, Toast.LENGTH_SHORT).show();

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/wallet/SeedWalletFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/wallet/SeedWalletFragment.java
@@ -68,6 +68,7 @@ public class SeedWalletFragment extends Fragment {
   public void onResume() {
     super.onResume();
     viewModel.setPageTitle(R.string.wallet_setup);
+    viewModel.setIsHome(false);
   }
 
   private void setupConfirmSeedButton() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.java
@@ -21,6 +21,9 @@ import com.google.gson.Gson;
 
 import net.glxn.qrgen.android.QRCode;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import javax.inject.Inject;
 
 import dagger.hilt.android.AndroidEntryPoint;
@@ -28,7 +31,7 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public class InviteFragment extends Fragment {
 
-  private static final String TAG = InviteFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(InviteFragment.class);
 
   @Inject Gson gson;
   @Inject GlobalNetworkManager networkManager;
@@ -73,7 +76,7 @@ public class InviteFragment extends Fragment {
               role -> binding.laoPropertiesRoleText.setText(role.getStringId()));
 
     } catch (UnknownLaoException e) {
-      ErrorUtils.logAndShow(requireContext(), TAG, e, R.string.unknown_lao_exception);
+      ErrorUtils.logAndShow(requireContext(), logger, e, R.string.unknown_lao_exception);
       return null;
     }
 
@@ -89,6 +92,7 @@ public class InviteFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationCallbackToEvents(requireActivity(), getViewLifecycleOwner(), TAG);
+    LaoActivity.addBackNavigationCallbackToEvents(
+        requireActivity(), getViewLifecycleOwner(), logger);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
@@ -36,6 +36,8 @@ import com.github.dedis.popstellar.utility.Constants;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 
+import org.apache.logging.log4j.Logger;
+
 import java.security.GeneralSecurityException;
 import java.util.*;
 import java.util.function.Supplier;
@@ -370,11 +372,11 @@ public class LaoActivity extends AppCompatActivity {
 
   /** Adds a specific callback for the back button that opens the events tab */
   public static void addBackNavigationCallbackToEvents(
-      FragmentActivity activity, LifecycleOwner lifecycleOwner, String tag) {
+      FragmentActivity activity, LifecycleOwner lifecycleOwner, Logger logger) {
     addBackNavigationCallback(
         activity,
         lifecycleOwner,
         ActivityUtils.buildBackButtonCallback(
-            tag, "event list", ((LaoActivity) activity)::setEventsTab));
+            logger, "event list", ((LaoActivity) activity)::setEventsTab));
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.ui.lao;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -36,6 +35,7 @@ import com.github.dedis.popstellar.utility.Constants;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.security.GeneralSecurityException;
@@ -46,7 +46,7 @@ import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
 public class LaoActivity extends AppCompatActivity {
-  public static final String TAG = LaoActivity.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(LaoActivity.class);
 
   LaoViewModel laoViewModel;
   LaoActivityBinding binding;
@@ -90,7 +90,7 @@ public class LaoActivity extends AppCompatActivity {
       laoViewModel.savePersistentData();
     } catch (GeneralSecurityException e) {
       // We do not display the security error to the user
-      Log.d(TAG, "Storage was unsuccessful du to wallet error " + e);
+      logger.debug("Storage was unsuccessful du to wallet error " + e);
       Toast.makeText(this, R.string.error_storage_wallet, Toast.LENGTH_SHORT).show();
     }
   }
@@ -178,13 +178,13 @@ public class LaoActivity extends AppCompatActivity {
     binding.laoNavigationDrawer.setNavigationItemSelectedListener(
         item -> {
           MainMenuTab tab = MainMenuTab.findByMenu(item.getItemId());
-          Log.i(TAG, "Opening tab : " + tab.getName());
+          logger.info("Opening tab : " + tab.getName());
           boolean selected = openTab(tab);
           if (selected) {
-            Log.d(TAG, "The tab was successfully opened");
+            logger.debug("The tab was successfully opened");
             laoViewModel.setCurrentTab(tab);
           } else {
-            Log.d(TAG, "The tab wasn't opened");
+            logger.debug("The tab wasn't opened");
           }
           binding.laoDrawerLayout.close();
           return selected;
@@ -200,7 +200,7 @@ public class LaoActivity extends AppCompatActivity {
               .findViewById(R.id.drawer_header_lao_title);
       laoNameView.setText(laoViewModel.getLao().getName());
     } catch (UnknownLaoException e) {
-      ErrorUtils.logAndShow(this, TAG, e, R.string.unknown_lao_exception);
+      ErrorUtils.logAndShow(this, logger, e, R.string.unknown_lao_exception);
       startActivity(HomeActivity.newIntent(this));
     }
   }
@@ -238,7 +238,7 @@ public class LaoActivity extends AppCompatActivity {
         startActivity(HomeActivity.newIntent(this));
         return true;
       default:
-        Log.w(TAG, "Unhandled tab type : " + tab);
+        logger.warn("Unhandled tab type : " + tab);
         return false;
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoViewModel.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao;
 
 import android.app.Application;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
@@ -24,6 +23,9 @@ import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 import com.github.dedis.popstellar.utility.error.keys.*;
 import com.github.dedis.popstellar.utility.security.KeyManager;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.security.GeneralSecurityException;
 
 import javax.inject.Inject;
@@ -35,7 +37,7 @@ import io.reactivex.disposables.Disposable;
 
 @HiltViewModel
 public class LaoViewModel extends AndroidViewModel implements PopViewModel {
-  public static final String TAG = LaoViewModel.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(LaoViewModel.class);
 
   private final MutableLiveData<MainMenuTab> currentTab = new MutableLiveData<>();
 
@@ -213,14 +215,14 @@ public class LaoViewModel extends AndroidViewModel implements PopViewModel {
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(
                 laoView -> {
-                  Log.d(TAG, "got an update for lao: " + laoView);
+                  logger.debug("got an update for lao: " + laoView);
 
                   setIsOrganizer(laoView.getOrganizer().equals(keyManager.getMainPublicKey()));
                   setIsWitness(laoView.getWitnesses().contains(keyManager.getMainPublicKey()));
 
                   updateRole();
                 },
-                error -> Log.d(TAG, "error updating LAO :" + error)));
+                error -> logger.debug("error updating LAO :" + error)));
   }
 
   protected void observeRollCalls(String laoId) {
@@ -245,7 +247,7 @@ public class LaoViewModel extends AndroidViewModel implements PopViewModel {
                 },
                 error ->
                     ErrorUtils.logAndShow(
-                        getApplication(), TAG, error, R.string.unknown_roll_call_exception)));
+                        getApplication(), logger, error, R.string.unknown_roll_call_exception)));
   }
 
   private boolean isRollCallAttended(RollCall rollcall, String laoId) {
@@ -253,7 +255,7 @@ public class LaoViewModel extends AndroidViewModel implements PopViewModel {
       PublicKey pk = wallet.generatePoPToken(laoId, rollcall.getPersistentId()).getPublicKey();
       return rollcall.isClosed() && rollcall.getAttendees().contains(pk);
     } catch (KeyGenerationException | UninitializedWalletException e) {
-      Log.e(TAG, "failed to retrieve public key from wallet", e);
+      logger.error("failed to retrieve public key from wallet", e);
       return false;
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHistoryFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHistoryFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.digitalcash;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 
 import androidx.fragment.app.Fragment;
@@ -12,10 +11,13 @@ import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.ActivityUtils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import io.reactivex.android.schedulers.AndroidSchedulers;
 
 public class DigitalCashHistoryFragment extends Fragment {
-  private static final String TAG = DigitalCashHistoryFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(DigitalCashHistoryFragment.class);
 
   private LaoViewModel laoViewModel;
 
@@ -49,7 +51,7 @@ public class DigitalCashHistoryFragment extends Fragment {
             .getTransactionsObservable()
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(
-                adapter::setList, error -> Log.d(TAG, "error with history update " + error)));
+                adapter::setList, error -> logger.debug("error with history update " + error)));
 
     handleBackNav();
     return view;
@@ -67,6 +69,6 @@ public class DigitalCashHistoryFragment extends Fragment {
         requireActivity(),
         getViewLifecycleOwner(),
         ActivityUtils.buildBackButtonCallback(
-            TAG, "last fragment", ((LaoActivity) requireActivity())::resetLastFragment));
+            logger, "last fragment", ((LaoActivity) requireActivity())::resetLastFragment));
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHomeFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHomeFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.digitalcash;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 
 import androidx.annotation.NonNull;
@@ -15,6 +14,9 @@ import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import io.reactivex.android.schedulers.AndroidSchedulers;
 
 /**
@@ -22,6 +24,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
  * method to create an instance of this fragment.
  */
 public class DigitalCashHomeFragment extends Fragment {
+
   private DigitalCashHomeFragmentBinding binding;
   private LaoViewModel laoViewModel;
   private DigitalCashViewModel digitalCashViewModel;
@@ -38,7 +41,7 @@ public class DigitalCashHomeFragment extends Fragment {
     return new DigitalCashHomeFragment();
   }
 
-  public static final String TAG = DigitalCashHomeFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(DigitalCashHomeFragment.class);
 
   @Override
   public View onCreateView(
@@ -71,13 +74,13 @@ public class DigitalCashHomeFragment extends Fragment {
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(
                 transactions -> {
-                  Log.d(TAG, "updating transactions " + transactions);
+                  logger.debug("updating transactions " + transactions);
                   long totalAmount = digitalCashViewModel.getOwnBalance();
                   binding.coinAmountText.setText(String.valueOf(totalAmount));
                 },
                 error ->
                     ErrorUtils.logAndShow(
-                        requireContext(), TAG, error, R.string.error_retrieve_own_token)));
+                        requireContext(), logger, error, R.string.error_retrieve_own_token)));
   }
 
   private void setupReceiveButton() {
@@ -130,6 +133,7 @@ public class DigitalCashHomeFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationCallbackToEvents(requireActivity(), getViewLifecycleOwner(), TAG);
+    LaoActivity.addBackNavigationCallbackToEvents(
+        requireActivity(), getViewLifecycleOwner(), logger);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashIssueFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashIssueFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.digitalcash;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 import android.widget.ArrayAdapter;
 import android.widget.Toast;
@@ -21,6 +20,9 @@ import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 import com.github.dedis.popstellar.utility.error.keys.KeyException;
 import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.security.GeneralSecurityException;
 import java.time.Instant;
 import java.util.*;
@@ -34,7 +36,7 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public class DigitalCashIssueFragment extends Fragment {
 
-  public static final String TAG = DigitalCashIssueFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(DigitalCashIssueFragment.class);
 
   private DigitalCashIssueFragmentBinding binding;
   private LaoViewModel laoViewModel;
@@ -102,9 +104,9 @@ public class DigitalCashIssueFragment extends Fragment {
           postTransaction(issueMap);
         }
       } catch (NoRollCallException r) {
-        ErrorUtils.logAndShow(requireContext(), TAG, r, R.string.no_rollcall_exception);
+        ErrorUtils.logAndShow(requireContext(), logger, r, R.string.no_rollcall_exception);
       } catch (UnknownLaoException e) {
-        ErrorUtils.logAndShow(requireContext(), TAG, e, R.string.unknown_lao_exception);
+        ErrorUtils.logAndShow(requireContext(), logger, e, R.string.unknown_lao_exception);
       }
     }
   }
@@ -165,7 +167,7 @@ public class DigitalCashIssueFragment extends Fragment {
     try {
       myArray = digitalCashViewModel.getAttendeesFromTheRollCallList();
     } catch (NoRollCallException e) {
-      Log.d(TAG, getString(R.string.error_no_rollcall_closed_in_LAO));
+      logger.debug(getString(R.string.error_no_rollcall_closed_in_LAO));
       Toast.makeText(
               requireContext(),
               getString(R.string.digital_cash_please_enter_roll_call),
@@ -207,10 +209,10 @@ public class DigitalCashIssueFragment extends Fragment {
                 error -> {
                   if (error instanceof KeyException || error instanceof GeneralSecurityException) {
                     ErrorUtils.logAndShow(
-                        requireContext(), TAG, error, R.string.error_retrieve_own_token);
+                        requireContext(), logger, error, R.string.error_retrieve_own_token);
                   } else {
                     ErrorUtils.logAndShow(
-                        requireContext(), TAG, error, R.string.error_post_transaction);
+                        requireContext(), logger, error, R.string.error_post_transaction);
                   }
                 }));
   }
@@ -221,7 +223,7 @@ public class DigitalCashIssueFragment extends Fragment {
         .addCallback(
             getViewLifecycleOwner(),
             ActivityUtils.buildBackButtonCallback(
-                TAG,
+                logger,
                 "digital cash home",
                 () ->
                     LaoActivity.setCurrentFragment(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashReceiptFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashReceiptFragment.java
@@ -13,12 +13,15 @@ import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.ActivityUtils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 /**
  * A simple {@link Fragment} subclass. Use the {@link DigitalCashReceiptFragment} factory method to
  * create an instance of this fragment.
  */
 public class DigitalCashReceiptFragment extends Fragment {
-  public static final String TAG = DigitalCashReceiptFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(DigitalCashReceiptFragment.class);
   private DigitalCashReceiptFragmentBinding binding;
   private LaoViewModel laoViewModel;
   private DigitalCashViewModel digitalCashViewModel;
@@ -85,7 +88,7 @@ public class DigitalCashReceiptFragment extends Fragment {
         requireActivity(),
         getViewLifecycleOwner(),
         ActivityUtils.buildBackButtonCallback(
-            TAG,
+            logger,
             "digital cash home",
             () -> DigitalCashHomeFragment.openFragment(getParentFragmentManager())));
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashReceiveFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashReceiveFragment.java
@@ -21,6 +21,9 @@ import com.google.gson.Gson;
 
 import net.glxn.qrgen.android.QRCode;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import javax.inject.Inject;
 
 import dagger.hilt.android.AndroidEntryPoint;
@@ -32,8 +35,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
  */
 @AndroidEntryPoint
 public class DigitalCashReceiveFragment extends Fragment {
-  public static final String TAG = DigitalCashReceiveFragment.class.getSimpleName();
-
+  private static final Logger logger = LogManager.getLogger(DigitalCashReceiveFragment.class);
   @Inject Gson gson;
 
   private DigitalCashReceiveFragmentBinding binding;
@@ -88,7 +90,7 @@ public class DigitalCashReceiveFragment extends Fragment {
                 },
                 error ->
                     ErrorUtils.logAndShow(
-                        requireContext(), TAG, error, R.string.error_retrieve_own_token)));
+                        requireContext(), logger, error, R.string.error_retrieve_own_token)));
   }
 
   @Override
@@ -104,7 +106,7 @@ public class DigitalCashReceiveFragment extends Fragment {
         .addCallback(
             getViewLifecycleOwner(),
             ActivityUtils.buildBackButtonCallback(
-                TAG,
+                logger,
                 "digital cash home",
                 () ->
                     LaoActivity.setCurrentFragment(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashSendFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashSendFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.digitalcash;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 import android.widget.ArrayAdapter;
 import android.widget.Toast;
@@ -21,6 +20,9 @@ import com.github.dedis.popstellar.utility.error.ErrorUtils;
 import com.github.dedis.popstellar.utility.error.keys.KeyException;
 import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.security.GeneralSecurityException;
 import java.time.Instant;
 import java.util.*;
@@ -32,7 +34,7 @@ import io.reactivex.Completable;
  * method to create an instance of this fragment.
  */
 public class DigitalCashSendFragment extends Fragment {
-  private static final String TAG = DigitalCashSendFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(DigitalCashSendFragment.class);
   private DigitalCashSendFragmentBinding binding;
   private LaoViewModel laoViewModel;
   private DigitalCashViewModel digitalCashViewModel;
@@ -98,13 +100,13 @@ public class DigitalCashSendFragment extends Fragment {
                                         R.id.fragment_digital_cash_receipt,
                                         DigitalCashReceiptFragment::newInstance);
                                   },
-                                  error -> Log.d(TAG, "error posting transaction", error)));
+                                  error -> logger.debug("error posting transaction", error)));
                     }
 
                   } catch (KeyException keyException) {
                     ErrorUtils.logAndShow(
                         requireContext(),
-                        TAG,
+                        logger,
                         keyException,
                         R.string.digital_cash_please_enter_a_lao);
                   }
@@ -115,7 +117,7 @@ public class DigitalCashSendFragment extends Fragment {
     try {
       setUpTheAdapter();
     } catch (KeyException e) {
-      ErrorUtils.logAndShow(requireContext(), TAG, e, R.string.digital_cash_error_poptoken);
+      ErrorUtils.logAndShow(requireContext(), logger, e, R.string.digital_cash_error_poptoken);
     }
   }
 
@@ -129,7 +131,7 @@ public class DigitalCashSendFragment extends Fragment {
   public boolean canPostTransaction(PublicKey publicKey, int amount) {
     long currentBalance = digitalCashViewModel.getUserBalance(publicKey);
     if (currentBalance < amount) {
-      Log.d(TAG, "Current Balance: " + currentBalance + " amount: " + amount);
+      logger.debug("Current Balance: " + currentBalance + " amount: " + amount);
       Toast.makeText(
               requireContext(), R.string.digital_cash_warning_not_enough_money, Toast.LENGTH_SHORT)
           .show();
@@ -178,7 +180,7 @@ public class DigitalCashSendFragment extends Fragment {
     try {
       members.remove(digitalCashViewModel.getValidToken().getPublicKey().getEncoded());
     } catch (KeyException e) {
-      Log.e(TAG, getResources().getString(R.string.error_retrieve_own_token));
+      logger.error(getResources().getString(R.string.error_retrieve_own_token));
     }
   }
 
@@ -208,10 +210,10 @@ public class DigitalCashSendFragment extends Fragment {
             error -> {
               if (error instanceof KeyException || error instanceof GeneralSecurityException) {
                 ErrorUtils.logAndShow(
-                    requireContext(), TAG, error, R.string.error_retrieve_own_token);
+                    requireContext(), logger, error, R.string.error_retrieve_own_token);
               } else {
                 ErrorUtils.logAndShow(
-                    requireContext(), TAG, error, R.string.error_post_transaction);
+                    requireContext(), logger, error, R.string.error_post_transaction);
               }
             });
   }
@@ -222,7 +224,7 @@ public class DigitalCashSendFragment extends Fragment {
         .addCallback(
             getViewLifecycleOwner(),
             ActivityUtils.buildBackButtonCallback(
-                TAG,
+                logger,
                 "digital cash home",
                 () ->
                     LaoActivity.setCurrentFragment(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashViewModel.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.digitalcash;
 
 import android.app.Application;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -26,6 +25,9 @@ import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
 import com.github.dedis.popstellar.utility.security.KeyManager;
 import com.google.gson.Gson;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.*;
@@ -40,7 +42,7 @@ import io.reactivex.*;
 @HiltViewModel
 public class DigitalCashViewModel extends AndroidViewModel {
 
-  public static final String TAG = DigitalCashViewModel.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(DigitalCashViewModel.class);
 
   private String laoId;
   private static final String LAO_FAILURE_MESSAGE = "failed to retrieve lao";
@@ -157,7 +159,7 @@ public class DigitalCashViewModel extends AndroidViewModel {
       outputs.add(addOutput);
       return amount;
     } catch (Exception e) {
-      Log.e(TAG, RECEIVER_KEY_ERROR, e);
+      logger.error(RECEIVER_KEY_ERROR, e);
       return 0;
     }
   }
@@ -177,7 +179,7 @@ public class DigitalCashViewModel extends AndroidViewModel {
     try {
       laoView = getLao();
     } catch (UnknownLaoException e) {
-      Log.e(TAG, LAO_FAILURE_MESSAGE);
+      logger.error(LAO_FAILURE_MESSAGE);
       return Completable.error(new UnknownLaoException());
     }
 
@@ -193,7 +195,8 @@ public class DigitalCashViewModel extends AndroidViewModel {
                   .getMessageSender()
                   .publish(channel, msg)
                   .doOnComplete(
-                      () -> Log.d(TAG, "Successfully sent post transaction message : " + postTxn));
+                      () ->
+                          logger.debug("Successfully sent post transaction message : " + postTxn));
             });
   }
 
@@ -292,14 +295,14 @@ public class DigitalCashViewModel extends AndroidViewModel {
       // Overflow in the amount (no characters or negative numbers can be inserted)
       ErrorUtils.logAndShow(
           getApplication().getApplicationContext(),
-          TAG,
+          logger,
           R.string.digital_cash_amount_inserted_error);
       return false;
     }
     if (parsedAmount <= MIN_LAO_COIN) {
       ErrorUtils.logAndShow(
           getApplication().getApplicationContext(),
-          TAG,
+          logger,
           R.string.digital_cash_amount_min_indication);
       return false;
     } else if (currentPublicKeySelected.isEmpty() && (radioGroup == NOTHING_SELECTED)) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/HistoryListAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/HistoryListAdapter.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.digitalcash;
 
 import android.annotation.SuppressLint;
-import android.util.Log;
 import android.view.*;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -18,11 +17,14 @@ import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 import com.github.dedis.popstellar.utility.error.keys.KeyException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
 public class HistoryListAdapter extends RecyclerView.Adapter<HistoryListAdapter.HistoryViewHolder> {
-  private static final String TAG = HistoryListAdapter.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(HistoryListAdapter.class);
   private List<TransactionHistoryElement> transactions = new ArrayList<>();
   private final Map<String, Boolean> expandMap = new HashMap<>();
   private final DigitalCashViewModel viewModel;
@@ -46,7 +48,7 @@ public class HistoryListAdapter extends RecyclerView.Adapter<HistoryListAdapter.
   public void onBindViewHolder(@NonNull HistoryViewHolder holder, int position) {
     TransactionHistoryElement element = transactions.get(position);
     if (element == null) {
-      Log.d(TAG, "element is null");
+      logger.debug("element is null");
       return;
     }
     String transactionId = element.getId();
@@ -68,7 +70,7 @@ public class HistoryListAdapter extends RecyclerView.Adapter<HistoryListAdapter.
 
     View.OnClickListener listener =
         v -> {
-          Log.d(TAG, "transaction is " + transactionId + " position is " + position);
+          logger.debug("transaction is " + transactionId + " position is " + position);
           boolean expandStatus = expandMap.get(transactionId);
           expandMap.put(transactionId, !expandStatus);
           notifyItemChanged(position);
@@ -97,7 +99,7 @@ public class HistoryListAdapter extends RecyclerView.Adapter<HistoryListAdapter.
     try {
       ownKey = viewModel.getValidToken().getPublicKey();
     } catch (KeyException e) {
-      ErrorUtils.logAndShow(activity, TAG, e, R.string.error_retrieve_own_token);
+      ErrorUtils.logAndShow(activity, logger, e, R.string.error_retrieve_own_token);
       return new ArrayList<>();
     }
     for (TransactionObject transactionObject : transactionObjects) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/UpcomingEventsFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/UpcomingEventsFragment.java
@@ -14,9 +14,12 @@ import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.ui.lao.event.eventlist.UpcomingEventsAdapter;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public class UpcomingEventsFragment extends Fragment {
 
-  private static final String TAG = UpcomingEventsFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(UpcomingEventsFragment.class);
   private LaoViewModel laoViewModel;
 
   public static UpcomingEventsFragment newInstance() {
@@ -39,7 +42,7 @@ public class UpcomingEventsFragment extends Fragment {
     binding.upcomingEventsRecyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
     binding.upcomingEventsRecyclerView.setAdapter(
         new UpcomingEventsAdapter(
-            eventsViewModel.getEvents(), laoViewModel, requireActivity(), TAG));
+            eventsViewModel.getEvents(), laoViewModel, requireActivity(), logger));
 
     handleBackNav();
     return binding.getRoot();
@@ -53,6 +56,7 @@ public class UpcomingEventsFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationCallbackToEvents(requireActivity(), getViewLifecycleOwner(), TAG);
+    LaoActivity.addBackNavigationCallbackToEvents(
+        requireActivity(), getViewLifecycleOwner(), logger);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/consensus/ConsensusViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/consensus/ConsensusViewModel.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.event.consensus;
 
 import android.app.Application;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
@@ -20,6 +19,9 @@ import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 import com.github.dedis.popstellar.utility.security.KeyManager;
 import com.google.gson.Gson;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.List;
 
 import javax.inject.Inject;
@@ -29,7 +31,7 @@ import io.reactivex.*;
 
 @HiltViewModel
 public class ConsensusViewModel extends AndroidViewModel {
-  private static final String TAG = ConsensusViewModel.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(ConsensusViewModel.class);
 
   private String laoId;
 
@@ -66,8 +68,7 @@ public class ConsensusViewModel extends AndroidViewModel {
    */
   public Single<MessageGeneral> sendConsensusElect(
       long creation, String objId, String type, String property, Object value) {
-    Log.d(
-        TAG,
+    logger.debug(
         String.format(
             "creating a new consensus for type: %s, property: %s, value: %s",
             type, property, value));
@@ -76,7 +77,7 @@ public class ConsensusViewModel extends AndroidViewModel {
     try {
       laoView = getLao();
     } catch (UnknownLaoException e) {
-      ErrorUtils.logAndShow(getApplication(), TAG, e, R.string.unknown_lao_exception);
+      ErrorUtils.logAndShow(getApplication(), logger, e, R.string.unknown_lao_exception);
       return Single.error(new UnknownLaoException());
     }
 
@@ -98,8 +99,7 @@ public class ConsensusViewModel extends AndroidViewModel {
    */
   public Completable sendConsensusElectAccept(ElectInstance electInstance, boolean accept) {
     MessageID messageId = electInstance.getMessageId();
-    Log.d(
-        TAG,
+    logger.debug(
         "sending a new elect_accept for consensus with messageId : "
             + messageId
             + " with value "

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/consensus/ElectionStartFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/consensus/ElectionStartFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.event.consensus;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 import android.widget.GridView;
 
@@ -17,6 +16,9 @@ import com.github.dedis.popstellar.repository.ElectionRepository;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.error.*;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -38,7 +40,7 @@ import static io.reactivex.android.schedulers.AndroidSchedulers.mainThread;
 @AndroidEntryPoint
 public class ElectionStartFragment extends Fragment {
 
-  private static final String TAG = ElectionStartFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(ElectionStartFragment.class);
   private static final String ELECTION_ID = "election_id";
 
   public static final String CONSENSUS_TYPE = "election";
@@ -98,7 +100,7 @@ public class ElectionStartFragment extends Fragment {
       subscribeTo(election, this::updateElection);
       subscribeTo(merged, this::updateNodesAndElection);
     } catch (UnknownElectionException | UnknownLaoException e) {
-      ErrorUtils.logAndShow(requireContext(), TAG, e, R.string.generic_error);
+      ErrorUtils.logAndShow(requireContext(), logger, e, R.string.generic_error);
       return null;
     }
 
@@ -110,7 +112,7 @@ public class ElectionStartFragment extends Fragment {
 
       if (ownNode == null) {
         // Only possible if the user wasn't an acceptor, but shouldn't have access to this fragment
-        Log.e(TAG, "Couldn't find the Node with public key : " + laoViewModel.getPublicKey());
+        logger.error("Couldn't find the Node with public key : " + laoViewModel.getPublicKey());
         throw new IllegalStateException(
             "Only acceptors are allowed to access ElectionStartFragment");
       }
@@ -123,7 +125,7 @@ public class ElectionStartFragment extends Fragment {
       GridView gridView = binding.nodesGrid;
       gridView.setAdapter(adapter);
     } catch (UnknownLaoException e) {
-      ErrorUtils.logAndShow(requireContext(), TAG, R.string.error_no_lao);
+      ErrorUtils.logAndShow(requireContext(), logger, R.string.error_no_lao);
       return null;
     }
 
@@ -136,7 +138,7 @@ public class ElectionStartFragment extends Fragment {
     disposables.add(
         observable.subscribe(
             onNext,
-            err -> ErrorUtils.logAndShow(requireContext(), TAG, err, R.string.generic_error)));
+            err -> ErrorUtils.logAndShow(requireContext(), logger, err, R.string.generic_error)));
   }
 
   private void updateNodes(List<ConsensusNode> nodes) {
@@ -195,7 +197,7 @@ public class ElectionStartFragment extends Fragment {
                         msg -> {},
                         error ->
                             ErrorUtils.logAndShow(
-                                requireContext(), TAG, error, R.string.error_start_election))));
+                                requireContext(), logger, error, R.string.error_start_election))));
   }
 
   private void updateStartAndStatus(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/consensus/NodesAcceptorAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/consensus/NodesAcceptorAdapter.java
@@ -14,11 +14,14 @@ import com.github.dedis.popstellar.model.objects.ElectInstance.State;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.*;
 
 public class NodesAcceptorAdapter extends BaseAdapter {
 
-  private static final String TAG = NodesAcceptorAdapter.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(NodesAcceptorAdapter.class);
   private List<ConsensusNode> nodes = new ArrayList<>();
   private final ConsensusNode ownNode;
   private final String instanceId;
@@ -112,7 +115,7 @@ public class NodesAcceptorAdapter extends BaseAdapter {
                                 error ->
                                     ErrorUtils.logAndShow(
                                         parent.getContext(),
-                                        TAG,
+                                        logger,
                                         error,
                                         R.string.error_consensus_accept)))));
     binding.setLifecycleOwner(lifecycleOwner);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/ElectionViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/ElectionViewModel.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.ui.lao.event.election;
 import android.app.Application;
 import android.os.Handler;
 import android.os.Looper;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -21,6 +20,9 @@ import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.error.keys.KeyException;
 import com.github.dedis.popstellar.utility.security.KeyManager;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
@@ -33,7 +35,7 @@ import io.reactivex.Single;
 
 @HiltViewModel
 public class ElectionViewModel extends AndroidViewModel {
-  public static final String TAG = ElectionViewModel.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(ElectionViewModel.class);
 
   private String laoId;
 
@@ -80,13 +82,13 @@ public class ElectionViewModel extends AndroidViewModel {
       long start,
       long end,
       List<ElectionQuestion.Question> questions) {
-    Log.d(TAG, "creating a new election with name " + name);
+    logger.debug("creating a new election with name " + name);
 
     LaoView laoView;
     try {
       laoView = getLao();
     } catch (UnknownLaoException e) {
-      ErrorUtils.logAndShow(getApplication(), TAG, e, R.string.unknown_lao_exception);
+      ErrorUtils.logAndShow(getApplication(), logger, e, R.string.unknown_lao_exception);
       return Completable.error(new UnknownLaoException());
     }
 
@@ -114,12 +116,12 @@ public class ElectionViewModel extends AndroidViewModel {
    * @param election election to be opened
    */
   public Completable openElection(Election election) {
-    Log.d(TAG, "opening election with name : " + election.getName());
+    logger.debug("opening election with name : " + election.getName());
     LaoView laoView;
     try {
       laoView = getLao();
     } catch (UnknownLaoException e) {
-      ErrorUtils.logAndShow(getApplication(), TAG, e, R.string.unknown_lao_exception);
+      ErrorUtils.logAndShow(getApplication(), logger, e, R.string.unknown_lao_exception);
       return Completable.error(new UnknownLaoException());
     }
 
@@ -136,12 +138,12 @@ public class ElectionViewModel extends AndroidViewModel {
   }
 
   public Completable endElection(Election election) {
-    Log.d(TAG, "ending election with name : " + election.getName());
+    logger.debug("ending election with name : " + election.getName());
     LaoView laoView;
     try {
       laoView = getLao();
     } catch (UnknownLaoException e) {
-      ErrorUtils.logAndShow(getApplication(), TAG, e, R.string.unknown_lao_exception);
+      ErrorUtils.logAndShow(getApplication(), logger, e, R.string.unknown_lao_exception);
       return Completable.error(new UnknownLaoException());
     }
 
@@ -167,12 +169,11 @@ public class ElectionViewModel extends AndroidViewModel {
     try {
       election = electionRepo.getElection(laoId, electionId);
     } catch (UnknownElectionException e) {
-      Log.d(TAG, "failed to retrieve current election");
+      logger.debug("failed to retrieve current election");
       return Completable.error(e);
     }
 
-    Log.d(
-        TAG,
+    logger.debug(
         "sending a new vote in election : "
             + election
             + " with election start time"
@@ -182,13 +183,13 @@ public class ElectionViewModel extends AndroidViewModel {
     try {
       laoView = getLao();
     } catch (UnknownLaoException e) {
-      ErrorUtils.logAndShow(getApplication(), TAG, e, R.string.unknown_lao_exception);
+      ErrorUtils.logAndShow(getApplication(), logger, e, R.string.unknown_lao_exception);
       return Completable.error(new UnknownLaoException());
     }
 
     return Single.fromCallable(
             () -> keyManager.getValidPoPToken(laoId, rollCallRepo.getLastClosedRollCall(laoId)))
-        .doOnSuccess(token -> Log.d(TAG, "Retrieved PoP Token to send votes : " + token))
+        .doOnSuccess(token -> logger.debug("Retrieved PoP Token to send votes : " + token))
         .flatMapCompletable(
             token -> {
               CompletableFuture<CastVote> vote = createCastVote(votes, election, laoView);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/adapters/ElectionResultPagerAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/adapters/ElectionResultPagerAdapter.java
@@ -13,8 +13,10 @@ import com.github.dedis.popstellar.model.network.method.message.data.election.El
 import com.github.dedis.popstellar.model.network.method.message.data.election.QuestionResult;
 import com.github.dedis.popstellar.repository.ElectionRepository;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
-import com.github.dedis.popstellar.ui.lao.event.election.fragments.ElectionResultFragment;
 import com.github.dedis.popstellar.utility.error.UnknownElectionException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -26,7 +28,7 @@ import static com.github.dedis.popstellar.utility.error.ErrorUtils.logAndShow;
 public class ElectionResultPagerAdapter
     extends RecyclerView.Adapter<ElectionResultPagerAdapter.Pager2ViewHolder> {
 
-  private static final String TAG = ElectionResultFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(ElectionResultPagerAdapter.class);
 
   private List<QuestionResults> currentResults;
   private ElectionResultListAdapter adapter;
@@ -53,7 +55,7 @@ public class ElectionResultPagerAdapter
                     }
                   }));
     } catch (UnknownElectionException err) {
-      logAndShow(viewModel.getApplication(), TAG, err, R.string.generic_error);
+      logAndShow(viewModel.getApplication(), logger, err, R.string.generic_error);
     }
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/adapters/ElectionSetupViewPagerAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/adapters/ElectionSetupViewPagerAdapter.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.ui.lao.event.election.adapters;
 import android.content.Context;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.*;
 import android.widget.*;
 
@@ -15,6 +14,9 @@ import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.CastVoteBallotOptionLayoutBinding;
 import com.github.dedis.popstellar.ui.lao.event.election.fragments.ElectionSetupFragment;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -22,7 +24,7 @@ import java.util.stream.Collectors;
 public class ElectionSetupViewPagerAdapter
     extends RecyclerView.Adapter<ElectionSetupViewPagerAdapter.ViewHolder> {
 
-  public static final String TAG = ElectionSetupViewPagerAdapter.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(ElectionSetupViewPagerAdapter.class);
   private final List<String> votingMethod;
   private final List<List<String>> ballotOptions;
   private final List<Integer> numberBallotOptions;
@@ -249,7 +251,7 @@ public class ElectionSetupViewPagerAdapter
             }
             // Keeps the list of string updated when the user changes the text
             ballotOptions.get(position).set(ballotIndex, editable.toString());
-            Log.d(TAG, "Postion is " + position + " ballot options are" + ballotOptions);
+            logger.debug("Postion is " + position + " ballot options are" + ballotOptions);
             boolean areFieldsFilled = numberBallotOptions.get(position) >= 2;
             if (areFieldsFilled) {
               listOfValidBallots.add(position);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/CastVoteFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/CastVoteFragment.java
@@ -24,6 +24,9 @@ import com.github.dedis.popstellar.utility.ActivityUtils;
 import com.github.dedis.popstellar.utility.error.UnknownElectionException;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.*;
 
 import javax.inject.Inject;
@@ -39,7 +42,7 @@ import static com.github.dedis.popstellar.utility.error.ErrorUtils.logAndShow;
  */
 @AndroidEntryPoint
 public class CastVoteFragment extends Fragment {
-  public static final String TAG = CastVoteFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(CastVoteFragment.class);
 
   private static final String ELECTION_ID = "election_id";
 
@@ -102,7 +105,7 @@ public class CastVoteFragment extends Fragment {
       CircleIndicator3 circleIndicator = binding.swipeIndicator;
       circleIndicator.setViewPager(pager);
     } catch (UnknownElectionException err) {
-      logAndShow(requireContext(), TAG, err, R.string.generic_error);
+      logAndShow(requireContext(), logger, err, R.string.generic_error);
       return null;
     }
 
@@ -148,7 +151,7 @@ public class CastVoteFragment extends Fragment {
       binding.castVoteLaoName.setText(laoView.getName());
       return false;
     } catch (UnknownLaoException e) {
-      logAndShow(requireContext(), TAG, R.string.error_no_lao);
+      logAndShow(requireContext(), logger, R.string.error_no_lao);
       return true;
     }
   }
@@ -159,7 +162,7 @@ public class CastVoteFragment extends Fragment {
       binding.castVoteElectionName.setText(election.getName());
       return false;
     } catch (UnknownElectionException e) {
-      logAndShow(requireContext(), TAG, R.string.error_no_election);
+      logAndShow(requireContext(), logger, R.string.error_no_election);
       return true;
     }
   }
@@ -194,12 +197,11 @@ public class CastVoteFragment extends Fragment {
               .sendVote(electionId, plainVotes)
               .subscribe(
                   () ->
-                      Toast.makeText(
-                              requireContext(), R.string.vote_sent, Toast.LENGTH_LONG)
+                      Toast.makeText(requireContext(), R.string.vote_sent, Toast.LENGTH_LONG)
                           .show(),
-                  err -> logAndShow(requireContext(), TAG, err, R.string.error_send_vote)));
+                  err -> logAndShow(requireContext(), logger, err, R.string.error_send_vote)));
     } catch (UnknownElectionException err) {
-      logAndShow(requireContext(), TAG, err, R.string.generic_error);
+      logAndShow(requireContext(), logger, err, R.string.generic_error);
     } finally {
       voteButton.setEnabled(true);
     }
@@ -217,7 +219,7 @@ public class CastVoteFragment extends Fragment {
         requireActivity(),
         getViewLifecycleOwner(),
         ActivityUtils.buildBackButtonCallback(
-            TAG,
+            logger,
             "election",
             () ->
                 ElectionFragment.openFragment(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionFragment.java
@@ -23,6 +23,9 @@ import com.github.dedis.popstellar.ui.lao.event.election.ElectionViewModel;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 import com.github.dedis.popstellar.utility.error.UnknownElectionException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.text.SimpleDateFormat;
 import java.util.*;
 
@@ -37,7 +40,7 @@ import static com.github.dedis.popstellar.utility.Constants.*;
 @AndroidEntryPoint
 public class ElectionFragment extends Fragment {
 
-  private static final String TAG = ElectionFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(ElectionFragment.class);
 
   private static final String ELECTION_ID = "election_id";
 
@@ -102,7 +105,7 @@ public class ElectionFragment extends Fragment {
           try {
             election = electionRepository.getElection(laoViewModel.getLaoId(), electionId);
           } catch (UnknownElectionException e) {
-            ErrorUtils.logAndShow(requireContext(), TAG, e, R.string.generic_error);
+            ErrorUtils.logAndShow(requireContext(), logger, e, R.string.generic_error);
             return;
           }
 
@@ -125,7 +128,7 @@ public class ElectionFragment extends Fragment {
                                       error ->
                                           ErrorUtils.logAndShow(
                                               requireContext(),
-                                              TAG,
+                                              logger,
                                               error,
                                               R.string.error_open_election))))
                   .setNegativeButton(R.string.no, null)
@@ -146,7 +149,7 @@ public class ElectionFragment extends Fragment {
                                       error ->
                                           ErrorUtils.logAndShow(
                                               requireContext(),
-                                              TAG,
+                                              logger,
                                               error,
                                               R.string.error_end_election))))
                   .setNegativeButton(R.string.no, null)
@@ -165,7 +168,7 @@ public class ElectionFragment extends Fragment {
           try {
             election = electionRepository.getElection(laoViewModel.getLaoId(), electionId);
           } catch (UnknownElectionException e) {
-            ErrorUtils.logAndShow(requireContext(), TAG, e, R.string.generic_error);
+            ErrorUtils.logAndShow(requireContext(), logger, e, R.string.generic_error);
             return;
           }
 
@@ -211,9 +214,10 @@ public class ElectionFragment extends Fragment {
               .subscribe(
                   this::setupElectionContent,
                   err ->
-                      ErrorUtils.logAndShow(requireContext(), TAG, err, R.string.generic_error)));
+                      ErrorUtils.logAndShow(
+                          requireContext(), logger, err, R.string.generic_error)));
     } catch (UnknownElectionException e) {
-      ErrorUtils.logAndShow(requireContext(), TAG, e, R.string.generic_error);
+      ErrorUtils.logAndShow(requireContext(), logger, e, R.string.generic_error);
     }
   }
 
@@ -390,7 +394,8 @@ public class ElectionFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationCallbackToEvents(requireActivity(), getViewLifecycleOwner(), TAG);
+    LaoActivity.addBackNavigationCallbackToEvents(
+        requireActivity(), getViewLifecycleOwner(), logger);
   }
 
   public static void openFragment(FragmentManager manager, String electionId) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionResultFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionResultFragment.java
@@ -18,6 +18,9 @@ import com.github.dedis.popstellar.ui.lao.event.election.adapters.ElectionResult
 import com.github.dedis.popstellar.utility.ActivityUtils;
 import com.github.dedis.popstellar.utility.error.*;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import javax.inject.Inject;
 
 import dagger.hilt.android.AndroidEntryPoint;
@@ -27,7 +30,7 @@ import static com.github.dedis.popstellar.utility.error.ErrorUtils.logAndShow;
 
 @AndroidEntryPoint
 public class ElectionResultFragment extends Fragment {
-  private static final String TAG = ElectionResultFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(ElectionResultFragment.class);
 
   private static final String ELECTION_ID = "election_id";
   private LaoViewModel laoViewModel;
@@ -74,10 +77,10 @@ public class ElectionResultFragment extends Fragment {
       CircleIndicator3 circleIndicator = binding.swipeIndicatorElectionResults;
       circleIndicator.setViewPager(viewPager2);
     } catch (UnknownLaoException e) {
-      ErrorUtils.logAndShow(requireContext(), TAG, R.string.error_no_lao);
+      ErrorUtils.logAndShow(requireContext(), logger, R.string.error_no_lao);
       return null;
     } catch (UnknownElectionException e) {
-      logAndShow(requireContext(), TAG, R.string.error_no_election);
+      logAndShow(requireContext(), logger, R.string.error_no_election);
       return null;
     }
 
@@ -99,7 +102,7 @@ public class ElectionResultFragment extends Fragment {
         requireActivity(),
         getViewLifecycleOwner(),
         ActivityUtils.buildBackButtonCallback(
-            TAG,
+            logger,
             "election",
             () ->
                 ElectionFragment.openFragment(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionSetupFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionSetupFragment.java
@@ -1,9 +1,9 @@
 package com.github.dedis.popstellar.ui.lao.event.election.fragments;
 
+import android.annotation.SuppressLint;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.*;
 import android.widget.*;
 import android.widget.AdapterView.OnItemSelectedListener;
@@ -25,6 +25,9 @@ import com.github.dedis.popstellar.ui.lao.event.election.adapters.ElectionSetupV
 import com.github.dedis.popstellar.ui.lao.event.eventlist.EventListFragment;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,7 +38,7 @@ import me.relex.circleindicator.CircleIndicator3;
 @AndroidEntryPoint
 public class ElectionSetupFragment extends AbstractEventCreationFragment {
 
-  public static final String TAG = ElectionSetupFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(ElectionSetupFragment.class);
 
   // mandatory fields for submitting
   private EditText electionNameText;
@@ -191,6 +194,7 @@ public class ElectionSetupFragment extends AbstractEventCreationFragment {
   }
 
   /** Setups the submit button that creates the new election */
+  @SuppressLint("DefaultLocale")
   private void setupElectionSubmitButton() {
     submitButton.setOnClickListener(
         v -> {
@@ -227,8 +231,7 @@ public class ElectionSetupFragment extends AbstractEventCreationFragment {
 
           String electionName = electionNameText.getText().toString();
 
-          Log.d(
-              TAG,
+          logger.debug(
               String.format(
                   "Creating election with version %s, name %s, creation time %d, start time %d, end time %d, questions %s",
                   electionVersion,
@@ -255,7 +258,7 @@ public class ElectionSetupFragment extends AbstractEventCreationFragment {
                               EventListFragment::newInstance),
                       error ->
                           ErrorUtils.logAndShow(
-                              requireContext(), TAG, error, R.string.error_create_election)));
+                              requireContext(), logger, error, R.string.error_create_election)));
         });
   }
 
@@ -296,6 +299,7 @@ public class ElectionSetupFragment extends AbstractEventCreationFragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationCallbackToEvents(requireActivity(), getViewLifecycleOwner(), TAG);
+    LaoActivity.addBackNavigationCallbackToEvents(
+        requireActivity(), getViewLifecycleOwner(), logger);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventListAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventListAdapter.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.event.eventlist;
 
 import android.annotation.SuppressLint;
-import android.util.Log;
 import android.view.*;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -17,6 +16,9 @@ import com.github.dedis.popstellar.model.objects.event.EventCategory;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.ui.lao.event.LaoDetailAnimation;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.*;
 
 import io.reactivex.Observable;
@@ -31,11 +33,11 @@ public class EventListAdapter extends EventsAdapter {
   private final boolean[] expanded = new boolean[2];
   public static final int TYPE_HEADER = 0;
   public static final int TYPE_EVENT = 1;
-  public static final String TAG = EventListAdapter.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(EventListAdapter.class);
 
   public EventListAdapter(
       LaoViewModel viewModel, Observable<Set<Event>> events, FragmentActivity activity) {
-    super(events, viewModel, activity, TAG);
+    super(events, viewModel, activity, logger);
     eventsMap = new EnumMap<>(EventCategory.class);
     eventsMap.put(PAST, new ArrayList<>());
     eventsMap.put(PRESENT, new ArrayList<>());
@@ -160,7 +162,7 @@ public class EventListAdapter extends EventsAdapter {
       return Objects.requireNonNull(eventsMap.get(PAST))
           .get(position - eventAccumulator - secondSectionOffset);
     }
-    Log.e(TAG, "position was " + position);
+    logger.error("position was " + position);
     throw new IllegalStateException("no event matches");
   }
 
@@ -184,7 +186,7 @@ public class EventListAdapter extends EventsAdapter {
     if (position == eventAccumulator + 1) {
       return PAST;
     }
-    Log.e(TAG, "Illegal position " + position);
+    logger.error("Illegal position " + position);
     throw new IllegalStateException("No event category");
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventListFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventListFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.event.eventlist;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 
 import androidx.annotation.NonNull;
@@ -25,6 +24,9 @@ import com.github.dedis.popstellar.utility.error.ErrorUtils;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.gson.Gson;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -35,8 +37,7 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public class EventListFragment extends Fragment {
 
-  public static final String TAG = EventListFragment.class.getSimpleName();
-
+  private static final Logger logger = LogManager.getLogger(EventListFragment.class);
   @Inject Gson gson;
 
   private EventListFragmentBinding binding;
@@ -86,7 +87,8 @@ public class EventListFragment extends Fragment {
                   setupEmptyEventsTextVisibility(events);
                 },
                 error ->
-                    ErrorUtils.logAndShow(requireContext(), TAG, R.string.error_event_observed)));
+                    ErrorUtils.logAndShow(
+                        requireContext(), logger, R.string.error_event_observed)));
 
     // Add listener to upcoming events card
     binding.upcomingEventsCard.setOnClickListener(
@@ -146,7 +148,7 @@ public class EventListFragment extends Fragment {
                 R.id.fragment_setup_election_event,
                 ElectionSetupFragment::newInstance);
       default:
-        return v -> Log.d(TAG, "unknown event type: " + type);
+        return v -> logger.debug("unknown event type: " + type);
     }
   }
 
@@ -168,7 +170,7 @@ public class EventListFragment extends Fragment {
 
     EventListAdapter eventListAdapter =
         new EventListAdapter(laoViewModel, eventsViewModel.getEvents(), requireActivity());
-    Log.d(TAG, "created adapter");
+    logger.debug("created adapter");
     LinearLayoutManager mLayoutManager = new LinearLayoutManager(getContext());
     eventList.setLayoutManager(mLayoutManager);
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventsAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventsAdapter.java
@@ -1,6 +1,5 @@
 package com.github.dedis.popstellar.ui.lao.event.eventlist;
 
-import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -20,6 +19,7 @@ import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.ui.lao.event.election.fragments.ElectionFragment;
 import com.github.dedis.popstellar.ui.lao.event.rollcall.RollCallFragment;
 
+import org.apache.logging.log4j.Logger;
 import org.ocpsoft.prettytime.PrettyTime;
 
 import java.util.*;
@@ -31,16 +31,16 @@ public abstract class EventsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
   private List<Event> events;
   private final LaoViewModel laoViewModel;
   private final FragmentActivity activity;
-  private final String tag;
+  private final Logger logger;
 
   protected EventsAdapter(
       Observable<Set<Event>> observable,
       LaoViewModel viewModel,
       FragmentActivity activity,
-      String tag) {
+      Logger logger) {
     this.laoViewModel = viewModel;
     this.activity = activity;
-    this.tag = tag;
+    this.logger = logger;
     subscribeToEventSet(observable);
   }
 
@@ -48,7 +48,7 @@ public abstract class EventsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
     this.laoViewModel.addDisposable(
         observable
             .map(eventList -> eventList.stream().sorted().collect(Collectors.toList()))
-            .subscribe(this::updateEventSet, err -> Log.e(tag, "ERROR", err)));
+            .subscribe(this::updateEventSet, err -> logger.error("ERROR", err)));
   }
 
   public abstract void updateEventSet(List<Event> events);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/UpcomingEventsAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/UpcomingEventsAdapter.java
@@ -13,6 +13,8 @@ import com.github.dedis.popstellar.model.objects.event.Event;
 import com.github.dedis.popstellar.model.objects.event.EventState;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 
+import org.apache.logging.log4j.Logger;
+
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -25,8 +27,8 @@ public class UpcomingEventsAdapter extends EventsAdapter {
       Observable<Set<Event>> observable,
       LaoViewModel viewModel,
       FragmentActivity activity,
-      String tag) {
-    super(observable, viewModel, activity, tag);
+      Logger logger) {
+    super(observable, viewModel, activity, logger);
   }
 
   @SuppressLint("NotifyDataSetChanged")

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallCreationFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallCreationFragment.java
@@ -19,6 +19,9 @@ import com.github.dedis.popstellar.ui.lao.event.eventlist.EventListFragment;
 import com.github.dedis.popstellar.utility.ActivityUtils;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.Objects;
 
 import dagger.hilt.android.AndroidEntryPoint;
@@ -28,7 +31,7 @@ import io.reactivex.Single;
 @AndroidEntryPoint
 public final class RollCallCreationFragment extends AbstractEventCreationFragment {
 
-  public static final String TAG = RollCallCreationFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(RollCallCreationFragment.class);
 
   private RollCallCreateFragmentBinding binding;
   private LaoViewModel laoViewModel;
@@ -139,7 +142,7 @@ public final class RollCallCreationFragment extends AbstractEventCreationFragmen
                     EventListFragment::newInstance),
             error ->
                 ErrorUtils.logAndShow(
-                    requireContext(), TAG, error, R.string.error_create_rollcall)));
+                    requireContext(), logger, error, R.string.error_create_rollcall)));
   }
 
   private void handleBackNav() {
@@ -147,6 +150,8 @@ public final class RollCallCreationFragment extends AbstractEventCreationFragmen
         requireActivity(),
         getViewLifecycleOwner(),
         ActivityUtils.buildBackButtonCallback(
-            TAG, "event list", () -> EventListFragment.openFragment(getParentFragmentManager())));
+            logger,
+            "event list",
+            () -> EventListFragment.openFragment(getParentFragmentManager())));
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
@@ -7,7 +7,6 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 import android.widget.*;
 
@@ -39,6 +38,9 @@ import com.google.gson.Gson;
 
 import net.glxn.qrgen.android.QRCode;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -52,7 +54,7 @@ import static com.github.dedis.popstellar.utility.Constants.*;
 @AndroidEntryPoint
 public class RollCallFragment extends Fragment {
 
-  public static final String TAG = RollCallFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(RollCallFragment.class);
 
   @Inject Gson gson;
   @Inject RollCallRepository rollCallRepo;
@@ -99,7 +101,7 @@ public class RollCallFragment extends Fragment {
           rollCallRepo.getRollCallWithPersistentId(
               laoViewModel.getLaoId(), requireArguments().getString(ROLL_CALL_ID));
     } catch (UnknownRollCallException e) {
-      ErrorUtils.logAndShow(requireContext(), TAG, e, R.string.unknown_roll_call_exception);
+      ErrorUtils.logAndShow(requireContext(), logger, e, R.string.unknown_roll_call_exception);
       return null;
     }
 
@@ -134,7 +136,7 @@ public class RollCallFragment extends Fragment {
                                   () -> RollCallFragment.newInstance(rollCall.getPersistentId())),
                           error ->
                               ErrorUtils.logAndShow(
-                                  requireContext(), TAG, error, R.string.error_open_rollcall)));
+                                  requireContext(), logger, error, R.string.error_open_rollcall)));
               break;
             case OPENED:
               // will add the scan to this fragment in the future
@@ -149,7 +151,7 @@ public class RollCallFragment extends Fragment {
                                   EventListFragment::newInstance),
                           error ->
                               ErrorUtils.logAndShow(
-                                  requireContext(), TAG, error, R.string.error_close_rollcall)));
+                                  requireContext(), logger, error, R.string.error_close_rollcall)));
               break;
             default:
               throw new IllegalStateException("Roll-Call should not be in a " + state + " state");
@@ -171,13 +173,13 @@ public class RollCallFragment extends Fragment {
             .getRollCallObservable(rollCall.getPersistentId())
             .subscribe(
                 rc -> {
-                  Log.d(TAG, "Received rc update: " + rc);
+                  logger.debug("Received rc update: " + rc);
                   rollCall = rc;
                   setUpStateDependantContent();
                 },
                 error ->
                     ErrorUtils.logAndShow(
-                        requireContext(), TAG, error, R.string.unknown_roll_call_exception)));
+                        requireContext(), logger, error, R.string.unknown_roll_call_exception)));
 
     handleBackNav();
     return binding.getRoot();
@@ -193,7 +195,7 @@ public class RollCallFragment extends Fragment {
           rollCallRepo.getRollCallWithPersistentId(
               laoViewModel.getLaoId(), requireArguments().getString(ROLL_CALL_ID));
     } catch (UnknownRollCallException e) {
-      ErrorUtils.logAndShow(requireContext(), TAG, e, R.string.unknown_roll_call_exception);
+      ErrorUtils.logAndShow(requireContext(), logger, e, R.string.unknown_roll_call_exception);
     }
   }
 
@@ -201,10 +203,10 @@ public class RollCallFragment extends Fragment {
     try {
       return laoViewModel.getCurrentPopToken(rollCall);
     } catch (KeyException e) {
-      ErrorUtils.logAndShow(requireContext(), TAG, e, R.string.key_generation_exception);
+      ErrorUtils.logAndShow(requireContext(), logger, e, R.string.key_generation_exception);
       return null;
     } catch (UnknownLaoException e) {
-      ErrorUtils.logAndShow(requireContext(), TAG, e, R.string.unknown_lao_exception);
+      ErrorUtils.logAndShow(requireContext(), logger, e, R.string.unknown_lao_exception);
       return null;
     }
   }
@@ -360,7 +362,7 @@ public class RollCallFragment extends Fragment {
     }
 
     String pk = popToken.getPublicKey().getEncoded();
-    Log.d(TAG, "key displayed is " + pk);
+    logger.debug("key displayed is " + pk);
 
     // Set the QR visible only if the rollcall is opened and the user isn't the organizer
     binding.rollCallPkQrCode.setVisibility((rollCall.isOpen()) ? View.VISIBLE : View.INVISIBLE);
@@ -437,7 +439,8 @@ public class RollCallFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationCallbackToEvents(requireActivity(), getViewLifecycleOwner(), TAG);
+    LaoActivity.addBackNavigationCallbackToEvents(
+        requireActivity(), getViewLifecycleOwner(), logger);
   }
 
   /**

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapter.java
@@ -11,6 +11,9 @@ import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.time.Instant;
 import java.util.List;
 
@@ -18,7 +21,7 @@ import static android.text.format.DateUtils.getRelativeTimeSpanString;
 
 public class ChirpListAdapter extends BaseAdapter {
 
-  private static final String TAG = ChirpListAdapter.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(ChirpListAdapter.class);
 
   private final LaoViewModel laoViewModel;
   private final SocialMediaViewModel socialMediaViewModel;
@@ -38,7 +41,8 @@ public class ChirpListAdapter extends BaseAdapter {
             .getChirps()
             .subscribe(
                 this::replaceList,
-                err -> ErrorUtils.logAndShow(context, TAG, err, R.string.unknown_chirp_exception)));
+                err ->
+                    ErrorUtils.logAndShow(context, logger, err, R.string.unknown_chirp_exception)));
   }
 
   public void replaceList(List<Chirp> chirps) {
@@ -93,7 +97,7 @@ public class ChirpListAdapter extends BaseAdapter {
                                   .show(),
                           error ->
                               ErrorUtils.logAndShow(
-                                  context, TAG, error, R.string.error_delete_chirp))));
+                                  context, logger, error, R.string.error_delete_chirp))));
     } else {
       deleteChirp.setVisibility(View.GONE);
     }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListFragment.java
@@ -19,7 +19,6 @@ import dagger.hilt.android.AndroidEntryPoint;
 /** Fragment displaying the chirp list and the add chirp button */
 @AndroidEntryPoint
 public class ChirpListFragment extends Fragment {
-  public static final String TAG = SocialMediaSendFragment.class.getSimpleName();
 
   private ChirpListFragmentBinding binding;
   private LaoViewModel laoViewModel;

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaFollowingFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaFollowingFragment.java
@@ -13,13 +13,16 @@ import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.ActivityUtils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import dagger.hilt.android.AndroidEntryPoint;
 
 /** Fragment that shows people we are subscribed to */
 @AndroidEntryPoint
 public class SocialMediaFollowingFragment extends Fragment {
 
-  public static final String TAG = SocialMediaFollowingFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(SocialMediaFollowingFragment.class);
   private LaoViewModel laoViewModel;
 
   public static SocialMediaFollowingFragment newInstance() {
@@ -58,7 +61,7 @@ public class SocialMediaFollowingFragment extends Fragment {
         requireActivity(),
         getViewLifecycleOwner(),
         ActivityUtils.buildBackButtonCallback(
-            TAG,
+            logger,
             "social media home",
             () -> SocialMediaHomeFragment.openFragment(getParentFragmentManager())));
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaHomeFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaHomeFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.socialmedia;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 
 import androidx.annotation.*;
@@ -13,6 +12,9 @@ import com.github.dedis.popstellar.databinding.SocialMediaHomeFragmentBinding;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.ActivityUtils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.function.Supplier;
 
@@ -28,7 +30,7 @@ public class SocialMediaHomeFragment extends Fragment {
   private SocialMediaViewModel socialMediaViewModel;
   private SocialMediaHomeFragmentBinding binding;
 
-  public static final String TAG = SocialMediaHomeFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(SocialMediaHomeFragment.class);
 
   @Nullable
   @Override
@@ -58,7 +60,7 @@ public class SocialMediaHomeFragment extends Fragment {
     binding.socialMediaNavBar.setOnItemSelectedListener(
         item -> {
           SocialMediaTab tab = SocialMediaTab.findByMenu(item.getItemId());
-          Log.i(TAG, "Opening tab : " + tab.getName());
+          logger.info("Opening tab : " + tab.getName());
           openBottomTab(tab);
           return true;
         });
@@ -128,6 +130,7 @@ public class SocialMediaHomeFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationCallbackToEvents(requireActivity(), getViewLifecycleOwner(), TAG);
+    LaoActivity.addBackNavigationCallbackToEvents(
+        requireActivity(), getViewLifecycleOwner(), logger);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaProfileFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaProfileFragment.java
@@ -13,12 +13,15 @@ import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.ActivityUtils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import dagger.hilt.android.AndroidEntryPoint;
 
 /** Fragment of the user's profile page */
 @AndroidEntryPoint
 public class SocialMediaProfileFragment extends Fragment {
-  public static final String TAG = SocialMediaProfileFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(SocialMediaProfileFragment.class);
   private LaoViewModel laoViewModel;
 
   public static SocialMediaProfileFragment newInstance() {
@@ -57,7 +60,7 @@ public class SocialMediaProfileFragment extends Fragment {
         requireActivity(),
         getViewLifecycleOwner(),
         ActivityUtils.buildBackButtonCallback(
-            TAG,
+            logger,
             "social media home",
             () -> SocialMediaHomeFragment.openFragment(getParentFragmentManager())));
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaSearchFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaSearchFragment.java
@@ -13,12 +13,15 @@ import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.ActivityUtils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import dagger.hilt.android.AndroidEntryPoint;
 
 /** Fragment that let us search for chirps and users */
 @AndroidEntryPoint
 public class SocialMediaSearchFragment extends Fragment {
-  public static final String TAG = SocialMediaSearchFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(SocialMediaSearchFragment.class);
   private LaoViewModel laoViewModel;
 
   public static SocialMediaSearchFragment newInstance() {
@@ -57,7 +60,7 @@ public class SocialMediaSearchFragment extends Fragment {
         requireActivity(),
         getViewLifecycleOwner(),
         ActivityUtils.buildBackButtonCallback(
-            TAG,
+            logger,
             "social media home",
             () -> SocialMediaHomeFragment.openFragment(getParentFragmentManager())));
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaSendFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaSendFragment.java
@@ -15,6 +15,9 @@ import com.github.dedis.popstellar.utility.ActivityUtils;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 import com.github.dedis.popstellar.utility.error.keys.KeyException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.security.GeneralSecurityException;
 import java.time.Instant;
 
@@ -24,8 +27,7 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public class SocialMediaSendFragment extends Fragment {
 
-  public static final String TAG = SocialMediaSendFragment.class.getSimpleName();
-
+  private static final Logger logger = LogManager.getLogger(SocialMediaSendFragment.class);
   private SocialMediaSendFragmentBinding binding;
   private LaoViewModel laoViewModel;
   private SocialMediaViewModel socialMediaViewModel;
@@ -75,7 +77,7 @@ public class SocialMediaSendFragment extends Fragment {
     // Trying to send a chirp when no LAO has been chosen in the application will not send it, it
     // will make a toast appear and it will log the error
     if (laoViewModel.getLaoId() == null) {
-      ErrorUtils.logAndShow(requireContext(), TAG, R.string.error_no_lao);
+      ErrorUtils.logAndShow(requireContext(), logger, R.string.error_no_lao);
     } else {
       laoViewModel.addDisposable(
           socialMediaViewModel
@@ -91,10 +93,10 @@ public class SocialMediaSendFragment extends Fragment {
                     if (error instanceof KeyException
                         || error instanceof GeneralSecurityException) {
                       ErrorUtils.logAndShow(
-                          requireContext(), TAG, error, R.string.error_retrieve_own_token);
+                          requireContext(), logger, error, R.string.error_retrieve_own_token);
                     } else {
                       ErrorUtils.logAndShow(
-                          requireContext(), TAG, error, R.string.error_sending_chirp);
+                          requireContext(), logger, error, R.string.error_sending_chirp);
                     }
                   }));
       socialMediaViewModel.setBottomNavigationTab(SocialMediaTab.HOME);
@@ -106,6 +108,8 @@ public class SocialMediaSendFragment extends Fragment {
         requireActivity(),
         getViewLifecycleOwner(),
         ActivityUtils.buildBackButtonCallback(
-            TAG, "chirp list", () -> ChirpListFragment.OpenFragment(getParentFragmentManager())));
+            logger,
+            "chirp list",
+            () -> ChirpListFragment.OpenFragment(getParentFragmentManager())));
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.socialmedia;
 
 import android.app.Application;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -25,6 +24,9 @@ import com.github.dedis.popstellar.utility.scheduler.SchedulerProvider;
 import com.github.dedis.popstellar.utility.security.KeyManager;
 import com.google.gson.Gson;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -37,7 +39,7 @@ import io.reactivex.disposables.CompositeDisposable;
 
 @HiltViewModel
 public class SocialMediaViewModel extends AndroidViewModel {
-  public static final String TAG = SocialMediaViewModel.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(SocialMediaViewModel.class);
   private static final String LAO_FAILURE_MESSAGE = "failed to retrieve lao";
   private static final String SOCIAL = "social";
   public static final Integer MAX_CHAR_NUMBERS = 300;
@@ -126,20 +128,20 @@ public class SocialMediaViewModel extends AndroidViewModel {
    */
   public Single<MessageGeneral> sendChirp(
       String text, @Nullable MessageID parentId, long timestamp) {
-    Log.d(TAG, "Sending a chirp");
+    logger.debug("Sending a chirp");
 
     LaoView laoView;
     try {
       laoView = getLao();
     } catch (UnknownLaoException e) {
-      Log.e(TAG, LAO_FAILURE_MESSAGE);
+      logger.error(LAO_FAILURE_MESSAGE);
       return Single.error(new UnknownLaoException());
     }
 
     AddChirp addChirp = new AddChirp(text, parentId, timestamp);
 
     return Single.fromCallable(this::getValidPoPToken)
-        .doOnSuccess(token -> Log.d(TAG, "Retrieved PoPToken to send Chirp : " + token))
+        .doOnSuccess(token -> logger.debug("Retrieved PoPToken to send Chirp : " + token))
         .flatMap(
             token -> {
               Channel channel =
@@ -154,20 +156,20 @@ public class SocialMediaViewModel extends AndroidViewModel {
   }
 
   public Single<MessageGeneral> deleteChirp(MessageID chirpId, long timestamp) {
-    Log.d(TAG, "Deleting the chirp with id: " + chirpId);
+    logger.debug("Deleting the chirp with id: " + chirpId);
 
     final LaoView laoView;
     try {
       laoView = getLao();
     } catch (UnknownLaoException e) {
-      Log.e(TAG, LAO_FAILURE_MESSAGE);
+      logger.error(LAO_FAILURE_MESSAGE);
       return Single.error(new UnknownLaoException());
     }
 
     DeleteChirp deleteChirp = new DeleteChirp(chirpId, timestamp);
 
     return Single.fromCallable(this::getValidPoPToken)
-        .doOnSuccess(token -> Log.d(TAG, "Retrieved PoPToken to delete Chirp : " + token))
+        .doOnSuccess(token -> logger.debug("Retrieved PoPToken to delete Chirp : " + token))
         .flatMap(
             token -> {
               Channel channel =
@@ -217,13 +219,13 @@ public class SocialMediaViewModel extends AndroidViewModel {
    * @return true if the sender is the current user
    */
   public boolean isOwner(String sender) {
-    Log.d(TAG, "Testing if the sender is also the owner");
+    logger.debug("Testing if the sender is also the owner");
 
     try {
       PoPToken token = getValidPoPToken();
       return sender.equals(token.getPublicKey().getEncoded());
     } catch (KeyException e) {
-      ErrorUtils.logAndShow(getApplication(), TAG, e, R.string.error_retrieve_own_token);
+      ErrorUtils.logAndShow(getApplication(), logger, e, R.string.error_retrieve_own_token);
       return false;
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenFragment.java
@@ -4,7 +4,6 @@ import android.content.*;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 import android.widget.Toast;
 
@@ -30,6 +29,9 @@ import com.google.gson.Gson;
 
 import net.glxn.qrgen.android.QRCode;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import javax.inject.Inject;
 
 import dagger.hilt.android.AndroidEntryPoint;
@@ -37,7 +39,7 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public class TokenFragment extends Fragment {
 
-  private static final String TAG = TokenFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(TokenFragment.class);
 
   @Inject Gson gson;
   @Inject RollCallRepository rollCallRepo;
@@ -74,7 +76,7 @@ public class TokenFragment extends Fragment {
       RollCall rollCall =
           rollCallRepo.getRollCallWithPersistentId(
               laoViewModel.getLaoId(), requireArguments().getString(Constants.ROLL_CALL_ID));
-      Log.d(TAG, "token displayed from roll call: " + rollCall);
+      logger.debug("token displayed from roll call: " + rollCall);
 
       PoPToken poPToken = keyManager.getValidPoPToken(laoViewModel.getLaoId(), rollCall);
       PopTokenData data = new PopTokenData(poPToken.getPublicKey());
@@ -93,7 +95,7 @@ public class TokenFragment extends Fragment {
           });
 
     } catch (UnknownRollCallException | KeyException e) {
-      ErrorUtils.logAndShow(requireContext(), TAG, e, R.string.error_retrieve_own_token);
+      ErrorUtils.logAndShow(requireContext(), logger, e, R.string.error_retrieve_own_token);
       LaoActivity.setCurrentFragment(
           getParentFragmentManager(), R.id.fragment_event_list, LaoCreateFragment::new);
       return null;
@@ -115,6 +117,8 @@ public class TokenFragment extends Fragment {
         requireActivity(),
         getViewLifecycleOwner(),
         ActivityUtils.buildBackButtonCallback(
-            TAG, "token list", () -> TokenListFragment.openFragment(getParentFragmentManager())));
+            logger,
+            "token list",
+            () -> TokenListFragment.openFragment(getParentFragmentManager())));
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenListFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenListFragment.java
@@ -18,6 +18,9 @@ import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.ui.lao.event.rollcall.RollCallViewModel;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +32,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 @AndroidEntryPoint
 public class TokenListFragment extends Fragment {
 
-  public static final String TAG = TokenListFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(TokenListFragment.class);
 
   private TokenListFragmentBinding binding;
   private LaoViewModel laoViewModel;
@@ -126,6 +129,7 @@ public class TokenListFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationCallbackToEvents(requireActivity(), getViewLifecycleOwner(), TAG);
+    LaoActivity.addBackNavigationCallbackToEvents(
+        requireActivity(), getViewLifecycleOwner(), logger);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.witness;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 import android.widget.ListView;
 
@@ -13,6 +12,9 @@ import com.github.dedis.popstellar.databinding.WitnessMessageFragmentBinding;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.ArrayList;
 
 import dagger.hilt.android.AndroidEntryPoint;
@@ -20,7 +22,7 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public class WitnessMessageFragment extends Fragment {
 
-  public static final String TAG = WitnessMessageFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(WitnessMessageFragment.class);
   private WitnessMessageFragmentBinding binding;
   private WitnessingViewModel witnessingViewModel;
   private WitnessMessageListViewAdapter adapter;
@@ -60,7 +62,7 @@ public class WitnessMessageFragment extends Fragment {
         .observe(
             requireActivity(),
             messages -> {
-              Log.d(TAG, "witness messages updated");
+              logger.debug("witness messages updated");
               adapter.replaceList(messages);
             });
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
@@ -15,12 +15,15 @@ import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.List;
 
 /** Adapter to show the messages that have to be signed by the witnesses */
 public class WitnessMessageListViewAdapter extends BaseAdapter {
 
-  private static final String TAG = WitnessMessageListViewAdapter.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(WitnessMessageListViewAdapter.class);
   private final LaoViewModel laoViewModel;
   private final WitnessingViewModel witnessingViewModel;
 
@@ -102,7 +105,7 @@ public class WitnessMessageListViewAdapter extends BaseAdapter {
                                 () -> {},
                                 error ->
                                     ErrorUtils.logAndShow(
-                                        activity, TAG, error, R.string.error_sign_message))));
+                                        activity, logger, error, R.string.error_sign_message))));
           } else {
             adb.setTitle(R.string.not_a_witness);
             adb.setMessage(R.string.not_a_witness_explanation);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessingFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessingFragment.java
@@ -12,9 +12,12 @@ import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public class WitnessingFragment extends Fragment {
 
-  public static final String TAG = WitnessingFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(WitnessingFragment.class);
 
   public WitnessingFragment() {
     // Required empty public constructor
@@ -54,6 +57,7 @@ public class WitnessingFragment extends Fragment {
   }
 
   private void handleBackNav() {
-    LaoActivity.addBackNavigationCallbackToEvents(requireActivity(), getViewLifecycleOwner(), TAG);
+    LaoActivity.addBackNavigationCallbackToEvents(
+        requireActivity(), getViewLifecycleOwner(), logger);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QrScannerFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QrScannerFragment.java
@@ -2,7 +2,6 @@ package com.github.dedis.popstellar.ui.qrcode;
 
 import android.Manifest;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -19,6 +18,9 @@ import com.github.dedis.popstellar.ui.PopViewModel;
 import com.google.mlkit.vision.barcode.*;
 import com.google.mlkit.vision.barcode.common.Barcode;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -28,7 +30,7 @@ import static androidx.camera.view.CameraController.COORDINATE_SYSTEM_VIEW_REFER
 import static androidx.core.content.ContextCompat.checkSelfPermission;
 
 public class QrScannerFragment extends Fragment {
-  public static final String TAG = QrScannerFragment.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(QrScannerFragment.class);
 
   public static final String SCANNING_KEY = "scanning_action_key";
   public static final String BACK_ARGS = "back_arguments";
@@ -172,7 +174,7 @@ public class QrScannerFragment extends Fragment {
             result -> {
               List<Barcode> barcodes = result.getValue(barcodeScanner);
               if (barcodes != null && !barcodes.isEmpty()) {
-                Log.d(TAG, "barcode raw value :" + barcodes.get(0).getRawValue());
+                logger.debug("barcode raw value :" + barcodes.get(0).getRawValue());
                 onResult(barcodes.get(0));
               }
             }));

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/ActivityUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/ActivityUtils.java
@@ -31,7 +31,9 @@ public class ActivityUtils {
       FragmentManager manager, int containerId, int id, Supplier<Fragment> fragmentSupplier) {
     Fragment fragment = manager.findFragmentById(id);
     // If the fragment was not created yet, create it now
-    if (fragment == null) fragment = fragmentSupplier.get();
+    if (fragment == null) {
+      fragment = fragmentSupplier.get();
+    }
 
     // Set the new fragment in the container
     ActivityUtils.replaceFragmentInActivity(manager, fragment, containerId);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/ActivityUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/ActivityUtils.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.utility;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Color;
-import android.util.Log;
 
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
@@ -16,6 +15,9 @@ import com.github.dedis.popstellar.repository.local.PersistentData;
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.*;
 import java.security.GeneralSecurityException;
 import java.util.HashSet;
@@ -23,7 +25,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 public class ActivityUtils {
-  private static final String TAG = ActivityUtils.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(ActivityUtils.class);
 
   private static final String PERSISTENT_DATA_FILE_NAME = "persistent_data";
 
@@ -54,17 +56,17 @@ public class ActivityUtils {
    * @return true if the storage process was a success; false otherwise
    */
   public static boolean storePersistentData(Context context, PersistentData data) {
-    Log.d(TAG, "Initiating storage of " + data);
+    logger.debug("Initiating storage of " + data);
 
     try (ObjectOutputStream oos =
         new ObjectOutputStream(
             context.openFileOutput(PERSISTENT_DATA_FILE_NAME, Context.MODE_PRIVATE))) {
       oos.writeObject(data);
     } catch (IOException e) {
-      ErrorUtils.logAndShow(context, TAG, e, R.string.error_storing_data);
+      ErrorUtils.logAndShow(context, logger, e, R.string.error_storing_data);
       return false;
     }
-    Log.d(TAG, "storage successful");
+    logger.debug("storage successful");
     return true;
   }
 
@@ -75,21 +77,21 @@ public class ActivityUtils {
    * @return the data if found, null otherwise
    */
   public static PersistentData loadPersistentData(Context context) {
-    Log.d(TAG, "Initiating loading of data");
+    logger.debug("Initiating loading of data");
 
     PersistentData persistentData;
     try (ObjectInputStream ois =
         new ObjectInputStream(context.openFileInput(PERSISTENT_DATA_FILE_NAME))) {
       persistentData = (PersistentData) ois.readObject();
     } catch (FileNotFoundException e) {
-      ErrorUtils.logAndShow(context, TAG, e, R.string.nothing_stored);
+      ErrorUtils.logAndShow(context, logger, e, R.string.nothing_stored);
       return null;
     } catch (IOException | ClassNotFoundException e) {
-      ErrorUtils.logAndShow(context, TAG, e, R.string.error_loading_data);
+      ErrorUtils.logAndShow(context, logger, e, R.string.error_loading_data);
       return null;
     }
 
-    Log.d(TAG, "loading of " + persistentData);
+    logger.debug("loading of " + persistentData);
     return persistentData;
   }
 
@@ -100,7 +102,7 @@ public class ActivityUtils {
    * @return true if the clearing was a success; false otherwise
    */
   public static boolean clearStorage(Context context) {
-    Log.d(TAG, "clearing data");
+    logger.debug("clearing data");
 
     File file = new File(context.getFilesDir(), PERSISTENT_DATA_FILE_NAME);
     return file.delete();
@@ -128,8 +130,7 @@ public class ActivityUtils {
     }
 
     String[] seed = wallet.exportSeed();
-    Log.d(
-        TAG,
+    logger.debug(
         "seed length"
             + seed.length
             + " address "
@@ -143,17 +144,17 @@ public class ActivityUtils {
    * The following function creates an object of type OnBackPressedCallback given a specific
    * callback function. This avoids code repetitions.
    *
-   * @param tag String tag for the log
+   * @param logger logger of the class that invoked the callback
    * @param message String message for the log
    * @param callback Runnable function to use * as callback
    * @return the callback object
    */
   public static OnBackPressedCallback buildBackButtonCallback(
-      String tag, String message, Runnable callback) {
+      Logger logger, String message, Runnable callback) {
     return new OnBackPressedCallback(true) {
       @Override
       public void handleOnBackPressed() {
-        Log.d(tag, "Back pressed, going to " + message);
+        logger.debug("Back pressed, going to " + message);
         callback.run();
       }
     };

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/error/ErrorUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/error/ErrorUtils.java
@@ -2,18 +2,21 @@ package com.github.dedis.popstellar.utility.error;
 
 import android.content.Context;
 import android.os.Handler;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.StringRes;
 
 import com.github.dedis.popstellar.R;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.bouncycastle.util.Arrays;
 
 import java.util.concurrent.TimeoutException;
 
 public class ErrorUtils {
+
+  private static final Logger logger = LogManager.getLogger(ErrorUtils.class);
 
   private ErrorUtils() throws IllegalAccessException {
     throw new IllegalAccessException();
@@ -23,13 +26,13 @@ public class ErrorUtils {
    * Log non-error and show a localized {@link Toast} to the user
    *
    * @param context to retrieve the localized messages and show the toast on
-   * @param tag used to log the error
+   * @param logger of the class that launched the log
    * @param action short description of what was happening when the error occurred
    */
-  public static void logAndShow(Context context, String tag, @StringRes int action) {
+  public static void logAndShow(Context context, Logger logger, @StringRes int action) {
     String message = context.getString(action);
 
-    Log.e(tag, message);
+    logger.error(message);
     displayToast(context, message);
   }
 
@@ -42,16 +45,20 @@ public class ErrorUtils {
    * <p>Ex: "An error occurred while processing %1$s : %2$s
    *
    * @param context to retrieve the localized messages and show the toast on
-   * @param tag used to log the error
+   * @param logger of the class that launched the log
    * @param error to log
    * @param action short description of what was happening when the error occurred
    * @param actionArgs arguments to the message
    */
   public static void logAndShow(
-      Context context, String tag, Throwable error, @StringRes int action, String... actionArgs) {
+      Context context,
+      Logger logger,
+      Throwable error,
+      @StringRes int action,
+      String... actionArgs) {
     String exceptionMsg = getLocalizedMessage(context, error, action, actionArgs);
 
-    Log.e(tag, exceptionMsg, error);
+    logger.error(exceptionMsg, error);
     displayToast(context, exceptionMsg);
   }
 
@@ -78,9 +85,7 @@ public class ErrorUtils {
     } else {
       // It is not a known error, let's log it but not show information to
       // the average user as it will not be useful to him.
-      Log.d(
-          ErrorUtils.class.getSimpleName(),
-          "Error " + error.getClass() + " is not a know error type.");
+      logger.debug("Error " + error.getClass() + " is not a know error type.");
       return "";
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/MessageHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/MessageHandler.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.utility.handler;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
 import com.github.dedis.popstellar.model.network.method.message.data.*;
 import com.github.dedis.popstellar.model.objects.Channel;
@@ -11,6 +9,9 @@ import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
 import com.github.dedis.popstellar.utility.handler.data.HandlerContext;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -18,7 +19,7 @@ import javax.inject.Singleton;
 @Singleton
 public final class MessageHandler {
 
-  public static final String TAG = MessageHandler.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(MessageHandler.class);
 
   private final MessageRepository messageRepo;
   private final DataRegistry registry;
@@ -39,15 +40,15 @@ public final class MessageHandler {
   public void handleMessage(MessageSender messageSender, Channel channel, MessageGeneral message)
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
           UnknownElectionException, NoRollCallException {
-    Log.d(TAG, "handle incoming message");
+    logger.debug("handle incoming message");
 
     if (messageRepo.isMessagePresent(message.getMessageId())) {
-      Log.d(TAG, "the message has already been handled in the past");
+      logger.debug("the message has already been handled in the past");
       return;
     }
 
     Data data = message.getData();
-    Log.d(TAG, "data with class: " + data.getClass());
+    logger.debug("data with class: " + data.getClass());
     Objects dataObj = Objects.find(data.getObject());
     Action dataAction = Action.find(data.getAction());
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ChirpHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ChirpHandler.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.utility.handler.data;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.network.method.message.data.socialmedia.AddChirp;
 import com.github.dedis.popstellar.model.network.method.message.data.socialmedia.DeleteChirp;
 import com.github.dedis.popstellar.model.objects.Channel;
@@ -14,12 +12,15 @@ import com.github.dedis.popstellar.repository.SocialMediaRepository;
 import com.github.dedis.popstellar.utility.error.InvalidMessageIdException;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import javax.inject.Inject;
 
 /** Chirp messages handler class */
 public final class ChirpHandler {
 
-  public static final String TAG = ChirpHandler.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(ChirpHandler.class);
 
   private final LAORepository laoRepo;
   private final SocialMediaRepository socialMediaRepo;
@@ -41,7 +42,7 @@ public final class ChirpHandler {
     MessageID messageId = context.getMessageId();
     PublicKey senderPk = context.getSenderPk();
 
-    Log.d(TAG, "handleChirpAdd: " + channel + " id " + addChirp.getParentId());
+    logger.debug("handleChirpAdd: " + channel + " id " + addChirp.getParentId());
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
     Chirp chirp =
         new Chirp(
@@ -64,7 +65,7 @@ public final class ChirpHandler {
       throws UnknownLaoException, InvalidMessageIdException {
     Channel channel = context.getChannel();
 
-    Log.d(TAG, "handleDeleteChirp: " + channel + " id " + deleteChirp.getChirpId());
+    logger.debug("handleDeleteChirp: " + channel + " id " + deleteChirp.getChirpId());
 
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
     boolean chirpExist = socialMediaRepo.deleteChirp(laoView.getId(), deleteChirp.getChirpId());

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ConsensusHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ConsensusHandler.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.utility.handler.data;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.network.method.message.data.Data;
 import com.github.dedis.popstellar.model.network.method.message.data.consensus.*;
 import com.github.dedis.popstellar.model.objects.*;
@@ -11,6 +9,9 @@ import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.repository.LAORepository;
 import com.github.dedis.popstellar.utility.error.*;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.Optional;
 import java.util.Set;
 
@@ -18,7 +19,7 @@ import javax.inject.Inject;
 
 public final class ConsensusHandler {
 
-  public static final String TAG = ConsensusHandler.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(ConsensusHandler.class);
 
   private final LAORepository laoRepo;
 
@@ -39,7 +40,7 @@ public final class ConsensusHandler {
     MessageID messageId = context.getMessageId();
     PublicKey senderPk = context.getSenderPk();
 
-    Log.d(TAG, "handleElect: " + channel + " id " + consensusElect.getInstanceId());
+    logger.debug("handleElect: " + channel + " id " + consensusElect.getInstanceId());
 
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
     Set<PublicKey> nodes = laoView.getWitnesses();
@@ -60,13 +61,13 @@ public final class ConsensusHandler {
     MessageID messageId = context.getMessageId();
     PublicKey senderPk = context.getSenderPk();
 
-    Log.d(TAG, "handleElectAccept: " + channel + " id " + consensusElectAccept.getInstanceId());
+    logger.debug("handleElectAccept: " + channel + " id " + consensusElectAccept.getInstanceId());
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     Optional<ElectInstance> electInstanceOpt =
         laoView.getElectInstance(consensusElectAccept.getMessageId());
     if (!electInstanceOpt.isPresent()) {
-      Log.w(TAG, "elect_accept for invalid messageId : " + consensusElectAccept.getMessageId());
+      logger.warn("elect_accept for invalid messageId : " + consensusElectAccept.getMessageId());
       throw new InvalidMessageIdException(
           consensusElectAccept, consensusElectAccept.getMessageId());
     }
@@ -82,20 +83,20 @@ public final class ConsensusHandler {
 
   @SuppressWarnings("unused")
   public <T extends Data> void handleBackend(HandlerContext context, T data) {
-    Log.w(TAG, "Received a consensus message only for backend with action=" + data.getAction());
+    logger.warn("Received a consensus message only for backend with action=" + data.getAction());
   }
 
   public void handleLearn(HandlerContext context, ConsensusLearn consensusLearn)
       throws DataHandlingException, UnknownLaoException {
     Channel channel = context.getChannel();
 
-    Log.d(TAG, "handleLearn: " + channel + " id " + consensusLearn.getInstanceId());
+    logger.debug("handleLearn: " + channel + " id " + consensusLearn.getInstanceId());
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     Optional<ElectInstance> electInstanceOpt =
         laoView.getElectInstance(consensusLearn.getMessageId());
     if (!electInstanceOpt.isPresent()) {
-      Log.w(TAG, "learn for invalid messageId : " + consensusLearn.getMessageId());
+      logger.warn("learn for invalid messageId : " + consensusLearn.getMessageId());
       throw new InvalidMessageIdException(consensusLearn, consensusLearn.getMessageId());
     }
 
@@ -115,12 +116,12 @@ public final class ConsensusHandler {
       throws UnknownLaoException, InvalidMessageIdException {
     Channel channel = context.getChannel();
 
-    Log.d(TAG, "handleConsensusFailure: " + channel + " id " + failure.getInstanceId());
+    logger.debug("handleConsensusFailure: " + channel + " id " + failure.getInstanceId());
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     Optional<ElectInstance> electInstanceOpt = laoView.getElectInstance(failure.getMessageId());
     if (!electInstanceOpt.isPresent()) {
-      Log.w(TAG, "Failure for invalid messageId : " + failure.getMessageId());
+      logger.warn("Failure for invalid messageId : " + failure.getMessageId());
       throw new InvalidMessageIdException(failure, failure.getMessageId());
     }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.utility.handler.data;
 
 import android.annotation.SuppressLint;
-import android.util.Log;
 
 import com.github.dedis.popstellar.model.network.method.message.data.rollcall.*;
 import com.github.dedis.popstellar.model.objects.*;
@@ -14,6 +13,9 @@ import com.github.dedis.popstellar.repository.*;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 import com.github.dedis.popstellar.utility.error.UnknownRollCallException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -21,7 +23,7 @@ import javax.inject.Inject;
 /** Roll Call messages handler class */
 public final class RollCallHandler {
 
-  public static final String TAG = RollCallHandler.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(RollCallHandler.class);
 
   private static final String ROLL_CALL_NAME = "Roll Call Name : ";
   private static final String MESSAGE_ID = "Message ID : ";
@@ -51,7 +53,7 @@ public final class RollCallHandler {
     Channel channel = context.getChannel();
     MessageID messageId = context.getMessageId();
 
-    Log.d(TAG, "handleCreateRollCall: " + channel + " name " + createRollCall.getName());
+    logger.debug("handleCreateRollCall: " + channel + " name " + createRollCall.getName());
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     RollCallBuilder builder = new RollCallBuilder();
@@ -86,7 +88,7 @@ public final class RollCallHandler {
     Channel channel = context.getChannel();
     MessageID messageId = context.getMessageId();
 
-    Log.d(TAG, "handleOpenRollCall: " + channel + " msg=" + openRollCall);
+    logger.debug("handleOpenRollCall: " + channel + " msg=" + openRollCall);
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     String updateId = openRollCall.getUpdateId();
@@ -126,7 +128,7 @@ public final class RollCallHandler {
     Channel channel = context.getChannel();
     MessageID messageId = context.getMessageId();
 
-    Log.d(TAG, "handleCloseRollCall: " + channel);
+    logger.debug("handleCloseRollCall: " + channel);
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     String updateId = closeRollCall.getUpdateId();
@@ -168,8 +170,8 @@ public final class RollCallHandler {
                     .getMessageSender()
                     .subscribe(channel.subChannel("social").subChannel(token.getEncoded()))
                     .subscribe(
-                        () -> Log.d(TAG, "subscription a success"),
-                        error -> Log.d(TAG, "subscription error")));
+                        () -> logger.debug("subscription a success"),
+                        error -> logger.debug("subscription error")));
 
     laoRepo.updateLao(lao);
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/TransactionCoinHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/TransactionCoinHandler.java
@@ -1,19 +1,20 @@
 package com.github.dedis.popstellar.utility.handler.data;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.network.method.message.data.digitalcash.*;
 import com.github.dedis.popstellar.model.objects.*;
 import com.github.dedis.popstellar.model.objects.digitalcash.*;
 import com.github.dedis.popstellar.repository.DigitalCashRepository;
 import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.*;
 
 import javax.inject.Inject;
 
 public class TransactionCoinHandler {
-  public static final String TAG = TransactionCoinHandler.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(TransactionCoinHandler.class);
   private final DigitalCashRepository digitalCashRepo;
 
   @Inject
@@ -31,7 +32,7 @@ public class TransactionCoinHandler {
       HandlerContext context, PostTransactionCoin postTransactionCoin) throws NoRollCallException {
     Channel channel = context.getChannel();
 
-    Log.d(TAG, "handlePostTransactionCoin: " + channel + " msg=" + postTransactionCoin);
+    logger.debug("handlePostTransactionCoin: " + channel + " msg=" + postTransactionCoin);
 
     // inputs and outputs for the creation
     List<InputObject> inputs = new ArrayList<>();

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/Hash.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/Hash.java
@@ -1,6 +1,7 @@
 package com.github.dedis.popstellar.utility.security;
 
-import android.util.Log;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -10,7 +11,7 @@ import java.util.Base64;
 /** SHA256 Hashing Class */
 public class Hash {
 
-  public static final String TAG = Hash.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(Hash.class);
 
   /**
    * Hash some objects using SHA256. Concatenate the object's string representation following the
@@ -39,7 +40,7 @@ public class Hash {
       byte[] digestBuf = digest.digest();
       return Base64.getUrlEncoder().encodeToString(digestBuf);
     } catch (NoSuchAlgorithmException e) {
-      Log.e(TAG, "failed to hash", e);
+      logger.error("failed to hash", e);
       throw new UnsupportedOperationException("failed to retrieve SHA-256 instance", e);
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/KeyManager.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/KeyManager.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.utility.security;
 
-import android.util.Log;
-
 import androidx.annotation.VisibleForTesting;
 
 import com.github.dedis.popstellar.model.objects.RollCall;
@@ -13,6 +11,9 @@ import com.github.dedis.popstellar.utility.error.keys.*;
 import com.google.crypto.tink.*;
 import com.google.crypto.tink.integration.android.AndroidKeysetManager;
 import com.google.gson.*;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,7 +30,7 @@ import static com.github.dedis.popstellar.di.KeysetModule.DeviceKeyset;
 @Singleton
 public class KeyManager {
 
-  private static final String TAG = KeyManager.class.getSimpleName();
+  private static final Logger logger = LogManager.getLogger(KeyManager.class);
 
   private final AndroidKeysetManager keysetManager;
   private final Wallet wallet;
@@ -42,9 +43,9 @@ public class KeyManager {
 
     try {
       cacheMainKey();
-      Log.d(TAG, "Public Key = " + getMainPublicKey().getEncoded());
+      logger.debug("Public Key = " + getMainPublicKey().getEncoded());
     } catch (IOException | GeneralSecurityException e) {
-      Log.e(TAG, "Failed to retrieve device's key", e);
+      logger.error("Failed to retrieve device's key", e);
       throw new IllegalStateException("Failed to retrieve device's key", e);
     }
   }

--- a/fe2-android/app/src/main/res/drawable/home_icon.xml
+++ b/fe2-android/app/src/main/res/drawable/home_icon.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="30dp"
+  android:height="30dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24">
+  <path
+    android:fillColor="@android:color/white"
+    android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z" />
+</vector>

--- a/fe2-android/app/src/main/res/layout/home_activity.xml
+++ b/fe2-android/app/src/main/res/layout/home_activity.xml
@@ -18,7 +18,8 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:theme="@style/toolbar_style"
-        app:menu="@menu/options_menu" />
+        app:menu="@menu/options_menu"
+        app:navigationIcon="@drawable/home_icon" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout

--- a/fe2-android/app/src/main/res/layout/settings_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/settings_fragment.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/fragment_settings"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/fe2-android/app/src/main/res/layout/settings_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/settings_fragment.xml
@@ -3,7 +3,5 @@
   <androidx.constraintlayout.widget.ConstraintLayout
     android:id="@+id/fragment_settings"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-  </androidx.constraintlayout.widget.ConstraintLayout>
+    android:layout_height="match_parent"></androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/fe2-android/app/src/main/res/menu/options_menu.xml
+++ b/fe2-android/app/src/main/res/menu/options_menu.xml
@@ -8,4 +8,8 @@
     android:id="@+id/clear_storage"
     android:title="@string/clear_text"
     />
+  <item
+    android:id="@+id/home_settings"
+    android:title="@string/settings"
+    />
 </menu>

--- a/fe2-android/app/src/main/res/raw/log4j2.xml
+++ b/fe2-android/app/src/main/res/raw/log4j2.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console
+      name="console"
+      target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
+    </Console>
+    <Socket
+      name="socket"
+      host="${sys:logstash.host}"
+      port="${sys:logstash.port}"
+      protocol="tcp"
+      bufferedIo="true">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
+    </Socket>
+  </Appenders>
+  <Loggers>
+    <Root level="debug">
+      <AppenderRef ref="console" />
+      <if condition='${sys:enableRemoteLogging} == "true"'>
+        <then>
+          <AppenderRef ref="socket" />
+        </then>
+      </if>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -33,7 +33,8 @@
   <string name="settings">Settings</string>
   <string name="settings_debugging">Debugging</string>
   <string name="settings_logging">Logging</string>
-  <string name="settings_logging_summary">Check the box if you want to send logs to a server for remote debugging</string>
+  <string name="settings_logging_summary_off">Check the box if you want to send logs to a server for remote debugging</string>
+  <string name="settings_logging_summary_on">Uncheck the box if you want to stop sending logs to a server for remote debugging</string>
   <string name="settings_enable_logging_confirmation">Are you sure you want to enable logging? This can impact on app performance</string>
 
   <!-- Connect -->

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -29,6 +29,13 @@
   <string name="server_url">Server URL</string>
   <string name="no_lao_text">OOPS, Looks like you don\'t have any Local Autonomous Organization (LAO) yet.\n Join or Create one with the buttons below</string>
 
+  <!-- Settings -->
+  <string name="settings">Settings</string>
+  <string name="settings_debugging">Debugging</string>
+  <string name="settings_logging">Logging</string>
+  <string name="settings_logging_summary">Check the box if you want to send logs to a server for remote debugging</string>
+  <string name="settings_enable_logging_confirmation">Are you sure you want to enable logging? This can impact on app performance</string>
+
   <!-- Connect -->
   <string name="allow_camera_text">Please allow the camera to be used by the app</string>
   <string name="allow_camera_button">Allow Camera</string>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-  <string name="app_name">popstellar</string>
+  <string name="app_name">Popstellar</string>
 
   <!--  General-->
   <string name="yes">Yes</string>
@@ -28,6 +28,7 @@
   <string name="create">Create</string>
   <string name="server_url">Server URL</string>
   <string name="no_lao_text">OOPS, Looks like you don\'t have any Local Autonomous Organization (LAO) yet.\n Join or Create one with the buttons below</string>
+  <string name="app_info">Welcome to POPstellar, a Proof-Of-Personhood system developed by the DEDIS lab!</string>
 
   <!-- Settings -->
   <string name="settings">Settings</string>

--- a/fe2-android/app/src/main/res/xml/settings_preferences.xml
+++ b/fe2-android/app/src/main/res/xml/settings_preferences.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <PreferenceCategory android:title="@string/settings_debugging">
+
+    <SwitchPreference
+      android:key="enable_logging"
+      android:title="@string/settings_logging"
+      android:summary="@string/settings_logging_summary"
+      android:defaultValue="false" />
+
+  </PreferenceCategory>
+
+</PreferenceScreen>

--- a/fe2-android/app/src/main/res/xml/settings_preferences.xml
+++ b/fe2-android/app/src/main/res/xml/settings_preferences.xml
@@ -6,7 +6,8 @@
     <SwitchPreference
       android:key="enable_logging"
       android:title="@string/settings_logging"
-      android:summary="@string/settings_logging_summary"
+      android:summaryOff="@string/settings_logging_summary_off"
+      android:summaryOn="@string/settings_logging_summary_on"
       android:defaultValue="false" />
 
   </PreferenceCategory>


### PR DESCRIPTION
This PR aims to:
- introduce the settings tab in the application
- give the user the possibility to activate the remote logging. Very often during the POP party we are encountering issues like #1489 and we cannot either reproduce them or see the logs to try to fix. So the idea is to enable an option in the settings which sends to a server all the logs
- switched to log4j2 library for logging, as it can handle much simpler the socket through which sending logs