### PR TITLE
Add support for responses with map.

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/model/network/ResultObject.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/model/network/ResultObject.scala
@@ -1,19 +1,22 @@
 package ch.epfl.pop.model.network
 
 import ch.epfl.pop.model.network.method.message.Message
+import ch.epfl.pop.model.objects.Channel
 
-class ResultObject(val resultInt: Option[Int], val resultMessages: Option[List[Message]]) {
+class ResultObject(val resultInt: Option[Int], val resultMessages: Option[List[Message]], val resultMap: Option[Map[Channel, Set[Message]]]) {
 
-  def this(result: Int) = this(Some(result), None)
+  def this(result: Int) = this(Some(result), None, None)
 
-  def this(result: List[Message]) = this(None, Some(result))
+  def this(result: List[Message]) = this(None, Some(result), None)
+
+  def this(mapResult: Map[Channel, Set[Message]]) = this(None, None, Some(mapResult))
 
   def isIntResult: Boolean = resultInt.isDefined
 
   override def equals(o: Any): Boolean = {
     o match {
       case that: ResultObject =>
-        this.resultInt == that.resultInt && that.resultMessages == this.resultMessages
+        this.resultInt == that.resultInt && that.resultMessages == this.resultMessages && that.resultMap == this.resultMap
       case _ => false
     }
   }

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/network/ResultObjectSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/network/ResultObjectSuite.scala
@@ -1,5 +1,8 @@
+
 package ch.epfl.pop.model.network
 
+import ch.epfl.pop.model.network.method.message.Message
+import ch.epfl.pop.model.objects.Channel
 import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
 import org.scalatest.matchers.should.Matchers
 
@@ -9,31 +12,50 @@ class ResultObjectSuite extends FunSuite with Matchers {
 
     obj.resultInt should equal(Some(1))
     obj.resultMessages should equal(None)
+    obj.resultMap should equal(None)
   }
 
   test("List constructor works") {
     val obj: ResultObject = new ResultObject(List.empty)
 
     obj.resultInt should equal(None)
+    obj.resultMap should equal(None)
     obj.resultMessages should equal(Some(List.empty))
+  }
+
+  test("Map constructor works") {
+    val obj: ResultObject = new ResultObject(Map[Channel, Set[Message]]())
+
+    obj.resultInt should equal(None)
+    obj.resultMessages should equal(None)
+    obj.resultMap should equal(Some(Map.empty))
+
   }
 
   test("isIntResult returns right result") {
     val obj: ResultObject = new ResultObject(1)
     val obj2: ResultObject = new ResultObject(List.empty)
+    val obj3: ResultObject = new ResultObject(Map[Channel, Set[Message]]())
 
     obj.isIntResult should equal(true)
     obj2.isIntResult should equal(false)
+    obj3.isIntResult should equal(false)
+
   }
 
   test("equals works") {
     val obj: ResultObject = new ResultObject(1)
     val obj2: ResultObject = new ResultObject(List.empty)
+    val obj5: ResultObject = new ResultObject(Map[Channel, Set[Message]]())
     val obj3: ResultObject = new ResultObject(1)
     val obj4: ResultObject = new ResultObject(List.empty)
+    val obj6: ResultObject = new ResultObject(Map[Channel, Set[Message]]())
 
     obj.equals(obj3) should equal(true)
     obj2.equals(obj4) should equal(true)
     obj2.equals(obj) should equal(false)
+    obj5.equals(obj6) should equal(true)
+    obj5.equals(obj) should equal(false)
+    obj6.equals(obj2) should equal(false)
   }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/model/network/ResultObjectSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/model/network/ResultObjectSuite.scala
@@ -1,4 +1,3 @@
-
 package ch.epfl.pop.model.network
 
 import ch.epfl.pop.model.network.method.message.Message


### PR DESCRIPTION
This little pull request adds a map parameter to the ResultObject Type so that the server can send the map of missing ids when receiving a heartbeat as a response.