### PR TITLE
Enable remote logging and implement settings

### DIFF
--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -219,6 +219,7 @@ dependencies {
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'me.relex:circleindicator:2.1.6'
+    implementation 'com.takisoft.fix:preference-v7:27.0.0.0'
 
     // ================ Rx Java =================
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'

--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -278,6 +278,9 @@ dependencies {
     testImplementation "org.slf4j:slf4j-api:$slf4j_version"
     testImplementation "org.slf4j:slf4j-simple:$slf4j_version"
 
+    // ================== Timber =================
+    implementation 'com.jakewharton.timber:timber:5.0.1'
+
     // ================= Pretty Time =================
     implementation 'org.ocpsoft.prettytime:prettytime:5.0.4.Final'
 

--- a/fe2-android/app/build.gradle
+++ b/fe2-android/app/build.gradle
@@ -219,7 +219,8 @@ dependencies {
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'me.relex:circleindicator:2.1.6'
-    implementation 'com.takisoft.fix:preference-v7:27.0.0.0'
+    implementation "androidx.preference:preference:1.2.0"
+    implementation 'com.takisoft.preferencex:preferencex:1.1.0'
 
     // ================ Rx Java =================
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/PoPApplication.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/PoPApplication.java
@@ -2,7 +2,10 @@ package com.github.dedis.popstellar;
 
 import android.app.Application;
 
+import com.github.dedis.popstellar.utility.NetworkLogger;
+
 import dagger.hilt.android.HiltAndroidApp;
+import timber.log.Timber;
 
 /**
  * Application object of the app
@@ -10,4 +13,11 @@ import dagger.hilt.android.HiltAndroidApp;
  * <p>For now, it is only used by Hilt as an entry point. It extract the object's lifecycle.
  */
 @HiltAndroidApp
-public class PoPApplication extends Application {}
+public class PoPApplication extends Application {
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    // Associate the custom logger to Timber
+    Timber.plant(new NetworkLogger());
+  }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/PoPApplication.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/PoPApplication.java
@@ -18,6 +18,7 @@ public class PoPApplication extends Application {
   public void onCreate() {
     super.onCreate();
     // Associate the custom logger to Timber
-    Timber.plant(new NetworkLogger(getApplicationContext()));
+    NetworkLogger.loadFromPersistPreference(getApplicationContext());
+    Timber.plant(new NetworkLogger());
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/PoPApplication.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/PoPApplication.java
@@ -18,6 +18,6 @@ public class PoPApplication extends Application {
   public void onCreate() {
     super.onCreate();
     // Associate the custom logger to Timber
-    Timber.plant(new NetworkLogger());
+    Timber.plant(new NetworkLogger(getApplicationContext()));
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/PoPApplication.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/PoPApplication.java
@@ -18,7 +18,7 @@ public class PoPApplication extends Application {
   public void onCreate() {
     super.onCreate();
     // Associate the custom logger to Timber
-    NetworkLogger.loadFromPersistPreference(getApplicationContext());
+    NetworkLogger.loadFromPersistPreference(this);
     Timber.plant(new NetworkLogger());
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/di/KeysetModule.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/di/KeysetModule.java
@@ -2,7 +2,6 @@ package com.github.dedis.popstellar.di;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.util.Log;
 
 import com.google.crypto.tink.KeyTemplates;
 import com.google.crypto.tink.aead.AeadConfig;
@@ -26,6 +25,7 @@ import dagger.Provides;
 import dagger.hilt.InstallIn;
 import dagger.hilt.android.qualifiers.ApplicationContext;
 import dagger.hilt.components.SingletonComponent;
+import timber.log.Timber;
 
 @Module
 @InstallIn(SingletonComponent.class)
@@ -76,7 +76,7 @@ public class KeysetModule {
 
       return future.join();
     } catch (GeneralSecurityException e) {
-      Log.e(TAG, "Could not retrieve the device keyset from the app", e);
+      Timber.tag(TAG).e(e, "Could not retrieve the device keyset from the app");
       throw new SecurityException("Could not retrieve the device keyset from the app", e);
     }
   }
@@ -108,7 +108,7 @@ public class KeysetModule {
 
       return future.join();
     } catch (GeneralSecurityException e) {
-      Log.e(TAG, "Could not retrieve the wallet keyset from the app", e);
+      Timber.tag(TAG).e(e, "Could not retrieve the wallet keyset from the app");
       throw new SecurityException("Could not retrieve the wallet keyset from the app", e);
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/MessageGeneral.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/MessageGeneral.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.model.network.method.message;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 
 import com.github.dedis.popstellar.model.Immutable;
@@ -13,6 +11,8 @@ import com.google.gson.Gson;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.*;
+
+import timber.log.Timber;
 
 /**
  * Container of a high level message.
@@ -51,7 +51,7 @@ public final class MessageGeneral {
     sender = keyPair.getPublicKey();
     this.data = data;
     String dataJson = gson.toJson(data, Data.class);
-    Log.d(TAG, dataJson);
+    Timber.tag(TAG).d(dataJson);
     dataBuf = new Base64URLData(dataJson.getBytes(StandardCharsets.UTF_8));
 
     generateSignature(keyPair.getPrivateKey());
@@ -68,7 +68,7 @@ public final class MessageGeneral {
     try {
       signature = signer.sign(dataBuf);
     } catch (GeneralSecurityException e) {
-      Log.d(TAG, "failed to generate signature", e);
+      Timber.tag(TAG).d(e, "failed to generate signature");
     }
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/DataRegistry.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/DataRegistry.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.model.network.method.message.data;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -12,8 +10,12 @@ import com.github.dedis.popstellar.utility.handler.data.HandlerContext;
 
 import java.util.*;
 
+import timber.log.Timber;
+
 /** A registry of Data classes and handlers */
 public final class DataRegistry {
+
+  private static final String TAG = DataRegistry.class.getSimpleName();
 
   /** A mapping of (object, action) -> (class, handler) */
   private final Map<EntryPair, Entry<? extends Data>> mapping;
@@ -30,7 +32,7 @@ public final class DataRegistry {
    * @return the class assigned to the pair or empty if none are defined
    */
   public Optional<Class<? extends Data>> getType(Objects obj, Action action) {
-    Log.d("data", "getting data type");
+    Timber.tag(TAG).d("getting data type");
     return Optional.ofNullable(mapping.get(pair(obj, action))).map(Entry::getDataClass);
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonGenericMessageDeserializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonGenericMessageDeserializer.java
@@ -1,13 +1,13 @@
 package com.github.dedis.popstellar.model.network.serializer;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.network.GenericMessage;
 import com.github.dedis.popstellar.model.network.answer.Answer;
 import com.github.dedis.popstellar.model.network.method.Message;
 import com.google.gson.*;
 
 import java.lang.reflect.Type;
+
+import timber.log.Timber;
 
 /** Json deserializer for the generic messages */
 public class JsonGenericMessageDeserializer implements JsonDeserializer<GenericMessage> {
@@ -18,7 +18,7 @@ public class JsonGenericMessageDeserializer implements JsonDeserializer<GenericM
   public GenericMessage deserialize(
       JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
-    Log.d(TAG, "deserializing generic message");
+    Timber.tag(TAG).d("deserializing generic message");
     if (json.getAsJsonObject().has(METHOD)) {
       return context.deserialize(json, Message.class);
     } else {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonMessageSerializer.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonMessageSerializer.java
@@ -1,19 +1,21 @@
 package com.github.dedis.popstellar.model.network.serializer;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.network.method.*;
 import com.google.gson.*;
 
 import java.lang.reflect.Type;
 
+import timber.log.Timber;
+
 /** Json serializer and deserializer for the low level messages */
 public class JsonMessageSerializer implements JsonSerializer<Message>, JsonDeserializer<Message> {
+
+  private static final String TAG = JsonMessageSerializer.class.getSimpleName();
 
   @Override
   public Message deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
-    Log.d("deserializer", "deserializing message");
+    Timber.tag(TAG).d("deserializing message");
     JSONRPCRequest container = context.deserialize(json, JSONRPCRequest.class);
     JsonUtils.testRPCVersion(container.getJsonrpc());
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/serializer/JsonUtils.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.model.network.serializer;
 
-import android.util.Log;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.JsonObject;
@@ -11,6 +9,8 @@ import com.networknt.schema.*;
 import java.net.URI;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+
+import timber.log.Timber;
 
 /** Json utility class */
 public final class JsonUtils {
@@ -71,7 +71,7 @@ public final class JsonUtils {
    * @throws JsonParseException if the json is invalid or cannot be parsed
    */
   public static void verifyJson(String schemaPath, String json) throws JsonParseException {
-    Log.d(TAG, "verifyJson for : " + json);
+    Timber.tag(TAG).d("verifyJson for : %s", json);
 
     JsonSchema schema = loadSchema(schemaPath);
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Wallet.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/Wallet.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.model.objects;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 
 import com.github.dedis.popstellar.di.KeysetModule.WalletKeyset;
@@ -26,6 +24,7 @@ import javax.inject.Singleton;
 import io.github.novacrypto.bip39.*;
 import io.github.novacrypto.bip39.Validation.*;
 import io.github.novacrypto.bip39.wordlists.English;
+import timber.log.Timber;
 
 /**
  * This class represent a wallet that will enable users to store their PoP tokens with reasonable,
@@ -47,7 +46,7 @@ public class Wallet {
     try {
       aead = keysetManager.getKeysetHandle().getPrimitive(Aead.class);
     } catch (GeneralSecurityException e) {
-      Log.e(TAG, "Failed to initialize the Wallet", e);
+      Timber.tag(TAG).e(e, "Failed to initialize the Wallet");
       throw new IllegalStateException("Failed to initialize the Wallet", e);
     }
   }
@@ -73,7 +72,7 @@ public class Wallet {
             convertDataToPath(laoID),
             convertDataToPath(rollCallID));
 
-    Log.d(TAG, "Generated path: " + res);
+    Timber.tag(TAG).d("Generated path: %s", res);
 
     return generateKeyFromPath(res);
   }
@@ -111,7 +110,7 @@ public class Wallet {
     }
     byte[] decryptedBytes = aead.decrypt(encryptedMnemonic, new byte[0]);
     String words = new String(decryptedBytes, StandardCharsets.UTF_8);
-    Log.d(TAG, "Mnemonic words successfully decrypted for export");
+    Timber.tag(TAG).d("Mnemonic words successfully decrypted for export");
     return words.split(" ");
   }
 
@@ -131,7 +130,7 @@ public class Wallet {
       throw new SeedValidationException(e);
     }
     storeEncrypted(words);
-    Log.d(TAG, "Mnemonic words were successfully imported");
+    Timber.tag(TAG).d("Mnemonic words were successfully imported");
   }
 
   /**
@@ -145,7 +144,7 @@ public class Wallet {
 
   /** Logout the wallet by replacing the seed by a random one */
   public void logout() {
-    Log.d(TAG, "Logged out of wallet");
+    Timber.tag(TAG).d("Logged out of wallet");
     encryptedSeed = null;
     encryptedMnemonic = null;
   }
@@ -165,7 +164,7 @@ public class Wallet {
     encryptedSeed =
         aead.encrypt(
             new SeedCalculator().calculateSeed(String.join("", mnemonicWords), ""), new byte[0]);
-    Log.d(TAG, "Mnemonic words and seed successfully encrypted");
+    Timber.tag(TAG).d("Mnemonic words and seed successfully encrypted");
   }
 
   /**

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/PublicKey.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/PublicKey.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.model.objects.security;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.Immutable;
 import com.google.crypto.tink.PublicKeyVerify;
 import com.google.crypto.tink.subtle.Ed25519Verify;
@@ -9,6 +7,8 @@ import com.google.crypto.tink.subtle.Ed25519Verify;
 import java.security.*;
 import java.util.Arrays;
 import java.util.Base64;
+
+import timber.log.Timber;
 
 /** A public key that can be used to verify a signature */
 @Immutable
@@ -33,7 +33,7 @@ public class PublicKey extends Base64URLData {
       verifier.verify(signature.getData(), data.getData());
       return true;
     } catch (GeneralSecurityException e) {
-      Log.d(TAG, "failed to verify witness signature " + e.getMessage());
+      Timber.tag(TAG).d("failed to verify witness signature %s", e.getMessage());
       return false;
     }
   }
@@ -44,13 +44,13 @@ public class PublicKey extends Base64URLData {
    * @return String which correspond to the SHA256 Hash
    */
   public String computeHash() {
-    MessageDigest digest = null;
+    MessageDigest digest;
     try {
       digest = MessageDigest.getInstance("SHA-256");
       byte[] hash = digest.digest(this.getData());
       return Base64.getUrlEncoder().encodeToString(Arrays.copyOf(hash, 20));
     } catch (NoSuchAlgorithmException e) {
-      Log.e(TAG, "Something is wrong by hashing the String element ");
+      Timber.tag(TAG).e(e, "Something is wrong by hashing the String element");
       throw new IllegalArgumentException("Error in computing the hash in public key");
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/elGamal/ElectionPublicKey.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/elGamal/ElectionPublicKey.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.model.objects.security.elGamal;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.objects.security.Base64URLData;
 
 import java.io.ByteArrayOutputStream;
@@ -12,9 +10,12 @@ import java.util.Objects;
 import ch.epfl.dedis.lib.crypto.*;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import io.reactivex.annotations.NonNull;
+import timber.log.Timber;
 
 /** Represents a private key meant for El-Gam */
 public class ElectionPublicKey {
+
+  private static final String TAG = ElectionPublicKey.class.getSimpleName();
 
   // Point is generate with given public key
   private final Point publicKey;
@@ -106,9 +107,9 @@ public class ElectionPublicKey {
       output.write(C.toBytes());
       result = output.toByteArray();
     } catch (IOException e) {
-      Log.d(
-          "Encryption: ",
-          "Something happened during the encryption, could concatenate the final result into a byte array");
+      Timber.tag(TAG)
+          .d(
+              "Something happened during the encryption, could concatenate the final result into a byte array");
       result = null;
     }
     if (Objects.isNull(result)) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/elGamal/ElectionPublicKey.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/security/elGamal/ElectionPublicKey.java
@@ -109,7 +109,7 @@ public class ElectionPublicKey {
     } catch (IOException e) {
       Timber.tag(TAG)
           .d(
-              "Something happened during the encryption, could concatenate the final result into a byte array");
+              "Something happened during the encryption, could NOT concatenate the final result into a byte array");
       result = null;
     }
     if (Objects.isNull(result)) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/DigitalCashRepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/DigitalCashRepository.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.repository;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.objects.OutputObject;
 import com.github.dedis.popstellar.model.objects.digitalcash.TransactionObject;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
@@ -17,6 +15,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.Subject;
+import timber.log.Timber;
 
 @Singleton
 public class DigitalCashRepository {
@@ -45,7 +44,7 @@ public class DigitalCashRepository {
 
   public void updateTransactions(String laoId, TransactionObject transaction)
       throws NoRollCallException {
-    Log.d(TAG, "updating transactions on Lao " + laoId + " and transaction " + transaction);
+    Timber.tag(TAG).d("updating transactions on Lao %s and transaction %s", laoId, transaction);
     getLaoTransactions(laoId).updateTransactions(transaction);
   }
 
@@ -76,7 +75,7 @@ public class DigitalCashRepository {
       transactionsSubject.values().forEach(Observer::onComplete);
       transactionsSubject.clear();
       attendees.forEach(publicKey -> hashDictionary.put(publicKey.computeHash(), publicKey));
-      Log.d(TAG, "initializing digital cash with attendees " + attendees);
+      Timber.tag(TAG).d("initializing digital cash with attendees %s", attendees);
     }
 
     public synchronized void updateTransactions(TransactionObject transaction)

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.repository;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.objects.*;
 import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
@@ -14,6 +12,7 @@ import javax.inject.Singleton;
 import io.reactivex.Observable;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.Subject;
+import timber.log.Timber;
 
 @Singleton
 public class LAORepository {
@@ -42,7 +41,7 @@ public class LAORepository {
    * @return the Lao corresponding to this channel
    */
   public Lao getLaoByChannel(Channel channel) {
-    Log.d(TAG, "querying lao for channel " + channel);
+    Timber.tag(TAG).d("querying lao for channel %s", channel);
     return laoById.get(channel.extractLaoId());
   }
 
@@ -69,7 +68,7 @@ public class LAORepository {
   }
 
   public synchronized void updateLao(Lao lao) {
-    Log.d(TAG, "updating Lao " + lao);
+    Timber.tag(TAG).d("updating Lao %s", lao);
     if (lao == null) {
       throw new IllegalArgumentException();
     }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/RollCallRepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/RollCallRepository.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.repository;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 
 import com.github.dedis.popstellar.model.objects.RollCall;
@@ -18,6 +16,7 @@ import javax.inject.Singleton;
 import io.reactivex.Observable;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.Subject;
+import timber.log.Timber;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableSet;
@@ -49,7 +48,7 @@ public class RollCallRepository {
     if (rollCall == null) {
       throw new IllegalArgumentException("Roll call is null");
     }
-    Log.d(TAG, "Updating roll call on lao " + laoId + " : " + rollCall);
+    Timber.tag(TAG).d("Updating roll call on lao %s : %s", laoId, rollCall);
 
     // Retrieve Lao data and add the roll call to it
     getLaoRollCalls(laoId).update(rollCall);
@@ -150,11 +149,11 @@ public class RollCallRepository {
       // Publish new values on subjects
       if (rollCallSubjects.containsKey(persistentId)) {
         // If it exist we update the subject
-        Log.d(TAG, "Updating existing roll call " + rollCall.getName());
+        Timber.tag(TAG).d("Updating existing roll call %s", rollCall.getName());
         rollCallSubjects.get(persistentId).onNext(rollCall);
       } else {
         // If it does not, we create a new subject
-        Log.d(TAG, "New roll call, subject created for " + rollCall.getName());
+        Timber.tag(TAG).d("New roll call, subject created for %s", rollCall.getName());
         rollCallSubjects.put(persistentId, BehaviorSubject.createDefault(rollCall));
       }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/SocialMediaRepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/SocialMediaRepository.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.repository;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 
 import com.github.dedis.popstellar.model.objects.Chirp;
@@ -16,6 +14,7 @@ import javax.inject.Singleton;
 import io.reactivex.Observable;
 import io.reactivex.subjects.BehaviorSubject;
 import io.reactivex.subjects.Subject;
+import timber.log.Timber;
 
 /**
  * This class is the repository of the social media feature
@@ -43,7 +42,7 @@ public class SocialMediaRepository {
    * @param chirp to add
    */
   public void addChirp(String laoId, Chirp chirp) {
-    Log.d(TAG, "Adding new chirp on lao " + laoId + " : " + chirp);
+    Timber.tag(TAG).d("Adding new chirp on lao %s : %s", laoId, chirp);
     // Retrieve Lao data and add the chirp to it
     getLaoChirps(laoId).add(chirp);
   }
@@ -55,7 +54,7 @@ public class SocialMediaRepository {
    * @return true if a chirp with given id existed
    */
   public boolean deleteChirp(String laoId, MessageID id) {
-    Log.d(TAG, "Deleting chirp on lao " + laoId + " with id " + id);
+    Timber.tag(TAG).d("Deleting chirp on lao %s with id %s", laoId, id);
     return getLaoChirps(laoId).delete(id);
   }
 
@@ -100,7 +99,7 @@ public class SocialMediaRepository {
       MessageID id = chirp.getId();
       Chirp old = chirps.get(id);
       if (old != null) {
-        Log.w(TAG, "A chirp with id " + id + " already exist : " + old);
+        Timber.tag(TAG).w("A chirp with id %s already exist : %s", id, old);
         return;
       }
 
@@ -119,7 +118,7 @@ public class SocialMediaRepository {
       }
 
       if (chirp.isDeleted()) {
-        Log.d(TAG, "The chirp with id " + id + " is already deleted");
+        Timber.tag(TAG).d("The chirp with id %s is already deleted", id);
       } else {
         Subject<Chirp> subject = chirpSubjects.get(id);
         if (subject == null) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/Connection.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/Connection.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.repository.remote;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.network.GenericMessage;
 import com.github.dedis.popstellar.model.network.method.Message;
 import com.tinder.scarlet.*;
@@ -10,6 +8,7 @@ import com.tinder.scarlet.WebSocket.Event.*;
 import io.reactivex.Observable;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.subjects.BehaviorSubject;
+import timber.log.Timber;
 
 /** Represents a single websocket connection that can be closed */
 public class Connection {
@@ -33,7 +32,7 @@ public class Connection {
     disposables.add(
         laoService
             .observeMessage()
-            .doOnNext(msg -> Log.d(TAG, "Received a new message from remote: " + msg))
+            .doOnNext(msg -> Timber.tag(TAG).d("Received a new message from remote: %s", msg))
             .subscribe(messagesSubject::onNext, messagesSubject::onError));
 
     // Add logs on connection state events
@@ -42,7 +41,7 @@ public class Connection {
             .observeWebsocket()
             .subscribe(
                 event -> logEvent(event, url),
-                err -> Log.d(TAG, "Error in connection " + url, err)));
+                err -> Timber.tag(TAG).d(err, "Error in connection %s", url)));
   }
 
   protected Connection(Connection connection) {
@@ -56,16 +55,16 @@ public class Connection {
     String baseMsg = "Connection to " + url;
 
     if (event instanceof OnConnectionOpened) {
-      Log.i(TAG, baseMsg + " opened");
+      Timber.tag(TAG).i("%s opened", baseMsg);
     } else if (event instanceof OnConnectionClosed) {
       ShutdownReason reason = ((OnConnectionClosed) event).getShutdownReason();
-      Log.i(TAG, baseMsg + " closed: " + reason);
+      Timber.tag(TAG).i("%s closed: %s", baseMsg, reason);
     } else if (event instanceof OnConnectionFailed) {
       Throwable error = ((OnConnectionFailed) event).getThrowable();
-      Log.d(TAG, baseMsg + " failed", error);
+      Timber.tag(TAG).d(error, "%s failed", baseMsg);
     } else if (event instanceof OnConnectionClosing) {
       ShutdownReason reason = ((OnConnectionClosing) event).getShutdownReason();
-      Log.d(TAG, baseMsg + " is closing: " + reason);
+      Timber.tag(TAG).d("%s is closing: %s", baseMsg, reason);
     }
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
@@ -78,6 +78,8 @@ public class HomeActivity extends AppCompatActivity {
             handleWalletSettings();
           } else if (item.getItemId() == R.id.clear_storage) {
             handleClearing();
+          } else if (item.getItemId() == R.id.home_settings) {
+            handleSettings();
           }
           return true;
         });
@@ -168,6 +170,10 @@ public class HomeActivity extends AppCompatActivity {
         .show();
   }
 
+  private void handleSettings() {
+    setCurrentFragment(getSupportFragmentManager(), R.id.fragment_settings, SettingsFragment::new);
+  }
+
   private void restoreStoredState() {
     PersistentData data = ActivityUtils.loadPersistentData(this);
     viewModel.restoreConnections(data);
@@ -175,6 +181,10 @@ public class HomeActivity extends AppCompatActivity {
 
   public static HomeViewModel obtainViewModel(FragmentActivity activity) {
     return new ViewModelProvider(activity).get(HomeViewModel.class);
+  }
+
+  public static SettingsViewModel obtainSettingsViewModel(FragmentActivity activity) {
+    return new ViewModelProvider(activity).get(SettingsViewModel.class);
   }
 
   /** Factory method to create a fresh Intent that opens an HomeActivity */

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
@@ -71,6 +71,12 @@ public class HomeActivity extends AppCompatActivity {
   private void handleTopAppBar() {
     viewModel.getPageTitle().observe(this, binding.topAppBar::setTitle);
 
+    setNavigation();
+    setMenuItemListener();
+    observeWallet();
+  }
+
+  private void setNavigation() {
     // Observe whether the home icon or back arrow should be displayed
     viewModel
         .isHome()
@@ -109,7 +115,9 @@ public class HomeActivity extends AppCompatActivity {
                 .show();
           }
         });
+  }
 
+  private void setMenuItemListener() {
     // Set menu items behaviour
     binding.topAppBar.setOnMenuItemClickListener(
         item -> {
@@ -122,7 +130,9 @@ public class HomeActivity extends AppCompatActivity {
           }
           return true;
         });
+  }
 
+  private void observeWallet() {
     // Listen to wallet status to adapt the menu item title
     viewModel
         .getIsWalletSetUpEvent()
@@ -211,7 +221,8 @@ public class HomeActivity extends AppCompatActivity {
   }
 
   private void handleSettings() {
-    setCurrentFragment(getSupportFragmentManager(), 0, SettingsFragment::newInstance);
+    ActivityUtils.setFragmentInContainer(
+        getSupportFragmentManager(), R.id.fragment_container_home, SettingsFragment::newInstance);
   }
 
   private void restoreStoredState() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.IdRes;
@@ -25,6 +24,7 @@ import java.security.GeneralSecurityException;
 import java.util.function.Supplier;
 
 import dagger.hilt.android.AndroidEntryPoint;
+import timber.log.Timber;
 
 /** HomeActivity represents the entry point for the application. */
 @AndroidEntryPoint
@@ -105,7 +105,7 @@ public class HomeActivity extends AppCompatActivity {
             new MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.app_name)
                 .setMessage(R.string.app_info)
-                .setPositiveButton(R.string.ok, null)
+                .setNeutralButton(R.string.ok, (dialog, which) -> dialog.dismiss())
                 .show();
           }
         });
@@ -147,7 +147,7 @@ public class HomeActivity extends AppCompatActivity {
       viewModel.savePersistentData();
     } catch (GeneralSecurityException e) {
       // We do not display the security error to the user
-      Log.d(TAG, "Storage was unsuccessful due to wallet error " + e);
+      Timber.tag(TAG).d(e, "Storage was unsuccessful due to wallet error");
       Toast.makeText(this, R.string.error_storage_wallet, Toast.LENGTH_SHORT).show();
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
@@ -84,10 +84,10 @@ public class HomeActivity extends AppCompatActivity {
                 Fragment fragment =
                     getSupportFragmentManager().findFragmentById(R.id.fragment_container_home);
                 // If the fragment is not the seed wallet then make the back arrow appear
-                if (!(fragment instanceof SeedWalletFragment)) {
-                  binding.topAppBar.setNavigationIcon(R.drawable.back_arrow_icon);
-                } else {
+                if (fragment instanceof SeedWalletFragment) {
                   binding.topAppBar.setNavigationIcon(null);
+                } else {
+                  binding.topAppBar.setNavigationIcon(R.drawable.back_arrow_icon);
                 }
                 // Disable the overflow menu
                 binding.topAppBar.getMenu().setGroupVisible(0, false);
@@ -211,8 +211,7 @@ public class HomeActivity extends AppCompatActivity {
   }
 
   private void handleSettings() {
-    setCurrentFragment(
-        getSupportFragmentManager(), R.id.fragment_settings, SettingsFragment::newInstance);
+    setCurrentFragment(getSupportFragmentManager(), 0, SettingsFragment::newInstance);
   }
 
   private void restoreStoredState() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.ui.home;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
@@ -69,15 +68,8 @@ public class HomeActivity extends AppCompatActivity {
     }
   }
 
-  @Override
-  public void onResume() {
-    super.onResume();
-  }
-
   private void handleTopAppBar() {
     viewModel.getPageTitle().observe(this, binding.topAppBar::setTitle);
-
-    Drawable overflowMenuIcon = binding.topAppBar.getOverflowIcon();
 
     // Observe whether the home icon or back arrow should be displayed
     viewModel
@@ -87,10 +79,18 @@ public class HomeActivity extends AppCompatActivity {
             isHome -> {
               if (Boolean.TRUE.equals(isHome)) {
                 binding.topAppBar.setNavigationIcon(R.drawable.home_icon);
-                binding.topAppBar.setOverflowIcon(overflowMenuIcon);
+                binding.topAppBar.getMenu().setGroupVisible(0, true);
               } else {
-                binding.topAppBar.setNavigationIcon(R.drawable.back_arrow_icon);
-                binding.topAppBar.setOverflowIcon(null);
+                Fragment fragment =
+                    getSupportFragmentManager().findFragmentById(R.id.fragment_container_home);
+                // If the fragment is not the seed wallet then make the back arrow appear
+                if (!(fragment instanceof SeedWalletFragment)) {
+                  binding.topAppBar.setNavigationIcon(R.drawable.back_arrow_icon);
+                } else {
+                  binding.topAppBar.setNavigationIcon(null);
+                }
+                // Disable the overflow menu
+                binding.topAppBar.getMenu().setGroupVisible(0, false);
               }
             });
 
@@ -100,6 +100,13 @@ public class HomeActivity extends AppCompatActivity {
           if (Boolean.FALSE.equals(viewModel.isHome().getValue())) {
             // Press back arrow
             onBackPressed();
+          } else {
+            // If the user presses on the home button display the general info about the app
+            new MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.app_name)
+                .setMessage(R.string.app_info)
+                .setPositiveButton(R.string.ok, null)
+                .show();
           }
         });
 
@@ -151,7 +158,6 @@ public class HomeActivity extends AppCompatActivity {
     if (!(fragment instanceof SeedWalletFragment)) {
       setCurrentFragment(
           getSupportFragmentManager(), R.id.fragment_home, HomeFragment::newInstance);
-      viewModel.setIsHome(true);
     }
     // Move the application to background if back button is pressed on home
     if (fragment instanceof HomeFragment) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
@@ -3,6 +3,7 @@ package com.github.dedis.popstellar.ui.home;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
@@ -68,8 +69,39 @@ public class HomeActivity extends AppCompatActivity {
     }
   }
 
+  @Override
+  public void onResume() {
+    super.onResume();
+  }
+
   private void handleTopAppBar() {
     viewModel.getPageTitle().observe(this, binding.topAppBar::setTitle);
+
+    Drawable overflowMenuIcon = binding.topAppBar.getOverflowIcon();
+
+    // Observe whether the home icon or back arrow should be displayed
+    viewModel
+        .isHome()
+        .observe(
+            this,
+            isHome -> {
+              if (Boolean.TRUE.equals(isHome)) {
+                binding.topAppBar.setNavigationIcon(R.drawable.home_icon);
+                binding.topAppBar.setOverflowIcon(overflowMenuIcon);
+              } else {
+                binding.topAppBar.setNavigationIcon(R.drawable.back_arrow_icon);
+                binding.topAppBar.setOverflowIcon(null);
+              }
+            });
+
+    // Listen to click on left icon of toolbar
+    binding.topAppBar.setNavigationOnClickListener(
+        view -> {
+          if (Boolean.FALSE.equals(viewModel.isHome().getValue())) {
+            // Press back arrow
+            onBackPressed();
+          }
+        });
 
     // Set menu items behaviour
     binding.topAppBar.setOnMenuItemClickListener(
@@ -117,7 +149,9 @@ public class HomeActivity extends AppCompatActivity {
   public void onBackPressed() {
     Fragment fragment = getSupportFragmentManager().findFragmentById(R.id.fragment_container_home);
     if (!(fragment instanceof SeedWalletFragment)) {
-      setCurrentFragment(getSupportFragmentManager(), R.id.fragment_home, HomeFragment::new);
+      setCurrentFragment(
+          getSupportFragmentManager(), R.id.fragment_home, HomeFragment::newInstance);
+      viewModel.setIsHome(true);
     }
     // Move the application to background if back button is pressed on home
     if (fragment instanceof HomeFragment) {
@@ -137,13 +171,13 @@ public class HomeActivity extends AppCompatActivity {
                 setCurrentFragment(
                     getSupportFragmentManager(),
                     R.id.fragment_seed_wallet,
-                    SeedWalletFragment::new);
+                    SeedWalletFragment::newInstance);
               })
           .setNegativeButton(R.string.cancel, (dialog, which) -> dialog.dismiss())
           .show();
     } else {
       setCurrentFragment(
-          getSupportFragmentManager(), R.id.fragment_seed_wallet, SeedWalletFragment::new);
+          getSupportFragmentManager(), R.id.fragment_seed_wallet, SeedWalletFragment::newInstance);
     }
   }
 
@@ -171,7 +205,8 @@ public class HomeActivity extends AppCompatActivity {
   }
 
   private void handleSettings() {
-    setCurrentFragment(getSupportFragmentManager(), R.id.fragment_settings, SettingsFragment::new);
+    setCurrentFragment(
+        getSupportFragmentManager(), R.id.fragment_settings, SettingsFragment::newInstance);
   }
 
   private void restoreStoredState() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.home;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 
 import androidx.annotation.NonNull;
@@ -15,6 +14,7 @@ import com.github.dedis.popstellar.ui.qrcode.QrScannerFragment;
 import com.github.dedis.popstellar.ui.qrcode.ScanningAction;
 
 import dagger.hilt.android.AndroidEntryPoint;
+import timber.log.Timber;
 
 /** Fragment used to display the Home UI */
 @AndroidEntryPoint
@@ -57,14 +57,14 @@ public final class HomeFragment extends Fragment {
   private void setupButtonsActions() {
     binding.homeCreateButton.setOnClickListener(
         v -> {
-          Log.d(TAG, "Opening Create fragment");
+          Timber.tag(TAG).d("Opening Create fragment");
           HomeActivity.setCurrentFragment(
               getParentFragmentManager(), R.id.fragment_lao_create, LaoCreateFragment::newInstance);
         });
 
     binding.homeJoinButton.setOnClickListener(
         v -> {
-          Log.d(TAG, "Opening join fragment");
+          Timber.tag(TAG).d("Opening join fragment");
           HomeActivity.setCurrentFragment(
               getParentFragmentManager(),
               R.id.fragment_qr_scanner,
@@ -79,7 +79,7 @@ public final class HomeFragment extends Fragment {
         .observe(
             requireActivity(),
             laoIds -> {
-              Log.d(TAG, "Got a list update");
+              Timber.tag(TAG).d("Got a list update");
               laoListAdapter.setList(laoIds);
 
               if (!laoIds.isEmpty()) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeFragment.java
@@ -51,6 +51,7 @@ public final class HomeFragment extends Fragment {
   public void onResume() {
     super.onResume();
     viewModel.setPageTitle(R.string.home_title);
+    viewModel.setIsHome(true);
   }
 
   private void setupButtonsActions() {
@@ -68,6 +69,7 @@ public final class HomeFragment extends Fragment {
               getParentFragmentManager(),
               R.id.fragment_qr_scanner,
               () -> QrScannerFragment.newInstance(ScanningAction.ADD_LAO_PARTICIPANT));
+          viewModel.setIsHome(false);
         });
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeFragment.java
@@ -39,7 +39,6 @@ public final class HomeFragment extends Fragment {
     binding = HomeFragmentBinding.inflate(inflater, container, false);
     binding.setLifecycleOwner(getActivity());
     viewModel = HomeActivity.obtainViewModel(requireActivity());
-    binding.setViewmodel(viewModel);
 
     setupListAdapter();
     setupListUpdates();

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
@@ -45,6 +45,8 @@ public class HomeViewModel extends AndroidViewModel
 
   private final LiveData<List<String>> laoIdList;
   private final MutableLiveData<Integer> mPageTitle = new MutableLiveData<>();
+
+  /** This LiveData boolean is used to indicate whether the HomeFragment is displayed */
   private final MutableLiveData<Boolean> isHome = new MutableLiveData<>(Boolean.TRUE);
 
   /** Dependencies for this class */
@@ -190,6 +192,11 @@ public class HomeViewModel extends AndroidViewModel
     return isHome;
   }
 
+  /**
+   * Function to set the liveData isHome.
+   *
+   * @param isHome true if the current fragment is HomeFragment, false otherwise
+   */
   public void setIsHome(boolean isHome) {
     if (!Boolean.valueOf(isHome).equals(this.isHome.getValue())) {
       this.isHome.setValue(isHome);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
@@ -45,6 +45,7 @@ public class HomeViewModel extends AndroidViewModel
 
   private final LiveData<List<String>> laoIdList;
   private final MutableLiveData<Integer> mPageTitle = new MutableLiveData<>();
+  private final MutableLiveData<Boolean> isHome = new MutableLiveData<>(Boolean.TRUE);
 
   /** Dependencies for this class */
   private final Gson gson;
@@ -183,6 +184,16 @@ public class HomeViewModel extends AndroidViewModel
   @Override
   public void setPageTitle(int titleId) {
     mPageTitle.postValue(titleId);
+  }
+
+  public MutableLiveData<Boolean> isHome() {
+    return isHome;
+  }
+
+  public void setIsHome(boolean isHome) {
+    if (!Boolean.valueOf(isHome).equals(this.isHome.getValue())) {
+      this.isHome.setValue(isHome);
+    }
   }
 
   public boolean isWalletSetUp() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.home;
 
 import android.app.Application;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -33,6 +32,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel;
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
+import timber.log.Timber;
 
 @HiltViewModel
 public class HomeViewModel extends AndroidViewModel
@@ -99,7 +99,7 @@ public class HomeViewModel extends AndroidViewModel
     try {
       laoData = ConnectToLao.extractFrom(gson, data);
     } catch (JsonParseException e) {
-      Log.e(TAG, "Invalid QRCode laoData", e);
+      Timber.tag(TAG).e(e, "Invalid QRCode laoData");
       Toast.makeText(
               getApplication().getApplicationContext(),
               R.string.invalid_qrcode_data,
@@ -120,12 +120,12 @@ public class HomeViewModel extends AndroidViewModel
     if (data == null) {
       return;
     }
-    Log.d(TAG, "Saved state found : " + data);
+    Timber.tag(TAG).d("Saved state found : %s", data);
 
     if (!isWalletSetUp()) {
-      Log.d(TAG, "Restoring wallet");
+      Timber.tag(TAG).d("Restoring wallet");
       String[] seed = data.getWalletSeed();
-      Log.d(TAG, "seed is " + Arrays.toString(seed));
+      Timber.tag(TAG).d("seed is %s", Arrays.toString(seed));
       if (seed.length == 0) {
         ErrorUtils.logAndShow(
             getApplication().getApplicationContext(), TAG, R.string.no_seed_storage_found);
@@ -135,16 +135,16 @@ public class HomeViewModel extends AndroidViewModel
       try {
         importSeed(appended);
       } catch (GeneralSecurityException | SeedValidationException e) {
-        Log.e(TAG, "error importing seed from storage");
+        Timber.tag(TAG).e(e, "error importing seed from storage");
         return;
       }
     }
 
     if (data.getSubscriptions().equals(networkManager.getMessageSender().getSubscriptions())) {
-      Log.d(TAG, "current state is up to date");
+      Timber.tag(TAG).d("current state is up to date");
       return;
     }
-    Log.d(TAG, "restoring connections");
+    Timber.tag(TAG).d("restoring connections");
     networkManager.connect(data.getServerAddress(), data.getSubscriptions());
     getApplication()
         .startActivity(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LAOListAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LAOListAdapter.java
@@ -2,7 +2,6 @@ package com.github.dedis.popstellar.ui.home;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.util.Log;
 import android.view.*;
 import android.widget.TextView;
 
@@ -16,6 +15,8 @@ import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 
 import java.util.List;
+
+import timber.log.Timber;
 
 public class LAOListAdapter extends RecyclerView.Adapter<LAOListAdapter.LAOListItemViewHolder> {
 
@@ -54,7 +55,7 @@ public class LAOListAdapter extends RecyclerView.Adapter<LAOListAdapter.LAOListI
     CardView cardView = holder.cardView;
     cardView.setOnClickListener(
         v -> {
-          Log.d(TAG, "Opening lao detail activity on the home tab for lao " + laoId);
+          Timber.tag(TAG).d("Opening lao detail activity on the home tab for lao %s", laoId);
           activity.startActivity(LaoActivity.newIntentForLao(activity, laoId));
         });
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
@@ -58,6 +58,7 @@ public final class LaoCreateFragment extends Fragment {
   public void onResume() {
     super.onResume();
     viewModel.setPageTitle(R.string.lao_create_title);
+    viewModel.setIsHome(false);
   }
 
   TextWatcher launchWatcher =

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.ui.home;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.*;
 
 import androidx.annotation.NonNull;
@@ -19,6 +18,7 @@ import java.util.Objects;
 import javax.inject.Inject;
 
 import dagger.hilt.android.AndroidEntryPoint;
+import timber.log.Timber;
 
 /** Fragment used to display the Launch UI */
 @AndroidEntryPoint
@@ -104,7 +104,7 @@ public final class LaoCreateFragment extends Fragment {
               Objects.requireNonNull(binding.serverUrlEntryEditText.getText()).toString();
           String laoName =
               Objects.requireNonNull(binding.laoNameEntryEditText.getText()).toString();
-          Log.d(TAG, "creating lao with name " + laoName);
+          Timber.tag(TAG).d("creating lao with name %s", laoName);
 
           networkManager.connect(serverAddress);
           requireActivity()

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
@@ -1,6 +1,5 @@
 package com.github.dedis.popstellar.ui.home;
 
-import android.app.AlertDialog;
 import android.os.Bundle;
 import android.view.*;
 
@@ -8,7 +7,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.github.dedis.popstellar.R;
-import com.github.dedis.popstellar.databinding.SettingsFragmentBinding;
 import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat;
 
 import dagger.hilt.android.AndroidEntryPoint;
@@ -22,12 +20,18 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     return new SettingsFragment();
   }
 
-  private SettingsViewModel viewModel;
+  private SettingsViewModel settingsViewModel;
+  private HomeViewModel homeViewModel;
+
+  public SettingsFragment() {}
 
   @Override
   public void onCreatePreferencesFix(@Nullable Bundle savedInstanceState, String rootKey) {
     // Load the preferences from an XML resource
     setPreferencesFromResource(R.xml.settings_preferences, rootKey);
+
+    // Set callbacks for debugging section
+    setDebuggingPreferences();
   }
 
   @Override
@@ -35,39 +39,34 @@ public class SettingsFragment extends PreferenceFragmentCompat {
       @NonNull LayoutInflater inflater,
       @Nullable ViewGroup container,
       @Nullable Bundle savedInstanceState) {
-    SettingsFragmentBinding binding = SettingsFragmentBinding.inflate(inflater, container, false);
-    binding.setLifecycleOwner(getActivity());
-    viewModel = HomeActivity.obtainSettingsViewModel(requireActivity());
 
-    setDebuggingPreferences();
+    homeViewModel = HomeActivity.obtainViewModel(requireActivity());
+    settingsViewModel = HomeActivity.obtainSettingsViewModel(requireActivity());
 
-    return binding.getRoot();
+    return super.onCreateView(inflater, container, savedInstanceState);
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    homeViewModel.setPageTitle(R.string.settings);
+    homeViewModel.setIsHome(false);
   }
 
   /** Function that sets the callback for switching the preferences in the section "Debugging" */
   private void setDebuggingPreferences() {
+    // Set the callback for managing the logging
     getPreferenceManager()
         .findPreference("enable_logging")
         .setOnPreferenceChangeListener(
             ((preference, newValue) -> {
               boolean selected = (boolean) newValue;
               if (selected) {
-                final boolean[] confirmation = {false};
-                // confirmation screen
-                new AlertDialog.Builder(getContext())
-                    .setTitle(R.string.confirm_title)
-                    .setMessage(R.string.settings_enable_logging_confirmation)
-                    .setPositiveButton(R.string.yes, (dialogInterface, i) -> confirmation[0] = true)
-                    .setNegativeButton(R.string.no, null)
-                    .show();
-                if (confirmation[0]) {
-                  viewModel.enableLogging();
-                }
-                return confirmation[0];
+                settingsViewModel.enableLogging();
               } else {
-                viewModel.disableLogging();
-                return true;
+                settingsViewModel.disableLogging();
               }
+              return true;
             }));
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
@@ -1,0 +1,73 @@
+package com.github.dedis.popstellar.ui.home;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.view.*;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.github.dedis.popstellar.R;
+import com.github.dedis.popstellar.databinding.SettingsFragmentBinding;
+import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat;
+
+import dagger.hilt.android.AndroidEntryPoint;
+
+@AndroidEntryPoint
+public class SettingsFragment extends PreferenceFragmentCompat {
+
+  public static final String TAG = SettingsFragment.class.getSimpleName();
+
+  public static SettingsFragment newInstance() {
+    return new SettingsFragment();
+  }
+
+  private SettingsViewModel viewModel;
+
+  @Override
+  public void onCreatePreferencesFix(@Nullable Bundle savedInstanceState, String rootKey) {
+    // Load the preferences from an XML resource
+    setPreferencesFromResource(R.xml.settings_preferences, rootKey);
+  }
+
+  @Override
+  public View onCreateView(
+      @NonNull LayoutInflater inflater,
+      @Nullable ViewGroup container,
+      @Nullable Bundle savedInstanceState) {
+    SettingsFragmentBinding binding = SettingsFragmentBinding.inflate(inflater, container, false);
+    binding.setLifecycleOwner(getActivity());
+    viewModel = HomeActivity.obtainSettingsViewModel(requireActivity());
+
+    setDebuggingPreferences();
+
+    return binding.getRoot();
+  }
+
+  /** Function that sets the callback for switching the preferences in the section "Debugging" */
+  private void setDebuggingPreferences() {
+    getPreferenceManager()
+        .findPreference("enable_logging")
+        .setOnPreferenceChangeListener(
+            ((preference, newValue) -> {
+              boolean selected = (boolean) newValue;
+              if (selected) {
+                final boolean[] confirmation = {false};
+                // confirmation screen
+                new AlertDialog.Builder(getContext())
+                    .setTitle(R.string.confirm_title)
+                    .setMessage(R.string.settings_enable_logging_confirmation)
+                    .setPositiveButton(R.string.yes, (dialogInterface, i) -> confirmation[0] = true)
+                    .setNegativeButton(R.string.no, null)
+                    .show();
+                if (confirmation[0]) {
+                  viewModel.enableLogging();
+                }
+                return confirmation[0];
+              } else {
+                viewModel.disableLogging();
+                return true;
+              }
+            }));
+  }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
@@ -10,6 +10,7 @@ import androidx.preference.SwitchPreference;
 
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.utility.MessageValidator;
+import com.github.dedis.popstellar.utility.NetworkLogger;
 import com.takisoft.preferencex.EditTextPreference;
 import com.takisoft.preferencex.PreferenceFragmentCompat;
 
@@ -66,6 +67,12 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     SwitchPreference enableLogging =
         getPreferenceManager().findPreference(getString(R.string.settings_logging_key));
 
+    // Initially the switch is disabled unless it's already on
+    enableLogging.setEnabled(enableLogging.isChecked());
+
+    // Initially the edit text is enabled unless the logging is already on
+    serverUrl.setEnabled(!enableLogging.isChecked());
+
     // Set the callback for managing the logging
     enableLogging.setOnPreferenceChangeListener(
         ((preference, newValue) -> {
@@ -93,6 +100,8 @@ public class SettingsFragment extends PreferenceFragmentCompat {
 
           try {
             MessageValidator.verify().checkValidUrl(newUrl);
+            // Save the server url
+            NetworkLogger.setServerUrl(newUrl);
             // Enable the switch preference based on URL validity
             enableLogging.setEnabled(true);
             return true;
@@ -101,8 +110,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             // Show an error message and prevent the preference from being updated
             Toast.makeText(getContext(), R.string.error_settings_url_server, Toast.LENGTH_SHORT)
                 .show();
-            // Return false to not save an incorrect preference
-            return false;
+            return true;
           }
         });
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
@@ -14,6 +14,8 @@ import com.github.dedis.popstellar.utility.NetworkLogger;
 import com.takisoft.preferencex.EditTextPreference;
 import com.takisoft.preferencex.PreferenceFragmentCompat;
 
+import java.util.Objects;
+
 import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
@@ -68,10 +70,10 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         getPreferenceManager().findPreference(getString(R.string.settings_logging_key));
 
     // Initially the switch is disabled unless it's already on
-    enableLogging.setEnabled(enableLogging.isChecked());
+    Objects.requireNonNull(enableLogging).setEnabled(enableLogging.isChecked());
 
     // Initially the edit text is enabled unless the logging is already on
-    serverUrl.setEnabled(!enableLogging.isChecked());
+    Objects.requireNonNull(serverUrl).setEnabled(!enableLogging.isChecked());
 
     // Set the callback for managing the logging
     enableLogging.setOnPreferenceChangeListener(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
@@ -1,35 +1,34 @@
 package com.github.dedis.popstellar.ui.home;
 
 import android.app.Application;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
 
-import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
+import com.github.dedis.popstellar.utility.NetworkLogger;
 
 import javax.inject.Inject;
 
 import dagger.hilt.android.lifecycle.HiltViewModel;
+import timber.log.Timber;
 
 @HiltViewModel
 public class SettingsViewModel extends AndroidViewModel {
 
   public static final String TAG = SettingsViewModel.class.getSimpleName();
 
-  private final GlobalNetworkManager networkManager;
-
   @Inject
-  public SettingsViewModel(@NonNull Application application, GlobalNetworkManager networkManager) {
+  public SettingsViewModel(@NonNull Application application) {
     super(application);
-    this.networkManager = networkManager;
   }
 
   public void enableLogging() {
-    Log.d(TAG, "Enabling logging");
+    Timber.tag(TAG).d("Enabling logging");
+    NetworkLogger.enableRemote();
   }
 
   public void disableLogging() {
-    Log.d(TAG, "Disabling logging");
+    Timber.tag(TAG).d("Disabling logging");
+    NetworkLogger.disableRemote();
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
@@ -23,8 +23,8 @@ public class SettingsViewModel extends AndroidViewModel {
   }
 
   public void enableLogging() {
-    Timber.tag(TAG).d("Enabling remote logging");
     NetworkLogger.enableRemote();
+    Timber.tag(TAG).d("Enabling remote logging");
   }
 
   public void disableLogging() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
@@ -1,9 +1,12 @@
 package com.github.dedis.popstellar.ui.home;
 
 import android.app.Application;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
+
+import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 
 import javax.inject.Inject;
 
@@ -14,12 +17,19 @@ public class SettingsViewModel extends AndroidViewModel {
 
   public static final String TAG = SettingsViewModel.class.getSimpleName();
 
+  private final GlobalNetworkManager networkManager;
+
   @Inject
-  public SettingsViewModel(@NonNull Application application) {
+  public SettingsViewModel(@NonNull Application application, GlobalNetworkManager networkManager) {
     super(application);
+    this.networkManager = networkManager;
   }
 
-  public void enableLogging() {}
+  public void enableLogging() {
+    Log.d(TAG, "Enabling logging");
+  }
 
-  public void disableLogging() {}
+  public void disableLogging() {
+    Log.d(TAG, "Disabling logging");
+  }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
@@ -1,0 +1,25 @@
+package com.github.dedis.popstellar.ui.home;
+
+import android.app.Application;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.AndroidViewModel;
+
+import javax.inject.Inject;
+
+import dagger.hilt.android.lifecycle.HiltViewModel;
+
+@HiltViewModel
+public class SettingsViewModel extends AndroidViewModel {
+
+  public static final String TAG = SettingsViewModel.class.getSimpleName();
+
+  @Inject
+  public SettingsViewModel(@NonNull Application application) {
+    super(application);
+  }
+
+  public void enableLogging() {}
+
+  public void disableLogging() {}
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsViewModel.java
@@ -23,12 +23,12 @@ public class SettingsViewModel extends AndroidViewModel {
   }
 
   public void enableLogging() {
-    Timber.tag(TAG).d("Enabling logging");
+    Timber.tag(TAG).d("Enabling remote logging");
     NetworkLogger.enableRemote();
   }
 
   public void disableLogging() {
-    Timber.tag(TAG).d("Disabling logging");
+    Timber.tag(TAG).d("Disabling remote logging");
     NetworkLogger.disableRemote();
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/wallet/SeedWalletFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/wallet/SeedWalletFragment.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.ui.home.wallet;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.*;
 import android.widget.Toast;
 
@@ -25,6 +24,7 @@ import java.util.Objects;
 import javax.inject.Inject;
 
 import dagger.hilt.android.AndroidEntryPoint;
+import timber.log.Timber;
 
 /** Fragment used to display the new seed UI */
 @AndroidEntryPoint
@@ -87,7 +87,7 @@ public class SeedWalletFragment extends Fragment {
                   HomeActivity.setCurrentFragment(
                       getParentFragmentManager(), R.id.fragment_home, HomeFragment::newInstance);
                 } catch (GeneralSecurityException | SeedValidationException e) {
-                  Log.e(TAG, "Error importing key", e);
+                  Timber.tag(TAG).e(e, "Error importing key");
                   Toast.makeText(
                           requireContext().getApplicationContext(),
                           String.format(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/wallet/SeedWalletFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/wallet/SeedWalletFragment.java
@@ -68,6 +68,7 @@ public class SeedWalletFragment extends Fragment {
   public void onResume() {
     super.onResume();
     viewModel.setPageTitle(R.string.wallet_setup);
+    viewModel.setIsHome(false);
   }
 
   private void setupConfirmSeedButton() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.ui.lao;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -41,6 +40,7 @@ import java.util.*;
 import java.util.function.Supplier;
 
 import dagger.hilt.android.AndroidEntryPoint;
+import timber.log.Timber;
 
 @AndroidEntryPoint
 public class LaoActivity extends AppCompatActivity {
@@ -88,7 +88,7 @@ public class LaoActivity extends AppCompatActivity {
       laoViewModel.savePersistentData();
     } catch (GeneralSecurityException e) {
       // We do not display the security error to the user
-      Log.d(TAG, "Storage was unsuccessful du to wallet error " + e);
+      Timber.tag(TAG).d(e, "Storage was unsuccessful du to wallet error");
       Toast.makeText(this, R.string.error_storage_wallet, Toast.LENGTH_SHORT).show();
     }
   }
@@ -176,13 +176,13 @@ public class LaoActivity extends AppCompatActivity {
     binding.laoNavigationDrawer.setNavigationItemSelectedListener(
         item -> {
           MainMenuTab tab = MainMenuTab.findByMenu(item.getItemId());
-          Log.i(TAG, "Opening tab : " + tab.getName());
+          Timber.tag(TAG).i("Opening tab : %s", tab.getName());
           boolean selected = openTab(tab);
           if (selected) {
-            Log.d(TAG, "The tab was successfully opened");
+            Timber.tag(TAG).d("The tab was successfully opened");
             laoViewModel.setCurrentTab(tab);
           } else {
-            Log.d(TAG, "The tab wasn't opened");
+            Timber.tag(TAG).d("The tab wasn't opened");
           }
           binding.laoDrawerLayout.close();
           return selected;
@@ -236,7 +236,7 @@ public class LaoActivity extends AppCompatActivity {
         startActivity(HomeActivity.newIntent(this));
         return true;
       default:
-        Log.w(TAG, "Unhandled tab type : " + tab);
+        Timber.tag(TAG).w("Unhandled tab type : %s", tab);
         return false;
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoViewModel.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao;
 
 import android.app.Application;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
@@ -32,6 +31,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
+import timber.log.Timber;
 
 @HiltViewModel
 public class LaoViewModel extends AndroidViewModel implements PopViewModel {
@@ -213,14 +213,14 @@ public class LaoViewModel extends AndroidViewModel implements PopViewModel {
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(
                 laoView -> {
-                  Log.d(TAG, "got an update for lao: " + laoView);
+                  Timber.tag(TAG).d("got an update for lao: %s", laoView);
 
                   setIsOrganizer(laoView.getOrganizer().equals(keyManager.getMainPublicKey()));
                   setIsWitness(laoView.getWitnesses().contains(keyManager.getMainPublicKey()));
 
                   updateRole();
                 },
-                error -> Log.d(TAG, "error updating LAO :" + error)));
+                error -> Timber.tag(TAG).d(error, "error updating LAO")));
   }
 
   protected void observeRollCalls(String laoId) {
@@ -253,7 +253,7 @@ public class LaoViewModel extends AndroidViewModel implements PopViewModel {
       PublicKey pk = wallet.generatePoPToken(laoId, rollcall.getPersistentId()).getPublicKey();
       return rollcall.isClosed() && rollcall.getAttendees().contains(pk);
     } catch (KeyGenerationException | UninitializedWalletException e) {
-      Log.e(TAG, "failed to retrieve public key from wallet", e);
+      Timber.tag(TAG).e(e, "failed to retrieve public key from wallet");
       return false;
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHistoryFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHistoryFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.digitalcash;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 
 import androidx.fragment.app.Fragment;
@@ -13,6 +12,7 @@ import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.ActivityUtils;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
+import timber.log.Timber;
 
 public class DigitalCashHistoryFragment extends Fragment {
   private static final String TAG = DigitalCashHistoryFragment.class.getSimpleName();
@@ -49,7 +49,7 @@ public class DigitalCashHistoryFragment extends Fragment {
             .getTransactionsObservable()
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(
-                adapter::setList, error -> Log.d(TAG, "error with history update " + error)));
+                adapter::setList, error -> Timber.tag(TAG).d(error, "error with history update")));
 
     handleBackNav();
     return view;

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHomeFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashHomeFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.digitalcash;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 
 import androidx.annotation.NonNull;
@@ -16,6 +15,7 @@ import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
+import timber.log.Timber;
 
 /**
  * A simple {@link Fragment} subclass. Use the {@link DigitalCashHomeFragment#newInstance} factory
@@ -71,7 +71,7 @@ public class DigitalCashHomeFragment extends Fragment {
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(
                 transactions -> {
-                  Log.d(TAG, "updating transactions " + transactions);
+                  Timber.tag(TAG).d("updating transactions %s", transactions);
                   long totalAmount = digitalCashViewModel.getOwnBalance();
                   binding.coinAmountText.setText(String.valueOf(totalAmount));
                 },

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashIssueFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashIssueFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.digitalcash;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 import android.widget.ArrayAdapter;
 import android.widget.Toast;
@@ -26,6 +25,7 @@ import java.time.Instant;
 import java.util.*;
 
 import dagger.hilt.android.AndroidEntryPoint;
+import timber.log.Timber;
 
 /**
  * A simple {@link Fragment} subclass. Use the {@link DigitalCashIssueFragment#newInstance} factory
@@ -165,7 +165,7 @@ public class DigitalCashIssueFragment extends Fragment {
     try {
       myArray = digitalCashViewModel.getAttendeesFromTheRollCallList();
     } catch (NoRollCallException e) {
-      Log.d(TAG, getString(R.string.error_no_rollcall_closed_in_LAO));
+      Timber.tag(TAG).d(getString(R.string.error_no_rollcall_closed_in_LAO));
       Toast.makeText(
               requireContext(),
               getString(R.string.digital_cash_please_enter_roll_call),

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashSendFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashSendFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.digitalcash;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 import android.widget.ArrayAdapter;
 import android.widget.Toast;
@@ -26,6 +25,7 @@ import java.time.Instant;
 import java.util.*;
 
 import io.reactivex.Completable;
+import timber.log.Timber;
 
 /**
  * A simple {@link Fragment} subclass. Use the {@link DigitalCashSendFragment#newInstance} factory
@@ -98,7 +98,7 @@ public class DigitalCashSendFragment extends Fragment {
                                         R.id.fragment_digital_cash_receipt,
                                         DigitalCashReceiptFragment::newInstance);
                                   },
-                                  error -> Log.d(TAG, "error posting transaction", error)));
+                                  error -> Timber.tag(TAG).d(error, "error posting transaction")));
                     }
 
                   } catch (KeyException keyException) {
@@ -129,7 +129,7 @@ public class DigitalCashSendFragment extends Fragment {
   public boolean canPostTransaction(PublicKey publicKey, int amount) {
     long currentBalance = digitalCashViewModel.getUserBalance(publicKey);
     if (currentBalance < amount) {
-      Log.d(TAG, "Current Balance: " + currentBalance + " amount: " + amount);
+      Timber.tag(TAG).d("Current Balance: %s amount: %s", currentBalance, amount);
       Toast.makeText(
               requireContext(), R.string.digital_cash_warning_not_enough_money, Toast.LENGTH_SHORT)
           .show();
@@ -178,7 +178,7 @@ public class DigitalCashSendFragment extends Fragment {
     try {
       members.remove(digitalCashViewModel.getValidToken().getPublicKey().getEncoded());
     } catch (KeyException e) {
-      Log.e(TAG, getResources().getString(R.string.error_retrieve_own_token));
+      Timber.tag(TAG).e(e, getResources().getString(R.string.error_retrieve_own_token));
     }
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/DigitalCashViewModel.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.digitalcash;
 
 import android.app.Application;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -36,6 +35,7 @@ import javax.inject.Inject;
 import dagger.hilt.android.lifecycle.HiltViewModel;
 import io.reactivex.Observable;
 import io.reactivex.*;
+import timber.log.Timber;
 
 @HiltViewModel
 public class DigitalCashViewModel extends AndroidViewModel {
@@ -157,7 +157,7 @@ public class DigitalCashViewModel extends AndroidViewModel {
       outputs.add(addOutput);
       return amount;
     } catch (Exception e) {
-      Log.e(TAG, RECEIVER_KEY_ERROR, e);
+      Timber.tag(TAG).e(e, RECEIVER_KEY_ERROR);
       return 0;
     }
   }
@@ -177,7 +177,7 @@ public class DigitalCashViewModel extends AndroidViewModel {
     try {
       laoView = getLao();
     } catch (UnknownLaoException e) {
-      Log.e(TAG, LAO_FAILURE_MESSAGE);
+      Timber.tag(TAG).e(e, LAO_FAILURE_MESSAGE);
       return Completable.error(new UnknownLaoException());
     }
 
@@ -193,7 +193,9 @@ public class DigitalCashViewModel extends AndroidViewModel {
                   .getMessageSender()
                   .publish(channel, msg)
                   .doOnComplete(
-                      () -> Log.d(TAG, "Successfully sent post transaction message : " + postTxn));
+                      () ->
+                          Timber.tag(TAG)
+                              .d("Successfully sent post transaction message : %s", postTxn));
             });
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/HistoryListAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/digitalcash/HistoryListAdapter.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.digitalcash;
 
 import android.annotation.SuppressLint;
-import android.util.Log;
 import android.view.*;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -20,6 +19,8 @@ import com.github.dedis.popstellar.utility.error.keys.KeyException;
 
 import java.util.*;
 import java.util.stream.Collectors;
+
+import timber.log.Timber;
 
 public class HistoryListAdapter extends RecyclerView.Adapter<HistoryListAdapter.HistoryViewHolder> {
   private static final String TAG = HistoryListAdapter.class.getSimpleName();
@@ -46,7 +47,7 @@ public class HistoryListAdapter extends RecyclerView.Adapter<HistoryListAdapter.
   public void onBindViewHolder(@NonNull HistoryViewHolder holder, int position) {
     TransactionHistoryElement element = transactions.get(position);
     if (element == null) {
-      Log.d(TAG, "element is null");
+      Timber.tag(TAG).d("element is null");
       return;
     }
     String transactionId = element.getId();
@@ -68,7 +69,7 @@ public class HistoryListAdapter extends RecyclerView.Adapter<HistoryListAdapter.
 
     View.OnClickListener listener =
         v -> {
-          Log.d(TAG, "transaction is " + transactionId + " position is " + position);
+          Timber.tag(TAG).d("transaction is %s position is %s", transactionId, position);
           boolean expandStatus = expandMap.get(transactionId);
           expandMap.put(transactionId, !expandStatus);
           notifyItemChanged(position);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/consensus/ConsensusViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/consensus/ConsensusViewModel.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.event.consensus;
 
 import android.app.Application;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
@@ -26,6 +25,7 @@ import javax.inject.Inject;
 
 import dagger.hilt.android.lifecycle.HiltViewModel;
 import io.reactivex.*;
+import timber.log.Timber;
 
 @HiltViewModel
 public class ConsensusViewModel extends AndroidViewModel {
@@ -66,11 +66,8 @@ public class ConsensusViewModel extends AndroidViewModel {
    */
   public Single<MessageGeneral> sendConsensusElect(
       long creation, String objId, String type, String property, Object value) {
-    Log.d(
-        TAG,
-        String.format(
-            "creating a new consensus for type: %s, property: %s, value: %s",
-            type, property, value));
+    Timber.tag(TAG)
+        .d("creating a new consensus for type: %s, property: %s, value: %s", type, property, value);
 
     LaoView laoView;
     try {
@@ -98,12 +95,10 @@ public class ConsensusViewModel extends AndroidViewModel {
    */
   public Completable sendConsensusElectAccept(ElectInstance electInstance, boolean accept) {
     MessageID messageId = electInstance.getMessageId();
-    Log.d(
-        TAG,
-        "sending a new elect_accept for consensus with messageId : "
-            + messageId
-            + " with value "
-            + accept);
+    Timber.tag(TAG)
+        .d(
+            "sending a new elect_accept for consensus with messageId : %s with value %s",
+            messageId, accept);
 
     ConsensusElectAccept consensusElectAccept =
         new ConsensusElectAccept(electInstance.getInstanceId(), messageId, accept);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/consensus/ElectionStartFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/consensus/ElectionStartFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.event.consensus;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 import android.widget.GridView;
 
@@ -28,6 +27,7 @@ import dagger.hilt.android.AndroidEntryPoint;
 import io.reactivex.Observable;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.functions.Consumer;
+import timber.log.Timber;
 
 import static io.reactivex.android.schedulers.AndroidSchedulers.mainThread;
 
@@ -110,7 +110,8 @@ public class ElectionStartFragment extends Fragment {
 
       if (ownNode == null) {
         // Only possible if the user wasn't an acceptor, but shouldn't have access to this fragment
-        Log.e(TAG, "Couldn't find the Node with public key : " + laoViewModel.getPublicKey());
+        Timber.tag(TAG)
+            .e("Couldn't find the Node with public key : %s", laoViewModel.getPublicKey());
         throw new IllegalStateException(
             "Only acceptors are allowed to access ElectionStartFragment");
       }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/ElectionViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/ElectionViewModel.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.ui.lao.event.election;
 import android.app.Application;
 import android.os.Handler;
 import android.os.Looper;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -30,6 +29,7 @@ import javax.inject.Inject;
 import dagger.hilt.android.lifecycle.HiltViewModel;
 import io.reactivex.Completable;
 import io.reactivex.Single;
+import timber.log.Timber;
 
 @HiltViewModel
 public class ElectionViewModel extends AndroidViewModel {
@@ -80,7 +80,7 @@ public class ElectionViewModel extends AndroidViewModel {
       long start,
       long end,
       List<ElectionQuestion.Question> questions) {
-    Log.d(TAG, "creating a new election with name " + name);
+    Timber.tag(TAG).d("creating a new election with name %s", name);
 
     LaoView laoView;
     try {
@@ -114,7 +114,7 @@ public class ElectionViewModel extends AndroidViewModel {
    * @param election election to be opened
    */
   public Completable openElection(Election election) {
-    Log.d(TAG, "opening election with name : " + election.getName());
+    Timber.tag(TAG).d("opening election with name : %s", election.getName());
     LaoView laoView;
     try {
       laoView = getLao();
@@ -136,7 +136,7 @@ public class ElectionViewModel extends AndroidViewModel {
   }
 
   public Completable endElection(Election election) {
-    Log.d(TAG, "ending election with name : " + election.getName());
+    Timber.tag(TAG).d("ending election with name : %s", election.getName());
     LaoView laoView;
     try {
       laoView = getLao();
@@ -167,16 +167,14 @@ public class ElectionViewModel extends AndroidViewModel {
     try {
       election = electionRepo.getElection(laoId, electionId);
     } catch (UnknownElectionException e) {
-      Log.d(TAG, "failed to retrieve current election");
+      Timber.tag(TAG).d("failed to retrieve current election");
       return Completable.error(e);
     }
 
-    Log.d(
-        TAG,
-        "sending a new vote in election : "
-            + election
-            + " with election start time"
-            + election.getStartTimestamp());
+    Timber.tag(TAG)
+        .d(
+            "sending a new vote in election : %s with election start time %d",
+            election, election.getStartTimestamp());
 
     final LaoView laoView;
     try {
@@ -188,7 +186,7 @@ public class ElectionViewModel extends AndroidViewModel {
 
     return Single.fromCallable(
             () -> keyManager.getValidPoPToken(laoId, rollCallRepo.getLastClosedRollCall(laoId)))
-        .doOnSuccess(token -> Log.d(TAG, "Retrieved PoP Token to send votes : " + token))
+        .doOnSuccess(token -> Timber.tag(TAG).d("Retrieved PoP Token to send votes : %s", token))
         .flatMapCompletable(
             token -> {
               CompletableFuture<CastVote> vote = createCastVote(votes, election, laoView);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/adapters/ElectionSetupViewPagerAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/adapters/ElectionSetupViewPagerAdapter.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.ui.lao.event.election.adapters;
 import android.content.Context;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.*;
 import android.widget.*;
 
@@ -17,6 +16,8 @@ import com.github.dedis.popstellar.ui.lao.event.election.fragments.ElectionSetup
 
 import java.util.*;
 import java.util.stream.Collectors;
+
+import timber.log.Timber;
 
 /** This is where whe define behaviour of the ViewPager of election setup */
 public class ElectionSetupViewPagerAdapter
@@ -249,7 +250,7 @@ public class ElectionSetupViewPagerAdapter
             }
             // Keeps the list of string updated when the user changes the text
             ballotOptions.get(position).set(ballotIndex, editable.toString());
-            Log.d(TAG, "Postion is " + position + " ballot options are" + ballotOptions);
+            Timber.tag(TAG).d("Postion is %s ballot options are %s", position, ballotOptions);
             boolean areFieldsFilled = numberBallotOptions.get(position) >= 2;
             if (areFieldsFilled) {
               listOfValidBallots.add(position);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionSetupFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/fragments/ElectionSetupFragment.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.ui.lao.event.election.fragments;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.*;
 import android.widget.*;
 import android.widget.AdapterView.OnItemSelectedListener;
@@ -31,6 +30,7 @@ import java.util.stream.Collectors;
 
 import dagger.hilt.android.AndroidEntryPoint;
 import me.relex.circleindicator.CircleIndicator3;
+import timber.log.Timber;
 
 @AndroidEntryPoint
 public class ElectionSetupFragment extends AbstractEventCreationFragment {
@@ -227,16 +227,15 @@ public class ElectionSetupFragment extends AbstractEventCreationFragment {
 
           String electionName = electionNameText.getText().toString();
 
-          Log.d(
-              TAG,
-              String.format(
+          Timber.tag(TAG)
+              .d(
                   "Creating election with version %s, name %s, creation time %d, start time %d, end time %d, questions %s",
                   electionVersion,
                   electionName,
                   creationTimeInSeconds,
                   startTimeInSeconds,
                   endTimeInSeconds,
-                  filteredQuestions));
+                  filteredQuestions);
 
           laoViewModel.addDisposable(
               electionViewModel

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventListAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventListAdapter.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.event.eventlist;
 
 import android.annotation.SuppressLint;
-import android.util.Log;
 import android.view.*;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -20,6 +19,7 @@ import com.github.dedis.popstellar.ui.lao.event.LaoDetailAnimation;
 import java.util.*;
 
 import io.reactivex.Observable;
+import timber.log.Timber;
 
 import static com.github.dedis.popstellar.model.objects.event.EventCategory.PAST;
 import static com.github.dedis.popstellar.model.objects.event.EventCategory.PRESENT;
@@ -160,7 +160,7 @@ public class EventListAdapter extends EventsAdapter {
       return Objects.requireNonNull(eventsMap.get(PAST))
           .get(position - eventAccumulator - secondSectionOffset);
     }
-    Log.e(TAG, "position was " + position);
+    Timber.tag(TAG).e("position was %d", position);
     throw new IllegalStateException("no event matches");
   }
 
@@ -184,7 +184,7 @@ public class EventListAdapter extends EventsAdapter {
     if (position == eventAccumulator + 1) {
       return PAST;
     }
-    Log.e(TAG, "Illegal position " + position);
+    Timber.tag(TAG).e("Illegal position %d", position);
     throw new IllegalStateException("No event category");
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventListFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventListFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.event.eventlist;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 
 import androidx.annotation.NonNull;
@@ -30,6 +29,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import dagger.hilt.android.AndroidEntryPoint;
+import timber.log.Timber;
 
 /** Fragment used to display the list of events */
 @AndroidEntryPoint
@@ -146,7 +146,7 @@ public class EventListFragment extends Fragment {
                 R.id.fragment_setup_election_event,
                 ElectionSetupFragment::newInstance);
       default:
-        return v -> Log.d(TAG, "unknown event type: " + type);
+        return v -> Timber.tag(TAG).d("unknown event type: %s", type);
     }
   }
 
@@ -168,7 +168,7 @@ public class EventListFragment extends Fragment {
 
     EventListAdapter eventListAdapter =
         new EventListAdapter(laoViewModel, eventsViewModel.getEvents(), requireActivity());
-    Log.d(TAG, "created adapter");
+    Timber.tag(TAG).d("created adapter");
     LinearLayoutManager mLayoutManager = new LinearLayoutManager(getContext());
     eventList.setLayoutManager(mLayoutManager);
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventsAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventsAdapter.java
@@ -1,6 +1,5 @@
 package com.github.dedis.popstellar.ui.lao.event.eventlist;
 
-import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -26,8 +25,12 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import io.reactivex.Observable;
+import timber.log.Timber;
 
 public abstract class EventsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
+
+  private static final String TAG = EventsAdapter.class.getSimpleName();
+
   private List<Event> events;
   private final LaoViewModel laoViewModel;
   private final FragmentActivity activity;
@@ -48,7 +51,9 @@ public abstract class EventsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
     this.laoViewModel.addDisposable(
         observable
             .map(eventList -> eventList.stream().sorted().collect(Collectors.toList()))
-            .subscribe(this::updateEventSet, err -> Log.e(tag, "ERROR", err)));
+            .subscribe(
+                this::updateEventSet,
+                err -> Timber.tag(TAG).e(err, "Error subscribing to event set")));
   }
 
   public abstract void updateEventSet(List<Event> events);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventsAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/eventlist/EventsAdapter.java
@@ -29,8 +29,6 @@ import timber.log.Timber;
 
 public abstract class EventsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
-  private static final String TAG = EventsAdapter.class.getSimpleName();
-
   private List<Event> events;
   private final LaoViewModel laoViewModel;
   private final FragmentActivity activity;
@@ -53,7 +51,7 @@ public abstract class EventsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
             .map(eventList -> eventList.stream().sorted().collect(Collectors.toList()))
             .subscribe(
                 this::updateEventSet,
-                err -> Timber.tag(TAG).e(err, "Error subscribing to event set")));
+                err -> Timber.tag(tag).e(err, "Error subscribing to event set")));
   }
 
   public abstract void updateEventSet(List<Event> events);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
@@ -360,7 +360,7 @@ public class RollCallFragment extends Fragment {
     }
 
     String pk = popToken.getPublicKey().getEncoded();
-    Timber.tag(TAG).d(TAG, "key displayed is " + pk);
+    Timber.tag(TAG).d("key displayed is %s", pk);
 
     // Set the QR visible only if the rollcall is opened and the user isn't the organizer
     binding.rollCallPkQrCode.setVisibility((rollCall.isOpen()) ? View.VISIBLE : View.INVISIBLE);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
@@ -7,7 +7,6 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 import android.widget.*;
 
@@ -46,6 +45,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import dagger.hilt.android.AndroidEntryPoint;
+import timber.log.Timber;
 
 import static com.github.dedis.popstellar.utility.Constants.*;
 
@@ -171,7 +171,7 @@ public class RollCallFragment extends Fragment {
             .getRollCallObservable(rollCall.getPersistentId())
             .subscribe(
                 rc -> {
-                  Log.d(TAG, "Received rc update: " + rc);
+                  Timber.tag(TAG).d("Received rc update: %s", rc);
                   rollCall = rc;
                   setUpStateDependantContent();
                 },
@@ -360,7 +360,7 @@ public class RollCallFragment extends Fragment {
     }
 
     String pk = popToken.getPublicKey().getEncoded();
-    Log.d(TAG, "key displayed is " + pk);
+    Timber.tag(TAG).d(TAG, "key displayed is " + pk);
 
     // Set the QR visible only if the rollcall is opened and the user isn't the organizer
     binding.rollCallPkQrCode.setVisibility((rollCall.isOpen()) ? View.VISIBLE : View.INVISIBLE);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallViewModel.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.event.rollcall;
 
 import android.app.Application;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -32,6 +31,7 @@ import javax.inject.Inject;
 import dagger.hilt.android.lifecycle.HiltViewModel;
 import io.reactivex.Observable;
 import io.reactivex.*;
+import timber.log.Timber;
 
 @HiltViewModel
 public class RollCallViewModel extends AndroidViewModel implements QRCodeScanningViewModel {
@@ -105,7 +105,7 @@ public class RollCallViewModel extends AndroidViewModel implements QRCodeScannin
       long creation,
       long proposedStart,
       long proposedEnd) {
-    Log.d(TAG, "creating a new roll call with title " + title);
+    Timber.tag(TAG).d("creating a new roll call with title %s", title);
 
     LaoView laoView;
     try {
@@ -133,7 +133,7 @@ public class RollCallViewModel extends AndroidViewModel implements QRCodeScannin
    * @param id the roll call id to open
    */
   public Completable openRollCall(String id) {
-    Log.d(TAG, "call openRollCall with id " + id);
+    Timber.tag(TAG).d("call openRollCall with id %s", id);
 
     LaoView laoView;
     try {
@@ -144,12 +144,10 @@ public class RollCallViewModel extends AndroidViewModel implements QRCodeScannin
     }
 
     if (!rollCallRepo.canOpenRollCall(laoId)) {
-      Log.d(
-          TAG,
-          "failed to open roll call with id "
-              + id
-              + " because another roll call was already opened, laoID: "
-              + laoView.getId());
+      Timber.tag(TAG)
+          .d(
+              "failed to open roll call with id %s because another roll call was already opened, laoID: %s",
+              id, laoView.getId());
       return Completable.error(new DoubleOpenedRollCallException(id));
     }
 
@@ -157,7 +155,7 @@ public class RollCallViewModel extends AndroidViewModel implements QRCodeScannin
 
     RollCall rollCall;
     try {
-      Log.d(TAG, "failed to retrieve roll call with id " + id + ", laoID: " + laoView.getId());
+      Timber.tag(TAG).d("failed to retrieve roll call with id %s, laoID: %s", id, laoView.getId());
       rollCall = rollCallRepo.getRollCallWithId(laoId, id);
     } catch (UnknownRollCallException e) {
       return Completable.error(new UnknownRollCallException(id));
@@ -174,7 +172,7 @@ public class RollCallViewModel extends AndroidViewModel implements QRCodeScannin
   }
 
   private void openRollCall(String currentId, LaoView laoView, RollCall rollCall) {
-    Log.d(TAG, "opening rollcall with id " + currentId);
+    Timber.tag(TAG).d("opening rollcall with id %s", currentId);
     attendees.addAll(rollCall.getAttendees());
 
     try {
@@ -193,7 +191,7 @@ public class RollCallViewModel extends AndroidViewModel implements QRCodeScannin
    * <p>Publish a GeneralMessage containing CloseRollCall data.
    */
   public Completable closeRollCall(String id) {
-    Log.d(TAG, "call closeRollCall");
+    Timber.tag(TAG).d("call closeRollCall");
 
     LaoView laoView;
     try {
@@ -213,7 +211,7 @@ public class RollCallViewModel extends AndroidViewModel implements QRCodeScannin
         .publish(keyManager.getMainKeyPair(), channel, closeRollCall)
         .doOnComplete(
             () -> {
-              Log.d(TAG, "closed the roll call with id " + id);
+              Timber.tag(TAG).d("closed the roll call with id %s", id);
               attendees.clear();
             });
   }
@@ -277,7 +275,7 @@ public class RollCallViewModel extends AndroidViewModel implements QRCodeScannin
     }
 
     attendees.add(publicKey);
-    Log.d(TAG, "Attendee " + publicKey + " successfully added");
+    Timber.tag(TAG).d("Attendee %s successfully added", publicKey);
     Toast.makeText(getApplication(), R.string.attendee_scan_success, Toast.LENGTH_SHORT).show();
     nbScanned.postValue(attendees.size());
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaHomeFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaHomeFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.socialmedia;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 
 import androidx.annotation.*;
@@ -17,6 +16,7 @@ import com.github.dedis.popstellar.utility.ActivityUtils;
 import java.util.function.Supplier;
 
 import dagger.hilt.android.AndroidEntryPoint;
+import timber.log.Timber;
 
 /**
  * The purpose of this fragment is to provide a bottom nav bar and fragment container to social
@@ -58,7 +58,7 @@ public class SocialMediaHomeFragment extends Fragment {
     binding.socialMediaNavBar.setOnItemSelectedListener(
         item -> {
           SocialMediaTab tab = SocialMediaTab.findByMenu(item.getItemId());
-          Log.i(TAG, "Opening tab : " + tab.getName());
+          Timber.tag(TAG).i("Opening tab : %s", tab.getName());
           openBottomTab(tab);
           return true;
         });

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.socialmedia;
 
 import android.app.Application;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -34,6 +33,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.disposables.CompositeDisposable;
+import timber.log.Timber;
 
 @HiltViewModel
 public class SocialMediaViewModel extends AndroidViewModel {
@@ -126,20 +126,20 @@ public class SocialMediaViewModel extends AndroidViewModel {
    */
   public Single<MessageGeneral> sendChirp(
       String text, @Nullable MessageID parentId, long timestamp) {
-    Log.d(TAG, "Sending a chirp");
+    Timber.tag(TAG).d("Sending a chirp");
 
     LaoView laoView;
     try {
       laoView = getLao();
     } catch (UnknownLaoException e) {
-      Log.e(TAG, LAO_FAILURE_MESSAGE);
+      Timber.tag(TAG).e(e, LAO_FAILURE_MESSAGE);
       return Single.error(new UnknownLaoException());
     }
 
     AddChirp addChirp = new AddChirp(text, parentId, timestamp);
 
     return Single.fromCallable(this::getValidPoPToken)
-        .doOnSuccess(token -> Log.d(TAG, "Retrieved PoPToken to send Chirp : " + token))
+        .doOnSuccess(token -> Timber.tag(TAG).d("Retrieved PoPToken to send Chirp : %s", token))
         .flatMap(
             token -> {
               Channel channel =
@@ -154,20 +154,20 @@ public class SocialMediaViewModel extends AndroidViewModel {
   }
 
   public Single<MessageGeneral> deleteChirp(MessageID chirpId, long timestamp) {
-    Log.d(TAG, "Deleting the chirp with id: " + chirpId);
+    Timber.tag(TAG).d("Deleting the chirp with id: %s", chirpId);
 
     final LaoView laoView;
     try {
       laoView = getLao();
     } catch (UnknownLaoException e) {
-      Log.e(TAG, LAO_FAILURE_MESSAGE);
+      Timber.tag(TAG).e(e, LAO_FAILURE_MESSAGE);
       return Single.error(new UnknownLaoException());
     }
 
     DeleteChirp deleteChirp = new DeleteChirp(chirpId, timestamp);
 
     return Single.fromCallable(this::getValidPoPToken)
-        .doOnSuccess(token -> Log.d(TAG, "Retrieved PoPToken to delete Chirp : " + token))
+        .doOnSuccess(token -> Timber.tag(TAG).d("Retrieved PoPToken to delete Chirp : %s", token))
         .flatMap(
             token -> {
               Channel channel =
@@ -217,7 +217,7 @@ public class SocialMediaViewModel extends AndroidViewModel {
    * @return true if the sender is the current user
    */
   public boolean isOwner(String sender) {
-    Log.d(TAG, "Testing if the sender is also the owner");
+    Timber.tag(TAG).d("Testing if the sender is also the owner");
 
     try {
       PoPToken token = getValidPoPToken();

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenFragment.java
@@ -4,7 +4,6 @@ import android.content.*;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 import android.widget.Toast;
 
@@ -33,6 +32,7 @@ import net.glxn.qrgen.android.QRCode;
 import javax.inject.Inject;
 
 import dagger.hilt.android.AndroidEntryPoint;
+import timber.log.Timber;
 
 @AndroidEntryPoint
 public class TokenFragment extends Fragment {
@@ -74,7 +74,7 @@ public class TokenFragment extends Fragment {
       RollCall rollCall =
           rollCallRepo.getRollCallWithPersistentId(
               laoViewModel.getLaoId(), requireArguments().getString(Constants.ROLL_CALL_ID));
-      Log.d(TAG, "token displayed from roll call: " + rollCall);
+      Timber.tag(TAG).d("token displayed from roll call: %s", rollCall);
 
       PoPToken poPToken = keyManager.getValidPoPToken(laoViewModel.getLaoId(), rollCall);
       PopTokenData data = new PopTokenData(poPToken.getPublicKey());

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragment.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.witness;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 import android.widget.ListView;
 
@@ -16,6 +15,7 @@ import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import java.util.ArrayList;
 
 import dagger.hilt.android.AndroidEntryPoint;
+import timber.log.Timber;
 
 @AndroidEntryPoint
 public class WitnessMessageFragment extends Fragment {
@@ -60,7 +60,7 @@ public class WitnessMessageFragment extends Fragment {
         .observe(
             requireActivity(),
             messages -> {
-              Log.d(TAG, "witness messages updated");
+              Timber.tag(TAG).d("witness messages updated");
               adapter.replaceList(messages);
             });
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessingViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessingViewModel.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.witness;
 
 import android.app.Application;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -35,6 +34,7 @@ import io.reactivex.Completable;
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
+import timber.log.Timber;
 
 @HiltViewModel
 public class WitnessingViewModel extends AndroidViewModel implements QRCodeScanningViewModel {
@@ -102,12 +102,12 @@ public class WitnessingViewModel extends AndroidViewModel implements QRCodeScann
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(
                 laoView -> {
-                  Log.d(TAG, "got an update for lao: " + laoView);
+                  Timber.tag(TAG).d("got an update for lao: %s", laoView);
 
                   setWitnessMessages(new ArrayList<>(laoView.getWitnessMessages().values()));
                   setWitnesses(new ArrayList<>(laoView.getWitnesses()));
                 },
-                error -> Log.d(TAG, "error updating LAO :" + error)));
+                error -> Timber.tag(TAG).d(error, "error updating LAO")));
   }
 
   @Override
@@ -122,7 +122,7 @@ public class WitnessingViewModel extends AndroidViewModel implements QRCodeScann
   }
 
   protected Completable signMessage(WitnessMessage witnessMessage) {
-    Log.d(TAG, "signing message with ID " + witnessMessage.getMessageId());
+    Timber.tag(TAG).d("signing message with ID %s", witnessMessage.getMessageId());
     final LaoView laoView;
     try {
       laoView = getLao();
@@ -137,7 +137,7 @@ public class WitnessingViewModel extends AndroidViewModel implements QRCodeScann
               // Generate the signature of the message
               Signature signature = keyPair.sign(witnessMessage.getMessageId());
 
-              Log.d(TAG, "Signed message id, resulting signature : " + signature);
+              Timber.tag(TAG).d("Signed message id, resulting signature : %s", signature);
               WitnessMessageSignature signatureMessage =
                   new WitnessMessageSignature(witnessMessage.getMessageId(), signature);
 
@@ -165,7 +165,7 @@ public class WitnessingViewModel extends AndroidViewModel implements QRCodeScann
 
     scannedWitnesses.add(publicKey);
     nbScanned.setValue(scannedWitnesses.size());
-    Log.d(TAG, "Witness " + publicKey + " successfully scanned");
+    Timber.tag(TAG).d("Witness %s successfully scanned", publicKey);
     Toast.makeText(getApplication(), R.string.witness_scan_success, Toast.LENGTH_SHORT).show();
     disposables.add(
         updateLaoWitnesses()
@@ -173,7 +173,7 @@ public class WitnessingViewModel extends AndroidViewModel implements QRCodeScann
                 () -> {
                   String networkSuccess =
                       String.format(getApplication().getString(R.string.witness_added), publicKey);
-                  Log.d(TAG, networkSuccess);
+                  Timber.tag(TAG).d(networkSuccess);
                   Toast.makeText(getApplication(), networkSuccess, Toast.LENGTH_SHORT).show();
                 },
                 error -> {
@@ -184,7 +184,7 @@ public class WitnessingViewModel extends AndroidViewModel implements QRCodeScann
   }
 
   private Completable updateLaoWitnesses() {
-    Log.d(TAG, "Updating lao witnesses ");
+    Timber.tag(TAG).d("Updating lao witnesses ");
 
     LaoView laoView;
     try {
@@ -209,7 +209,7 @@ public class WitnessingViewModel extends AndroidViewModel implements QRCodeScann
     return networkManager
         .getMessageSender()
         .publish(channel, msg)
-        .doOnComplete(() -> Log.d(TAG, "updated lao witnesses"))
+        .doOnComplete(() -> Timber.tag(TAG).d("updated lao witnesses"))
         .andThen(dispatchLaoUpdate(updateLao, laoView, channel, msg));
   }
 
@@ -229,7 +229,7 @@ public class WitnessingViewModel extends AndroidViewModel implements QRCodeScann
     return networkManager
         .getMessageSender()
         .publish(keyManager.getMainKeyPair(), channel, stateLao)
-        .doOnComplete(() -> Log.d(TAG, "updated lao with " + stateLao));
+        .doOnComplete(() -> Timber.tag(TAG).d("updated lao with %s", stateLao));
   }
 
   private LaoView getLao() throws UnknownLaoException {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QrScannerFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/qrcode/QrScannerFragment.java
@@ -2,7 +2,6 @@ package com.github.dedis.popstellar.ui.qrcode;
 
 import android.Manifest;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.*;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -22,6 +21,8 @@ import com.google.mlkit.vision.barcode.common.Barcode;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
+
+import timber.log.Timber;
 
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 import static androidx.camera.view.CameraController.COORDINATE_SYSTEM_VIEW_REFERENCED;
@@ -172,7 +173,7 @@ public class QrScannerFragment extends Fragment {
             result -> {
               List<Barcode> barcodes = result.getValue(barcodeScanner);
               if (barcodes != null && !barcodes.isEmpty()) {
-                Log.d(TAG, "barcode raw value :" + barcodes.get(0).getRawValue());
+                Timber.tag(TAG).d("barcode raw value : %s", barcodes.get(0).getRawValue());
                 onResult(barcodes.get(0));
               }
             }));

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/ActivityUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/ActivityUtils.java
@@ -3,7 +3,6 @@ package com.github.dedis.popstellar.utility;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Color;
-import android.util.Log;
 
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
@@ -21,6 +20,8 @@ import java.security.GeneralSecurityException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Supplier;
+
+import timber.log.Timber;
 
 public class ActivityUtils {
   private static final String TAG = ActivityUtils.class.getSimpleName();
@@ -54,7 +55,7 @@ public class ActivityUtils {
    * @return true if the storage process was a success; false otherwise
    */
   public static boolean storePersistentData(Context context, PersistentData data) {
-    Log.d(TAG, "Initiating storage of " + data);
+    Timber.tag(TAG).d("Initiating storage of %s", data);
 
     try (ObjectOutputStream oos =
         new ObjectOutputStream(
@@ -64,7 +65,7 @@ public class ActivityUtils {
       ErrorUtils.logAndShow(context, TAG, e, R.string.error_storing_data);
       return false;
     }
-    Log.d(TAG, "storage successful");
+    Timber.tag(TAG).d("storage successful");
     return true;
   }
 
@@ -75,7 +76,7 @@ public class ActivityUtils {
    * @return the data if found, null otherwise
    */
   public static PersistentData loadPersistentData(Context context) {
-    Log.d(TAG, "Initiating loading of data");
+    Timber.tag(TAG).d("Initiating loading of data");
 
     PersistentData persistentData;
     try (ObjectInputStream ois =
@@ -89,7 +90,7 @@ public class ActivityUtils {
       return null;
     }
 
-    Log.d(TAG, "loading of " + persistentData);
+    Timber.tag(TAG).d("loading of %s", persistentData);
     return persistentData;
   }
 
@@ -100,7 +101,7 @@ public class ActivityUtils {
    * @return true if the clearing was a success; false otherwise
    */
   public static boolean clearStorage(Context context) {
-    Log.d(TAG, "clearing data");
+    Timber.tag(TAG).d("clearing data");
 
     File file = new File(context.getFilesDir(), PERSISTENT_DATA_FILE_NAME);
     return file.delete();
@@ -128,14 +129,10 @@ public class ActivityUtils {
     }
 
     String[] seed = wallet.exportSeed();
-    Log.d(
-        TAG,
-        "seed length"
-            + seed.length
-            + " address "
-            + serverAddress
-            + " subscriptions "
-            + subscriptions);
+    Timber.tag(TAG)
+        .d(
+            "seed length: %d, address: %s, subscriptions: %s",
+            seed.length, serverAddress, subscriptions);
     return storePersistentData(context, new PersistentData(seed, serverAddress, subscriptions));
   }
 
@@ -153,7 +150,7 @@ public class ActivityUtils {
     return new OnBackPressedCallback(true) {
       @Override
       public void handleOnBackPressed() {
-        Log.d(tag, "Back pressed, going to " + message);
+        Timber.tag(tag).d("Back pressed, going to %s", message);
         callback.run();
       }
     };

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/ActivityUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/ActivityUtils.java
@@ -31,7 +31,9 @@ public class ActivityUtils {
       FragmentManager manager, int containerId, int id, Supplier<Fragment> fragmentSupplier) {
     Fragment fragment = manager.findFragmentById(id);
     // If the fragment was not created yet, create it now
-    if (fragment == null) fragment = fragmentSupplier.get();
+    if (fragment == null) {
+      fragment = fragmentSupplier.get();
+    }
 
     // Set the new fragment in the container
     ActivityUtils.replaceFragmentInActivity(manager, fragment, containerId);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/ActivityUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/ActivityUtils.java
@@ -40,6 +40,14 @@ public class ActivityUtils {
     ActivityUtils.replaceFragmentInActivity(manager, fragment, containerId);
   }
 
+  public static void setFragmentInContainer(
+      FragmentManager manager, int containerId, Supplier<Fragment> fragmentSupplier) {
+    Fragment fragment = fragmentSupplier.get();
+
+    // Set the new fragment in the container
+    ActivityUtils.replaceFragmentInActivity(manager, fragment, containerId);
+  }
+
   public static void replaceFragmentInActivity(
       @NonNull FragmentManager fragmentManager, @NonNull Fragment fragment, int frameId) {
     FragmentTransaction transaction = fragmentManager.beginTransaction();

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/MessageValidator.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/MessageValidator.java
@@ -2,6 +2,7 @@ package com.github.dedis.popstellar.utility;
 
 import com.github.dedis.popstellar.model.objects.Lao;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
+
 import java.time.Instant;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -10,8 +11,11 @@ import java.util.regex.Pattern;
 public abstract class MessageValidator {
 
   /** URL-safe base64 pattern */
-  public static final Pattern BASE64_PATTERN =
+  private static final Pattern BASE64_PATTERN =
       Pattern.compile("^(?:[A-Za-z0-9-_]{4})*(?:[A-Za-z0-9-_]{2}==|[A-Za-z0-9-_]{3}=)?$");
+
+  private static final Pattern URL_PATTERN =
+      Pattern.compile("\\b(?:http|ws)s?:\\/\\/\\S*[^\\s.\"]");
 
   /** Prevent instantiations */
   private MessageValidator() {}
@@ -111,6 +115,13 @@ public abstract class MessageValidator {
     public MessageValidatorBuilder checkListNotEmpty(List<?> list) {
       if (list == null || list.isEmpty()) {
         throw new IllegalArgumentException("List cannot be empty");
+      }
+      return this;
+    }
+
+    public MessageValidatorBuilder checkValidUrl(String input) {
+      if (input == null || !URL_PATTERN.matcher(input).matches()) {
+        throw new IllegalArgumentException("Input is not a url");
       }
       return this;
     }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/NetworkLogger.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/NetworkLogger.java
@@ -65,7 +65,7 @@ public class NetworkLogger extends Timber.Tree {
     application.registerActivityLifecycleCallbacks(
         new Application.ActivityLifecycleCallbacks() {
 
-          private static final boolean saveEnergy = false;
+          private static final boolean SAVE_ENERGY = false;
 
           @Override
           public void onActivityCreated(
@@ -85,14 +85,14 @@ public class NetworkLogger extends Timber.Tree {
 
           @Override
           public void onActivityPaused(@NonNull Activity activity) {
-            if (saveEnergy) {
+            if (SAVE_ENERGY) {
               closeWebSocket();
             }
           }
 
           @Override
           public void onActivityStopped(@NonNull Activity activity) {
-            if (saveEnergy) {
+            if (SAVE_ENERGY) {
               closeWebSocket();
             }
           }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/NetworkLogger.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/NetworkLogger.java
@@ -7,40 +7,82 @@ import androidx.annotation.NonNull;
 import java.time.Clock;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import okhttp3.*;
 import timber.log.Timber;
 
 public class NetworkLogger extends Timber.Tree {
   private static final String SERVER_URL = "url";
 
+  private static WebSocket webSocket;
+  private static final Object lock = new Object();
+
   public static final AtomicBoolean sendToServer = new AtomicBoolean(false);
 
   @Override
   protected void log(int priority, String tag, @NonNull String message, Throwable t) {
+    String error = t == null ? "" : Log.getStackTraceString(t);
     // Print the log to console
-    Timber.tag(tag).log(priority, message, t);
+    if (t != null) {
+      Log.println(priority, tag, message + "\n" + error);
+    } else {
+      Log.println(priority, tag, message);
+    }
 
     // Send the log message to the remote server
     if (sendToServer.get()) {
-      sendToServer(
-          String.format(
-              "[%s] [%s] %s: %s\nE/: %s",
-              Clock.systemUTC().instant(),
-              getPriorityString(priority),
-              tag,
-              message,
-              t.getMessage()));
+      String log =
+          t == null
+              ? String.format(
+                  "[%s]-[%s]-%s: %s",
+                  Clock.systemUTC().instant(), getPriorityString(priority), tag, message)
+              : String.format(
+                  "[%s]-[%s]-%s: %s\nERROR: %s",
+                  Clock.systemUTC().instant(), getPriorityString(priority), tag, message, error);
+      sendToServer(log);
     }
   }
 
   public static void enableRemote() {
+    connectWebSocket();
     sendToServer.set(true);
   }
 
   public static void disableRemote() {
     sendToServer.set(false);
+    closeWebSocket();
   }
 
-  private void sendToServer(String log) {}
+  private static void connectWebSocket() {
+    Request request = new Request.Builder().url(SERVER_URL).build();
+    OkHttpClient client = new OkHttpClient();
+    webSocket =
+        client.newWebSocket(
+            request,
+            new WebSocketListener() {
+              @Override
+              public void onMessage(@NonNull WebSocket webSocket, @NonNull String text) {
+                // For now no message from the remote server is sent, so no handling required
+              }
+            });
+  }
+
+  private static void closeWebSocket() {
+    synchronized (lock) {
+      if (webSocket != null) {
+        webSocket.close(1000, null);
+        webSocket = null;
+      }
+    }
+  }
+
+  private void sendToServer(String log) {
+    synchronized (lock) {
+      if (webSocket == null) {
+        connectWebSocket();
+      }
+      webSocket.send(log);
+    }
+  }
 
   private String getPriorityString(int priority) {
     switch (priority) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/NetworkLogger.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/NetworkLogger.java
@@ -1,0 +1,59 @@
+package com.github.dedis.popstellar.utility;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import java.time.Clock;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import timber.log.Timber;
+
+public class NetworkLogger extends Timber.Tree {
+  private static final String SERVER_URL = "url";
+
+  public static final AtomicBoolean sendToServer = new AtomicBoolean(false);
+
+  @Override
+  protected void log(int priority, String tag, @NonNull String message, Throwable t) {
+    // Print the log to console
+    Timber.tag(tag).log(priority, message, t);
+
+    // Send the log message to the remote server
+    if (sendToServer.get()) {
+      sendToServer(
+          String.format(
+              "[%s] [%s] %s: %s\nE/: %s",
+              Clock.systemUTC().instant(),
+              getPriorityString(priority),
+              tag,
+              message,
+              t.getMessage()));
+    }
+  }
+
+  public static void enableRemote() {
+    sendToServer.set(true);
+  }
+
+  public static void disableRemote() {
+    sendToServer.set(false);
+  }
+
+  private void sendToServer(String log) {}
+
+  private String getPriorityString(int priority) {
+    switch (priority) {
+      case Log.DEBUG:
+        return "D/";
+      case Log.INFO:
+        return "I/";
+      case Log.WARN:
+        return "W/";
+      case Log.ERROR:
+        return "E/";
+      default:
+        return "UNKNOWN/";
+    }
+  }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/NetworkLogger.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/NetworkLogger.java
@@ -1,8 +1,13 @@
 package com.github.dedis.popstellar.utility;
 
+import android.annotation.SuppressLint;
+import android.content.Context;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.preference.PreferenceManager;
+
+import com.github.dedis.popstellar.R;
 
 import java.time.Clock;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -10,17 +15,45 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import okhttp3.*;
 import timber.log.Timber;
 
+/**
+ * This class extends the default Timber.Tree to implement a custom logger which decides whether to
+ * forward logs also to a server or to print them on the console.
+ */
 public class NetworkLogger extends Timber.Tree {
-  private static final String SERVER_URL = "url";
+
+  private static final String TAG = NetworkLogger.class.getSimpleName();
+
+  /** URL of the remote server to which sending the logs */
+  private static String serverUrl;
 
   private static WebSocket webSocket;
+  /**
+   * As the connection is implemented static to be opened and closed only once, its access is
+   * synchronized through this lock
+   */
   private static final Object lock = new Object();
 
-  public static final AtomicBoolean sendToServer = new AtomicBoolean(false);
+  /**
+   * Boolean which is atomically set by the user from the settings and checked by the loggers. This
+   * value is set based on the settings, which is persisted even after the application is closed
+   */
+  public static AtomicBoolean sendToServer;
+
+  public NetworkLogger(Context context) {
+    sendToServer =
+        new AtomicBoolean(
+            PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(context.getString(R.string.settings_logging_key), false));
+    serverUrl =
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .getString(context.getString(R.string.settings_server_url_key), "");
+  }
 
   @Override
   protected void log(int priority, String tag, @NonNull String message, Throwable t) {
+    // Take the stack trace of the error if present
     String error = t == null ? "" : Log.getStackTraceString(t);
+
     // Print the log to console
     if (t != null) {
       Log.println(priority, tag, message + "\n" + error);
@@ -36,37 +69,46 @@ public class NetworkLogger extends Timber.Tree {
                   "[%s]-[%s]-%s: %s",
                   Clock.systemUTC().instant(), getPriorityString(priority), tag, message)
               : String.format(
-                  "[%s]-[%s]-%s: %s\nERROR: %s",
+                  "[%s]-[%s]-%s: %s%nERROR: %s",
                   Clock.systemUTC().instant(), getPriorityString(priority), tag, message, error);
       sendToServer(log);
     }
   }
 
+  /** Function to enable the remote logging. It opens the websocket */
   public static void enableRemote() {
     connectWebSocket();
     sendToServer.set(true);
   }
 
+  /** Function to disable the remote logging. It closes the websocket */
   public static void disableRemote() {
     sendToServer.set(false);
     closeWebSocket();
   }
 
+  @SuppressLint("LogNotTimber")
   private static void connectWebSocket() {
-    Request request = new Request.Builder().url(SERVER_URL).build();
-    OkHttpClient client = new OkHttpClient();
-    webSocket =
-        client.newWebSocket(
-            request,
-            new WebSocketListener() {
-              @Override
-              public void onMessage(@NonNull WebSocket webSocket, @NonNull String text) {
-                // For now no message from the remote server is sent, so no handling required
-              }
-            });
+    try {
+      Request request = new Request.Builder().url(serverUrl).build();
+      OkHttpClient client = new OkHttpClient();
+      // Create the socket with an empty listener
+      webSocket =
+          client.newWebSocket(
+              request,
+              new WebSocketListener() {
+                @Override
+                public void onMessage(@NonNull WebSocket webSocket, @NonNull String text) {
+                  // For now no message from the remote server is sent, so no handling required
+                }
+              });
+    } catch (IllegalArgumentException e) {
+      Log.e(TAG, "Error on the url provided", e);
+    }
   }
 
   private static void closeWebSocket() {
+    // Take the lock and then close the websocket
     synchronized (lock) {
       if (webSocket != null) {
         webSocket.close(1000, null);
@@ -76,11 +118,15 @@ public class NetworkLogger extends Timber.Tree {
   }
 
   private void sendToServer(String log) {
+    // Take the lock and send the log as UTF-8 encoded string
     synchronized (lock) {
       if (webSocket == null) {
         connectWebSocket();
       }
-      webSocket.send(log);
+      // Connect may fail
+      if (webSocket != null) {
+        webSocket.send(log);
+      }
     }
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/NetworkLogger.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/NetworkLogger.java
@@ -24,7 +24,7 @@ public class NetworkLogger extends Timber.Tree {
   private static final String TAG = NetworkLogger.class.getSimpleName();
 
   /** URL of the remote server to which sending the logs */
-  private static String serverUrl;
+  private static final StringBuilder serverUrl = new StringBuilder();
 
   private static WebSocket webSocket;
   /**
@@ -37,16 +37,15 @@ public class NetworkLogger extends Timber.Tree {
    * Boolean which is atomically set by the user from the settings and checked by the loggers. This
    * value is set based on the settings, which is persisted even after the application is closed
    */
-  public static AtomicBoolean sendToServer;
+  private static final AtomicBoolean sendToServer = new AtomicBoolean(false);
 
   public NetworkLogger(Context context) {
-    sendToServer =
-        new AtomicBoolean(
-            PreferenceManager.getDefaultSharedPreferences(context)
-                .getBoolean(context.getString(R.string.settings_logging_key), false));
-    serverUrl =
+    sendToServer.set(
+        (PreferenceManager.getDefaultSharedPreferences(context)
+            .getBoolean(context.getString(R.string.settings_logging_key), false)));
+    serverUrl.append(
         PreferenceManager.getDefaultSharedPreferences(context)
-            .getString(context.getString(R.string.settings_server_url_key), "");
+            .getString(context.getString(R.string.settings_server_url_key), ""));
   }
 
   @Override
@@ -87,10 +86,14 @@ public class NetworkLogger extends Timber.Tree {
     closeWebSocket();
   }
 
+  public static void setServerUrl(String url) {
+    serverUrl.replace(0, serverUrl.length(), url);
+  }
+
   @SuppressLint("LogNotTimber")
   private static void connectWebSocket() {
     try {
-      Request request = new Request.Builder().url(serverUrl).build();
+      Request request = new Request.Builder().url(serverUrl.toString()).build();
       OkHttpClient client = new OkHttpClient();
       // Create the socket with an empty listener
       webSocket =

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/NetworkLogger.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/NetworkLogger.java
@@ -65,7 +65,7 @@ public class NetworkLogger extends Timber.Tree {
     application.registerActivityLifecycleCallbacks(
         new Application.ActivityLifecycleCallbacks() {
 
-          private final boolean saveEnergy = false;
+          private static final boolean saveEnergy = false;
 
           @Override
           public void onActivityCreated(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/error/ErrorUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/error/ErrorUtils.java
@@ -2,7 +2,6 @@ package com.github.dedis.popstellar.utility.error;
 
 import android.content.Context;
 import android.os.Handler;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.StringRes;
@@ -13,7 +12,11 @@ import org.bouncycastle.util.Arrays;
 
 import java.util.concurrent.TimeoutException;
 
+import timber.log.Timber;
+
 public class ErrorUtils {
+
+  private static final String TAG = ErrorUtils.class.getSimpleName();
 
   private ErrorUtils() throws IllegalAccessException {
     throw new IllegalAccessException();
@@ -29,7 +32,7 @@ public class ErrorUtils {
   public static void logAndShow(Context context, String tag, @StringRes int action) {
     String message = context.getString(action);
 
-    Log.e(tag, message);
+    Timber.tag(tag).e(message);
     displayToast(context, message);
   }
 
@@ -51,7 +54,7 @@ public class ErrorUtils {
       Context context, String tag, Throwable error, @StringRes int action, String... actionArgs) {
     String exceptionMsg = getLocalizedMessage(context, error, action, actionArgs);
 
-    Log.e(tag, exceptionMsg, error);
+    Timber.tag(tag).e(error, exceptionMsg);
     displayToast(context, exceptionMsg);
   }
 
@@ -78,9 +81,7 @@ public class ErrorUtils {
     } else {
       // It is not a known error, let's log it but not show information to
       // the average user as it will not be useful to him.
-      Log.d(
-          ErrorUtils.class.getSimpleName(),
-          "Error " + error.getClass() + " is not a know error type.");
+      Timber.tag(TAG).d("Error %s is not a know error type", error.getClass());
       return "";
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/error/ErrorUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/error/ErrorUtils.java
@@ -54,7 +54,7 @@ public class ErrorUtils {
       Context context, String tag, Throwable error, @StringRes int action, String... actionArgs) {
     String exceptionMsg = getLocalizedMessage(context, error, action, actionArgs);
 
-    Timber.tag(tag).e(error, exceptionMsg);
+    Timber.tag(tag).e(error);
     displayToast(context, exceptionMsg);
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/MessageHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/MessageHandler.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.utility.handler;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
 import com.github.dedis.popstellar.model.network.method.message.data.*;
 import com.github.dedis.popstellar.model.objects.Channel;
@@ -13,6 +11,8 @@ import com.github.dedis.popstellar.utility.handler.data.HandlerContext;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import timber.log.Timber;
 
 /** General message handler class */
 @Singleton
@@ -39,15 +39,15 @@ public final class MessageHandler {
   public void handleMessage(MessageSender messageSender, Channel channel, MessageGeneral message)
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
           UnknownElectionException, NoRollCallException {
-    Log.d(TAG, "handle incoming message");
+    Timber.tag(TAG).d("handle incoming message");
 
     if (messageRepo.isMessagePresent(message.getMessageId())) {
-      Log.d(TAG, "the message has already been handled in the past");
+      Timber.tag(TAG).d("the message has already been handled in the past");
       return;
     }
 
     Data data = message.getData();
-    Log.d(TAG, "data with class: " + data.getClass());
+    Timber.tag(TAG).d("data with class: %s", data.getClass());
     Objects dataObj = Objects.find(data.getObject());
     Action dataAction = Action.find(data.getAction());
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ChirpHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ChirpHandler.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.utility.handler.data;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.network.method.message.data.socialmedia.AddChirp;
 import com.github.dedis.popstellar.model.network.method.message.data.socialmedia.DeleteChirp;
 import com.github.dedis.popstellar.model.objects.Channel;
@@ -15,6 +13,8 @@ import com.github.dedis.popstellar.utility.error.InvalidMessageIdException;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 
 import javax.inject.Inject;
+
+import timber.log.Timber;
 
 /** Chirp messages handler class */
 public final class ChirpHandler {
@@ -41,7 +41,7 @@ public final class ChirpHandler {
     MessageID messageId = context.getMessageId();
     PublicKey senderPk = context.getSenderPk();
 
-    Log.d(TAG, "handleChirpAdd: " + channel + " id " + addChirp.getParentId());
+    Timber.tag(TAG).d("handleChirpAdd: channel: %s, id: %s", channel, addChirp.getParentId());
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
     Chirp chirp =
         new Chirp(
@@ -64,7 +64,7 @@ public final class ChirpHandler {
       throws UnknownLaoException, InvalidMessageIdException {
     Channel channel = context.getChannel();
 
-    Log.d(TAG, "handleDeleteChirp: " + channel + " id " + deleteChirp.getChirpId());
+    Timber.tag(TAG).d("handleDeleteChirp: channel: %s, id: %s", channel, deleteChirp.getChirpId());
 
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
     boolean chirpExist = socialMediaRepo.deleteChirp(laoView.getId(), deleteChirp.getChirpId());

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ConsensusHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ConsensusHandler.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.utility.handler.data;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.network.method.message.data.Data;
 import com.github.dedis.popstellar.model.network.method.message.data.consensus.*;
 import com.github.dedis.popstellar.model.objects.*;
@@ -15,6 +13,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Inject;
+
+import timber.log.Timber;
 
 public final class ConsensusHandler {
 
@@ -39,7 +39,7 @@ public final class ConsensusHandler {
     MessageID messageId = context.getMessageId();
     PublicKey senderPk = context.getSenderPk();
 
-    Log.d(TAG, "handleElect: " + channel + " id " + consensusElect.getInstanceId());
+    Timber.tag(TAG).d("handleElect: channel: %s, id: %s", channel, consensusElect.getInstanceId());
 
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
     Set<PublicKey> nodes = laoView.getWitnesses();
@@ -60,13 +60,15 @@ public final class ConsensusHandler {
     MessageID messageId = context.getMessageId();
     PublicKey senderPk = context.getSenderPk();
 
-    Log.d(TAG, "handleElectAccept: " + channel + " id " + consensusElectAccept.getInstanceId());
+    Timber.tag(TAG)
+        .d("handleElectAccept: channel: %s, id: %s", channel, consensusElectAccept.getInstanceId());
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     Optional<ElectInstance> electInstanceOpt =
         laoView.getElectInstance(consensusElectAccept.getMessageId());
     if (!electInstanceOpt.isPresent()) {
-      Log.w(TAG, "elect_accept for invalid messageId : " + consensusElectAccept.getMessageId());
+      Timber.tag(TAG)
+          .w("elect_accept for invalid messageId : %s", consensusElectAccept.getMessageId());
       throw new InvalidMessageIdException(
           consensusElectAccept, consensusElectAccept.getMessageId());
     }
@@ -82,20 +84,21 @@ public final class ConsensusHandler {
 
   @SuppressWarnings("unused")
   public <T extends Data> void handleBackend(HandlerContext context, T data) {
-    Log.w(TAG, "Received a consensus message only for backend with action=" + data.getAction());
+    Timber.tag(TAG)
+        .w("Received a consensus message only for backend with action: %s", data.getAction());
   }
 
   public void handleLearn(HandlerContext context, ConsensusLearn consensusLearn)
       throws DataHandlingException, UnknownLaoException {
     Channel channel = context.getChannel();
 
-    Log.d(TAG, "handleLearn: " + channel + " id " + consensusLearn.getInstanceId());
+    Timber.tag(TAG).d("handleLearn: channel: %s, id: %s", channel, consensusLearn.getInstanceId());
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     Optional<ElectInstance> electInstanceOpt =
         laoView.getElectInstance(consensusLearn.getMessageId());
     if (!electInstanceOpt.isPresent()) {
-      Log.w(TAG, "learn for invalid messageId : " + consensusLearn.getMessageId());
+      Timber.tag(TAG).w("learn for invalid messageId : %s", consensusLearn.getMessageId());
       throw new InvalidMessageIdException(consensusLearn, consensusLearn.getMessageId());
     }
 
@@ -115,12 +118,13 @@ public final class ConsensusHandler {
       throws UnknownLaoException, InvalidMessageIdException {
     Channel channel = context.getChannel();
 
-    Log.d(TAG, "handleConsensusFailure: " + channel + " id " + failure.getInstanceId());
+    Timber.tag(TAG)
+        .d("handleConsensusFailure: channel: %s, id: %s", channel, failure.getInstanceId());
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     Optional<ElectInstance> electInstanceOpt = laoView.getElectInstance(failure.getMessageId());
     if (!electInstanceOpt.isPresent()) {
-      Log.w(TAG, "Failure for invalid messageId : " + failure.getMessageId());
+      Timber.tag(TAG).w("Failure for invalid messageId : %s", failure.getMessageId());
       throw new InvalidMessageIdException(failure, failure.getMessageId());
     }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.utility.handler.data;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 
 import com.github.dedis.popstellar.model.network.method.message.data.Data;
@@ -16,6 +14,8 @@ import com.github.dedis.popstellar.utility.error.*;
 import java.util.*;
 
 import javax.inject.Inject;
+
+import timber.log.Timber;
 
 import static com.github.dedis.popstellar.model.objects.event.EventState.*;
 
@@ -52,7 +52,8 @@ public final class ElectionHandler {
     }
 
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
-    Log.d(TAG, "handleElectionSetup: channel " + channel + " name " + electionSetup.getName());
+    Timber.tag(TAG)
+        .d("handleElectionSetup: channel: %s, name: %s", channel, electionSetup.getName());
 
     Election election =
         new Election.ElectionBuilder(
@@ -72,11 +73,12 @@ public final class ElectionHandler {
         .getMessageSender()
         .subscribe(election.getChannel())
         .doOnError(
-            err -> Log.e(TAG, "An error occurred while subscribing to election channel", err))
+            err ->
+                Timber.tag(TAG).e(err, "An error occurred while subscribing to election channel"))
         .onErrorComplete()
         .subscribe();
 
-    Log.d(TAG, "election id " + election.getId());
+    Timber.tag(TAG).d("election id %s", election.getId());
 
     Lao lao = laoView.createLaoCopy();
     lao.updateWitnessMessage(messageId, electionSetupWitnessMessage(messageId, election));
@@ -93,10 +95,10 @@ public final class ElectionHandler {
       throws UnknownElectionException {
     Channel channel = context.getChannel();
 
-    Log.d(TAG, "handling election result");
+    Timber.tag(TAG).d("handling election result");
 
     List<ElectionResultQuestion> resultsQuestions = electionResult.getElectionQuestionResults();
-    Log.d(TAG, "size of resultsQuestions is " + resultsQuestions.size());
+    Timber.tag(TAG).d("size of resultsQuestions is %d", resultsQuestions.size());
     // No need to check here that resultsQuestions is not empty, as it is already done at the
     // creation of the ElectionResult Data
 
@@ -134,7 +136,7 @@ public final class ElectionHandler {
       throws InvalidStateException, UnknownElectionException {
     Channel channel = context.getChannel();
 
-    Log.d(TAG, "handleOpenElection: channel " + channel);
+    Timber.tag(TAG).d("handleOpenElection: channel %s", channel);
     Election election = electionRepository.getElectionByChannel(channel);
 
     // If the state is not created, then this message is invalid
@@ -147,7 +149,7 @@ public final class ElectionHandler {
     Election updated =
         election.builder().setState(OPENED).setStart(openElection.getOpenedAt()).build();
 
-    Log.d(TAG, "election opened " + updated.getStartTimestamp());
+    Timber.tag(TAG).d("election opened %d", updated.getStartTimestamp());
     electionRepository.updateElection(updated);
   }
 
@@ -162,7 +164,7 @@ public final class ElectionHandler {
       throws UnknownElectionException {
     Channel channel = context.getChannel();
 
-    Log.d(TAG, "handleElectionEnd: channel " + channel);
+    Timber.tag(TAG).d("handleElectionEnd: channel %s", channel);
     Election election =
         electionRepository.getElectionByChannel(channel).builder().setState(CLOSED).build();
 
@@ -181,7 +183,7 @@ public final class ElectionHandler {
     MessageID messageId = context.getMessageId();
     PublicKey senderPk = context.getSenderPk();
 
-    Log.d(TAG, "handleCastVote: channel " + channel);
+    Timber.tag(TAG).d("handleCastVote: channel %s", channel);
     Election election = electionRepository.getElectionByChannel(channel);
     // Verify the vote was created before the end of the election or the election is not closed yet
     if (election.getEndTimestamp() >= castVote.getCreation() || election.getState() != CLOSED) {
@@ -255,7 +257,7 @@ public final class ElectionHandler {
       throws UnknownElectionException {
     Channel channel = context.getChannel();
 
-    Log.d(TAG, "handleElectionKey: channel " + channel);
+    Timber.tag(TAG).d("handleElectionKey: channel %s", channel);
 
     Election election =
         electionRepository
@@ -266,6 +268,6 @@ public final class ElectionHandler {
 
     electionRepository.updateElection(election);
 
-    Log.d(TAG, "handleElectionKey: election key has been set ");
+    Timber.tag(TAG).d("handleElectionKey: election key has been set");
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.utility.handler.data;
 
 import android.annotation.SuppressLint;
-import android.util.Log;
 
 import com.github.dedis.popstellar.model.network.method.message.data.rollcall.*;
 import com.github.dedis.popstellar.model.objects.*;
@@ -17,6 +16,8 @@ import com.github.dedis.popstellar.utility.error.UnknownRollCallException;
 import java.util.Set;
 
 import javax.inject.Inject;
+
+import timber.log.Timber;
 
 /** Roll Call messages handler class */
 public final class RollCallHandler {
@@ -51,7 +52,8 @@ public final class RollCallHandler {
     Channel channel = context.getChannel();
     MessageID messageId = context.getMessageId();
 
-    Log.d(TAG, "handleCreateRollCall: " + channel + " name " + createRollCall.getName());
+    Timber.tag(TAG)
+        .d("handleCreateRollCall: channel: %s, name: %s", channel, createRollCall.getName());
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     RollCallBuilder builder = new RollCallBuilder();
@@ -86,7 +88,7 @@ public final class RollCallHandler {
     Channel channel = context.getChannel();
     MessageID messageId = context.getMessageId();
 
-    Log.d(TAG, "handleOpenRollCall: " + channel + " msg=" + openRollCall);
+    Timber.tag(TAG).d("handleOpenRollCall: channel: %s, msg: %s", channel, openRollCall);
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     String updateId = openRollCall.getUpdateId();
@@ -126,7 +128,7 @@ public final class RollCallHandler {
     Channel channel = context.getChannel();
     MessageID messageId = context.getMessageId();
 
-    Log.d(TAG, "handleCloseRollCall: " + channel);
+    Timber.tag(TAG).d("handleCloseRollCall: channel: %s", channel);
     LaoView laoView = laoRepo.getLaoViewByChannel(channel);
 
     String updateId = closeRollCall.getUpdateId();
@@ -168,8 +170,8 @@ public final class RollCallHandler {
                     .getMessageSender()
                     .subscribe(channel.subChannel("social").subChannel(token.getEncoded()))
                     .subscribe(
-                        () -> Log.d(TAG, "subscription a success"),
-                        error -> Log.d(TAG, "subscription error")));
+                        () -> Timber.tag(TAG).d("subscription a success"),
+                        error -> Timber.tag(TAG).d(error, "subscription error")));
 
     laoRepo.updateLao(lao);
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/TransactionCoinHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/TransactionCoinHandler.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.utility.handler.data;
 
-import android.util.Log;
-
 import com.github.dedis.popstellar.model.network.method.message.data.digitalcash.*;
 import com.github.dedis.popstellar.model.objects.*;
 import com.github.dedis.popstellar.model.objects.digitalcash.*;
@@ -11,6 +9,8 @@ import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
 import java.util.*;
 
 import javax.inject.Inject;
+
+import timber.log.Timber;
 
 public class TransactionCoinHandler {
   public static final String TAG = TransactionCoinHandler.class.getSimpleName();
@@ -31,7 +31,8 @@ public class TransactionCoinHandler {
       HandlerContext context, PostTransactionCoin postTransactionCoin) throws NoRollCallException {
     Channel channel = context.getChannel();
 
-    Log.d(TAG, "handlePostTransactionCoin: " + channel + " msg=" + postTransactionCoin);
+    Timber.tag(TAG)
+        .d("handlePostTransactionCoin: channel: %s, msg: %s", channel, postTransactionCoin);
 
     // inputs and outputs for the creation
     List<InputObject> inputs = new ArrayList<>();

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/Hash.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/Hash.java
@@ -1,11 +1,11 @@
 package com.github.dedis.popstellar.utility.security;
 
-import android.util.Log;
-
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+
+import timber.log.Timber;
 
 /** SHA256 Hashing Class */
 public class Hash {
@@ -39,7 +39,7 @@ public class Hash {
       byte[] digestBuf = digest.digest();
       return Base64.getUrlEncoder().encodeToString(digestBuf);
     } catch (NoSuchAlgorithmException e) {
-      Log.e(TAG, "failed to hash", e);
+      Timber.tag(TAG).e(e, "failed to hash");
       throw new UnsupportedOperationException("failed to retrieve SHA-256 instance", e);
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/KeyManager.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/security/KeyManager.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.utility.security;
 
-import android.util.Log;
-
 import androidx.annotation.VisibleForTesting;
 
 import com.github.dedis.popstellar.model.objects.RollCall;
@@ -23,6 +21,8 @@ import java.util.Base64;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import timber.log.Timber;
+
 import static com.github.dedis.popstellar.di.KeysetModule.DeviceKeyset;
 
 /** Service managing keys and providing easy access to the main device key and PoP Tokens */
@@ -42,9 +42,9 @@ public class KeyManager {
 
     try {
       cacheMainKey();
-      Log.d(TAG, "Public Key = " + getMainPublicKey().getEncoded());
+      Timber.tag(TAG).d("Public Key = %s", getMainPublicKey().getEncoded());
     } catch (IOException | GeneralSecurityException e) {
-      Log.e(TAG, "Failed to retrieve device's key", e);
+      Timber.tag(TAG).e(e, "Failed to retrieve device's key");
       throw new IllegalStateException("Failed to retrieve device's key", e);
     }
   }

--- a/fe2-android/app/src/main/res/drawable/home_icon.xml
+++ b/fe2-android/app/src/main/res/drawable/home_icon.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="30dp"
+  android:height="30dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24">
+  <path
+    android:fillColor="@android:color/white"
+    android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z" />
+</vector>

--- a/fe2-android/app/src/main/res/layout/home_activity.xml
+++ b/fe2-android/app/src/main/res/layout/home_activity.xml
@@ -18,7 +18,8 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:theme="@style/toolbar_style"
-        app:menu="@menu/options_menu" />
+        app:menu="@menu/options_menu"
+        app:navigationIcon="@drawable/home_icon" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout

--- a/fe2-android/app/src/main/res/layout/settings_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/settings_fragment.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/fragment_settings"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/fe2-android/app/src/main/res/layout/settings_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/settings_fragment.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
-  <androidx.constraintlayout.widget.ConstraintLayout
-    android:id="@+id/fragment_settings"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"></androidx.constraintlayout.widget.ConstraintLayout>
-</layout>

--- a/fe2-android/app/src/main/res/layout/settings_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/settings_fragment.xml
@@ -3,7 +3,5 @@
   <androidx.constraintlayout.widget.ConstraintLayout
     android:id="@+id/fragment_settings"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-  </androidx.constraintlayout.widget.ConstraintLayout>
+    android:layout_height="match_parent"></androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/fe2-android/app/src/main/res/menu/options_menu.xml
+++ b/fe2-android/app/src/main/res/menu/options_menu.xml
@@ -8,4 +8,8 @@
     android:id="@+id/clear_storage"
     android:title="@string/clear_text"
     />
+  <item
+    android:id="@+id/home_settings"
+    android:title="@string/settings"
+    />
 </menu>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -314,7 +314,7 @@
   <string name="error_importing_key">"Error importing key : %1$s\nTry again</string>
   <string name="error_election_duplicate_question_name">Two different questions can\'t have the same name</string>
   <string name="error_election_duplicate_ballot_name">Two different ballot options can\'t have the same name</string>
-  <string name="error_settings_url_server">Invalid URL</string>
+  <string name="error_settings_url_server">Invalid URL! Please insert a valid one (http, https, ws, wss are supported)</string>
 
   <!-- Exception -->
   <string name="json_rpc_exception">An error response was replied by the server\nError %1$d - %2$s</string>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -33,7 +33,8 @@
   <string name="settings">Settings</string>
   <string name="settings_debugging">Debugging</string>
   <string name="settings_logging">Logging</string>
-  <string name="settings_logging_summary">Check the box if you want to send logs to a server for remote debugging</string>
+  <string name="settings_logging_summary_off">Check the box if you want to send logs to a server for remote debugging</string>
+  <string name="settings_logging_summary_on">Uncheck the box if you want to stop sending logs to a server for remote debugging</string>
   <string name="settings_enable_logging_confirmation">Are you sure you want to enable logging? This can impact on app performance</string>
 
   <!-- Connect -->

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -29,6 +29,13 @@
   <string name="server_url">Server URL</string>
   <string name="no_lao_text">OOPS, Looks like you don\'t have any Local Autonomous Organization (LAO) yet.\n Join or Create one with the buttons below</string>
 
+  <!-- Settings -->
+  <string name="settings">Settings</string>
+  <string name="settings_debugging">Debugging</string>
+  <string name="settings_logging">Logging</string>
+  <string name="settings_logging_summary">Check the box if you want to send logs to a server for remote debugging</string>
+  <string name="settings_enable_logging_confirmation">Are you sure you want to enable logging? This can impact on app performance</string>
+
   <!-- Connect -->
   <string name="allow_camera_text">Please allow the camera to be used by the app</string>
   <string name="allow_camera_button">Allow Camera</string>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -33,10 +33,13 @@
   <!-- Settings -->
   <string name="settings">Settings</string>
   <string name="settings_debugging">Debugging</string>
+  <string name="settings_logging_key">enable_logging</string>
+  <string name="settings_server_url_key">server_url</string>
   <string name="settings_logging">Logging</string>
-  <string name="settings_logging_summary_off">Check the box if you want to send logs to a server for remote debugging</string>
-  <string name="settings_logging_summary_on">Uncheck the box if you want to stop sending logs to a server for remote debugging</string>
-  <string name="settings_enable_logging_confirmation">Are you sure you want to enable logging? This can impact on app performance</string>
+  <string name="settings_logging_summary_off">Check the box if you want to send logs to the above server for remote debugging</string>
+  <string name="settings_logging_summary_on">Uncheck the box if you want to stop sending logs for remote debugging</string>
+  <string name="settings_remote_server">Remote server address</string>
+  <string name="settings_remote_server_info">Insert the URL of the remote server to enable logging</string>
 
   <!-- Connect -->
   <string name="allow_camera_text">Please allow the camera to be used by the app</string>
@@ -311,6 +314,7 @@
   <string name="error_importing_key">"Error importing key : %1$s\nTry again</string>
   <string name="error_election_duplicate_question_name">Two different questions can\'t have the same name</string>
   <string name="error_election_duplicate_ballot_name">Two different ballot options can\'t have the same name</string>
+  <string name="error_settings_url_server">Invalid URL</string>
 
   <!-- Exception -->
   <string name="json_rpc_exception">An error response was replied by the server\nError %1$d - %2$s</string>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-  <string name="app_name">popstellar</string>
+  <string name="app_name">Popstellar</string>
 
   <!--  General-->
   <string name="yes">Yes</string>
@@ -28,6 +28,7 @@
   <string name="create">Create</string>
   <string name="server_url">Server URL</string>
   <string name="no_lao_text">OOPS, Looks like you don\'t have any Local Autonomous Organization (LAO) yet.\n Join or Create one with the buttons below</string>
+  <string name="app_info">Welcome to POPstellar, a Proof-Of-Personhood system developed by the DEDIS lab!</string>
 
   <!-- Settings -->
   <string name="settings">Settings</string>

--- a/fe2-android/app/src/main/res/xml/settings_preferences.xml
+++ b/fe2-android/app/src/main/res/xml/settings_preferences.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <PreferenceCategory android:title="@string/settings_debugging">
+
+    <SwitchPreference
+      android:key="enable_logging"
+      android:title="@string/settings_logging"
+      android:summary="@string/settings_logging_summary"
+      android:defaultValue="false" />
+
+  </PreferenceCategory>
+
+</PreferenceScreen>

--- a/fe2-android/app/src/main/res/xml/settings_preferences.xml
+++ b/fe2-android/app/src/main/res/xml/settings_preferences.xml
@@ -13,8 +13,7 @@
       android:title="@string/settings_logging"
       android:summaryOff="@string/settings_logging_summary_off"
       android:summaryOn="@string/settings_logging_summary_on"
-      android:defaultValue="false"
-      android:enabled="false" />
+      android:defaultValue="false" />
 
   </PreferenceCategory>
 

--- a/fe2-android/app/src/main/res/xml/settings_preferences.xml
+++ b/fe2-android/app/src/main/res/xml/settings_preferences.xml
@@ -6,7 +6,8 @@
     <SwitchPreference
       android:key="enable_logging"
       android:title="@string/settings_logging"
-      android:summary="@string/settings_logging_summary"
+      android:summaryOff="@string/settings_logging_summary_off"
+      android:summaryOn="@string/settings_logging_summary_on"
       android:defaultValue="false" />
 
   </PreferenceCategory>

--- a/fe2-android/app/src/main/res/xml/settings_preferences.xml
+++ b/fe2-android/app/src/main/res/xml/settings_preferences.xml
@@ -3,13 +3,13 @@
 
   <PreferenceCategory android:title="@string/settings_debugging">
     <EditTextPreference
-      android:key="server_url"
+      android:key="@string/settings_server_url_key"
       android:title="@string/settings_remote_server"
       android:summary="@string/settings_remote_server_info"
       android:defaultValue="" />
 
     <SwitchPreference
-      android:key="enable_logging"
+      android:key="@string/settings_logging_key"
       android:title="@string/settings_logging"
       android:summaryOff="@string/settings_logging_summary_off"
       android:summaryOn="@string/settings_logging_summary_on"

--- a/fe2-android/app/src/main/res/xml/settings_preferences.xml
+++ b/fe2-android/app/src/main/res/xml/settings_preferences.xml
@@ -2,13 +2,19 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
   <PreferenceCategory android:title="@string/settings_debugging">
+    <EditTextPreference
+      android:key="server_url"
+      android:title="@string/settings_remote_server"
+      android:summary="@string/settings_remote_server_info"
+      android:defaultValue="" />
 
     <SwitchPreference
       android:key="enable_logging"
       android:title="@string/settings_logging"
       android:summaryOff="@string/settings_logging_summary_off"
       android:summaryOn="@string/settings_logging_summary_on"
-      android:defaultValue="false" />
+      android:defaultValue="false"
+      android:enabled="false" />
 
   </PreferenceCategory>
 

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/home/SettingsPageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/home/SettingsPageObject.java
@@ -1,0 +1,21 @@
+package com.github.dedis.popstellar.testutils.pages.home;
+
+import androidx.annotation.StringRes;
+
+import com.github.dedis.popstellar.R;
+
+public class SettingsPageObject {
+  private SettingsPageObject() {
+    throw new IllegalStateException("Page object");
+  }
+
+  @StringRes
+  public static int serverUrlKey() {
+    return R.string.settings_server_url_key;
+  }
+
+  @StringRes
+  public static int switchLogging() {
+    return R.string.settings_logging_key;
+  }
+}

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/home/SettingsFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/home/SettingsFragmentTest.java
@@ -1,0 +1,168 @@
+package com.github.dedis.popstellar.ui.home;
+
+import androidx.preference.EditTextPreference;
+import androidx.preference.SwitchPreference;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.github.dedis.popstellar.testutils.BundleBuilder;
+import com.github.dedis.popstellar.testutils.fragment.ActivityFragmentScenarioRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoTestRule;
+
+import dagger.hilt.android.testing.HiltAndroidRule;
+import dagger.hilt.android.testing.HiltAndroidTest;
+
+import static com.github.dedis.popstellar.testutils.pages.home.HomePageObject.homeFragmentContainerId;
+import static com.github.dedis.popstellar.testutils.pages.home.SettingsPageObject.serverUrlKey;
+import static com.github.dedis.popstellar.testutils.pages.home.SettingsPageObject.switchLogging;
+import static org.junit.Assert.*;
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4.class)
+public class SettingsFragmentTest {
+
+  private static final String CORRECT_URL = "wss://localhost:9000";
+
+  @Rule(order = 0)
+  public final MockitoTestRule mockitoRule = MockitoJUnit.testRule(this);
+
+  @Rule(order = 1)
+  public final HiltAndroidRule hiltRule = new HiltAndroidRule(this);
+
+  @Rule(order = 2)
+  public final ExternalResource setupRule =
+      new ExternalResource() {
+        @Override
+        protected void before() {
+          hiltRule.inject();
+        }
+      };
+
+  @Rule(order = 3)
+  public ActivityFragmentScenarioRule<HomeActivity, SettingsFragment> activityScenarioRule =
+      ActivityFragmentScenarioRule.launchIn(
+          HomeActivity.class,
+          new BundleBuilder().build(),
+          homeFragmentContainerId(),
+          SettingsFragment.class,
+          SettingsFragment::newInstance,
+          new BundleBuilder().build());
+
+  @Test
+  public void testCorrectServerUrlEnableLogging() {
+    activityScenarioRule
+        .getScenario()
+        .onFragment(
+            fragment -> {
+              EditTextPreference serverUrlPreference =
+                  fragment
+                      .getPreferenceManager()
+                      .findPreference(fragment.getString(serverUrlKey()));
+              SwitchPreference switchPreference =
+                  fragment
+                      .getPreferenceManager()
+                      .findPreference(fragment.getString(switchLogging()));
+
+              assertNotNull(switchPreference);
+              assertNotNull(serverUrlPreference);
+
+              // Check that the logging is disabled
+              assertFalse(switchPreference.isEnabled());
+
+              serverUrlPreference.callChangeListener(CORRECT_URL);
+
+              // Check that after a correct url set, switch is enabled
+              assertTrue(switchPreference.isEnabled());
+            });
+  }
+
+  @Test
+  public void testIncorrectServerUrl() {
+    String wrongUrl = "w://example";
+    activityScenarioRule
+        .getScenario()
+        .onFragment(
+            fragment -> {
+              EditTextPreference serverUrlPreference =
+                  fragment
+                      .getPreferenceManager()
+                      .findPreference(fragment.getString(serverUrlKey()));
+              SwitchPreference switchPreference =
+                  fragment
+                      .getPreferenceManager()
+                      .findPreference(fragment.getString(switchLogging()));
+
+              assertNotNull(switchPreference);
+              assertNotNull(serverUrlPreference);
+
+              // Check that the logging is disabled
+              assertFalse(switchPreference.isEnabled());
+
+              serverUrlPreference.callChangeListener(wrongUrl);
+
+              // Check that after a not correct url set, switch is still disabled
+              assertFalse(switchPreference.isEnabled());
+            });
+  }
+
+  @Test
+  public void testEnableLogging() {
+    activityScenarioRule
+        .getScenario()
+        .onFragment(
+            fragment -> {
+              EditTextPreference serverUrlPreference =
+                  fragment
+                      .getPreferenceManager()
+                      .findPreference(fragment.getString(serverUrlKey()));
+              SwitchPreference switchPreference =
+                  fragment
+                      .getPreferenceManager()
+                      .findPreference(fragment.getString(switchLogging()));
+
+              assertNotNull(serverUrlPreference);
+              assertNotNull(switchPreference);
+
+              serverUrlPreference.callChangeListener(CORRECT_URL);
+
+              // Turn on the switch
+              switchPreference.callChangeListener(true);
+
+              // Ensures that the server url edit text is disabled now
+              assertFalse(serverUrlPreference.isEnabled());
+            });
+  }
+
+  @Test
+  public void testDisableLogging() {
+    activityScenarioRule
+        .getScenario()
+        .onFragment(
+            fragment -> {
+              EditTextPreference serverUrlPreference =
+                  fragment
+                      .getPreferenceManager()
+                      .findPreference(fragment.getString(serverUrlKey()));
+              SwitchPreference switchPreference =
+                  fragment
+                      .getPreferenceManager()
+                      .findPreference(fragment.getString(switchLogging()));
+
+              assertNotNull(serverUrlPreference);
+              assertNotNull(switchPreference);
+
+              serverUrlPreference.setText(CORRECT_URL);
+
+              // Turn off the switch
+              switchPreference.callChangeListener(false);
+
+              // Ensures that the server url edit text is re-enabled
+              assertTrue(serverUrlPreference.isEnabled());
+            });
+  }
+}

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/MessageValidatorTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/MessageValidatorTest.java
@@ -104,4 +104,30 @@ public class MessageValidatorTest {
     assertThrows(
         IllegalArgumentException.class, () -> MessageValidator.verify().checkListNotEmpty(null));
   }
+
+  @Test
+  public void testCheckValidUrl() {
+    MessageValidator.verify().checkValidUrl("http://example.com");
+    MessageValidator.verify().checkValidUrl("https://example.com");
+    MessageValidator.verify().checkValidUrl("ws://example.com");
+    MessageValidator.verify().checkValidUrl("wss://10.0.2.2:8000/path");
+    MessageValidator.verify().checkValidUrl("https://example.com/path/to/file.html");
+    MessageValidator.verify().checkValidUrl("wss://example.com/path/to/file");
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> MessageValidator.verify().checkValidUrl("Random String"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> MessageValidator.verify().checkValidUrl("example.com"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> MessageValidator.verify().checkValidUrl("http:example.com"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> MessageValidator.verify().checkValidUrl("://example.com"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> MessageValidator.verify().checkValidUrl("http://example."));
+  }
 }

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/MessageValidatorTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/MessageValidatorTest.java
@@ -20,114 +20,101 @@ public class MessageValidatorTest {
 
   @Test
   public void testCheckValidLaoId() {
+    MessageValidator.MessageValidatorBuilder validator = MessageValidator.verify();
     String invalid1 = "invalidID";
     String invalid2 = "A" + ID.substring(1);
 
-    MessageValidator.verify().checkValidLaoId(ID, ORGANIZER, CREATION, NAME);
+    validator.checkValidLaoId(ID, ORGANIZER, CREATION, NAME);
     assertThrows(
         IllegalArgumentException.class,
-        () -> MessageValidator.verify().checkValidLaoId(invalid1, ORGANIZER, CREATION, NAME));
+        () -> validator.checkValidLaoId(invalid1, ORGANIZER, CREATION, NAME));
     assertThrows(
         IllegalArgumentException.class,
-        () -> MessageValidator.verify().checkValidLaoId(invalid2, ORGANIZER, CREATION, NAME));
+        () -> validator.checkValidLaoId(invalid2, ORGANIZER, CREATION, NAME));
   }
 
   @Test
   public void testCheckValidTime() {
+    MessageValidator.MessageValidatorBuilder validator = MessageValidator.verify();
     long currentTime = Instant.now().getEpochSecond();
     long futureTime = currentTime + DELTA_TIME;
 
-    MessageValidator.verify().checkValidTime(currentTime);
-    assertThrows(
-        IllegalArgumentException.class, () -> MessageValidator.verify().checkValidTime(futureTime));
-    assertThrows(
-        IllegalArgumentException.class, () -> MessageValidator.verify().checkValidTime(-1));
+    validator.checkValidTime(currentTime);
+    assertThrows(IllegalArgumentException.class, () -> validator.checkValidTime(futureTime));
+    assertThrows(IllegalArgumentException.class, () -> validator.checkValidTime(-1));
   }
 
   @Test
   public void testCheckValidOrderedTimes() {
+    MessageValidator.MessageValidatorBuilder validator = MessageValidator.verify();
     long currentTime = Instant.now().getEpochSecond();
     long futureTime = currentTime + DELTA_TIME;
     long pastTime = currentTime - DELTA_TIME;
 
-    MessageValidator.verify().checkValidOrderedTimes(pastTime, currentTime);
+    validator.checkValidOrderedTimes(pastTime, currentTime);
     assertThrows(
         IllegalArgumentException.class,
-        () -> MessageValidator.verify().checkValidOrderedTimes(futureTime, currentTime));
+        () -> validator.checkValidOrderedTimes(futureTime, currentTime));
     assertThrows(
         IllegalArgumentException.class,
-        () -> MessageValidator.verify().checkValidOrderedTimes(pastTime, futureTime));
+        () -> validator.checkValidOrderedTimes(pastTime, futureTime));
     assertThrows(
-        IllegalArgumentException.class,
-        () -> MessageValidator.verify().checkValidOrderedTimes(-1, currentTime));
+        IllegalArgumentException.class, () -> validator.checkValidOrderedTimes(-1, currentTime));
   }
 
   @Test
   public void testCheckBase64() {
+    MessageValidator.MessageValidatorBuilder validator = MessageValidator.verify();
     String validBase64 = Base64.getEncoder().encodeToString("test data".getBytes());
     String invalidBase64 = "This is not a valid Base64 string!";
     String field = "testField";
 
-    MessageValidator.verify().checkBase64(validBase64, field);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> MessageValidator.verify().checkBase64(invalidBase64, field));
-    assertThrows(
-        IllegalArgumentException.class, () -> MessageValidator.verify().checkBase64(null, field));
+    validator.checkBase64(validBase64, field);
+    assertThrows(IllegalArgumentException.class, () -> validator.checkBase64(invalidBase64, field));
+    assertThrows(IllegalArgumentException.class, () -> validator.checkBase64(null, field));
   }
 
   @Test
   public void testCheckStringNotEmpty() {
+    MessageValidator.MessageValidatorBuilder validator = MessageValidator.verify();
     String validString = "test string";
     String emptyString = "";
     String field = "testField";
 
-    MessageValidator.verify().checkStringNotEmpty(validString, field);
+    validator.checkStringNotEmpty(validString, field);
     assertThrows(
-        IllegalArgumentException.class,
-        () -> MessageValidator.verify().checkStringNotEmpty(emptyString, field));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> MessageValidator.verify().checkStringNotEmpty(null, field));
+        IllegalArgumentException.class, () -> validator.checkStringNotEmpty(emptyString, field));
+    assertThrows(IllegalArgumentException.class, () -> validator.checkStringNotEmpty(null, field));
   }
 
   @Test
   public void testCheckListNotEmpty() {
+    MessageValidator.MessageValidatorBuilder validator = MessageValidator.verify();
     List<Integer> valid1 = Arrays.asList(1, 2, 3);
     List<String> valid2 = Arrays.asList("a", "b");
     List<String> invalid = new ArrayList<>();
 
-    MessageValidator.verify().checkListNotEmpty(valid1);
-    MessageValidator.verify().checkListNotEmpty(valid2);
-    assertThrows(
-        IllegalArgumentException.class, () -> MessageValidator.verify().checkListNotEmpty(invalid));
-    assertThrows(
-        IllegalArgumentException.class, () -> MessageValidator.verify().checkListNotEmpty(null));
+    validator.checkListNotEmpty(valid1);
+    validator.checkListNotEmpty(valid2);
+    assertThrows(IllegalArgumentException.class, () -> validator.checkListNotEmpty(invalid));
+    assertThrows(IllegalArgumentException.class, () -> validator.checkListNotEmpty(null));
   }
 
   @Test
   public void testCheckValidUrl() {
-    MessageValidator.verify().checkValidUrl("http://example.com");
-    MessageValidator.verify().checkValidUrl("https://example.com");
-    MessageValidator.verify().checkValidUrl("ws://example.com");
-    MessageValidator.verify().checkValidUrl("wss://10.0.2.2:8000/path");
-    MessageValidator.verify().checkValidUrl("https://example.com/path/to/file.html");
-    MessageValidator.verify().checkValidUrl("wss://example.com/path/to/file");
+    MessageValidator.MessageValidatorBuilder validator = MessageValidator.verify();
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> MessageValidator.verify().checkValidUrl("Random String"));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> MessageValidator.verify().checkValidUrl("example.com"));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> MessageValidator.verify().checkValidUrl("http:example.com"));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> MessageValidator.verify().checkValidUrl("://example.com"));
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> MessageValidator.verify().checkValidUrl("http://example."));
+    validator.checkValidUrl("http://example.com");
+    validator.checkValidUrl("https://example.com");
+    validator.checkValidUrl("ws://example.com");
+    validator.checkValidUrl("wss://10.0.2.2:8000/path");
+    validator.checkValidUrl("https://example.com/path/to/file.html");
+    validator.checkValidUrl("wss://example.com/path/to/file");
+
+    assertThrows(IllegalArgumentException.class, () -> validator.checkValidUrl("Random String"));
+    assertThrows(IllegalArgumentException.class, () -> validator.checkValidUrl("example.com"));
+    assertThrows(IllegalArgumentException.class, () -> validator.checkValidUrl("http:example.com"));
+    assertThrows(IllegalArgumentException.class, () -> validator.checkValidUrl("://example.com"));
+    assertThrows(IllegalArgumentException.class, () -> validator.checkValidUrl("http://example."));
   }
 }


### PR DESCRIPTION
This PR aims to:
- introduce the settings tab in the application; the settings have been designed to be persistent.
- give the user the possibility to activate the remote logging. During the POP party we are encountering issues like #1489 and very often we cannot either reproduce them or see the logs. So the idea is to enable an option in the settings which sends to a server all the logs.
- switched to Timber library for logging, as it can act as a centralized point of log collection and dispatch

UI Screen:
<img src="https://user-images.githubusercontent.com/83547952/233810823-c3cf1761-3e15-45b7-9dbe-635a48599b3c.png" width="300" height="700">

*As many files were modified to replace all the logs the code coverage is slightly under threshold*