### PR TITLE
Add server peers list

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -267,7 +267,7 @@ jobs:
         run: sbt scalafmtCheckAll
 
       - name: Run unit tests
-        run: sbt -Dscala.config="src/main/scala/ch/epfl/pop/config" -Dtest="true" clean coverage test
+        run: sbt -Dscala.config="src/main/scala/ch/epfl/pop/config" -Dtest clean coverage test
 
       - name: Report coverage
         run: sbt coverageReport

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -267,7 +267,7 @@ jobs:
         run: sbt scalafmtCheckAll
 
       - name: Run unit tests
-        run: sbt -Dscala.config="src/main/scala/ch/epfl/pop/config" clean coverage test
+        run: sbt -Dscala.config="src/main/scala/ch/epfl/pop/config" -Dtest="true" clean coverage test
 
       - name: Report coverage
         run: sbt coverageReport

--- a/be2-scala/src/main/scala/ch/epfl/pop/config/RuntimeEnvironment.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/config/RuntimeEnvironment.scala
@@ -41,15 +41,7 @@ object RuntimeEnvironment {
   }
 
   private def testMode: Boolean = {
-    val testParam = sp("test")
-    if (testParam != null && testParam.trim.nonEmpty) {
-      testParam.toLowerCase match {
-        case "true" => true
-        case _      => false
-      }
-    } else {
-      false
-    }
+    sp("test") != null
   }
 
   private lazy val confDir: String = getConfDir

--- a/be2-scala/src/main/scala/ch/epfl/pop/config/RuntimeEnvironment.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/config/RuntimeEnvironment.scala
@@ -33,7 +33,7 @@ object RuntimeEnvironment {
 
     val virtualMachineParam = "scala.config"
     val pathConfig = sp(virtualMachineParam)
-    if (pathConfig != null && !pathConfig.trim.isEmpty) {
+    if (pathConfig != null && pathConfig.trim.nonEmpty) {
       pathConfig.trim
     } else {
       throw new RuntimeException(s"-D$virtualMachineParam was not provided.")

--- a/be2-scala/src/main/scala/ch/epfl/pop/config/RuntimeEnvironment.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/config/RuntimeEnvironment.scala
@@ -48,7 +48,7 @@ object RuntimeEnvironment {
   private lazy val appConfFile = confDir + File.separator + "application.conf"
 
   lazy val isTestMode: Boolean = testMode
-  lazy val serverPeersList: String =
+  lazy val serverPeersListPath: String =
     if (isTestMode) {
       confDir + File.separator + "server-peers-list-TEST.conf"
     } else {
@@ -63,7 +63,7 @@ object RuntimeEnvironment {
   def readServerPeers(): List[String] = {
     val source =
       try {
-        fromFile(serverPeersList)
+        fromFile(serverPeersListPath)
       } catch {
         case ex: Throwable =>
           println("RuntimeEnvironment: " + ex.toString)

--- a/be2-scala/src/main/scala/ch/epfl/pop/config/RuntimeEnvironment.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/config/RuntimeEnvironment.scala
@@ -50,7 +50,7 @@ object RuntimeEnvironment {
   lazy val isTestMode: Boolean = testMode
   lazy val serverPeersListPath: String =
     if (isTestMode) {
-      confDir + File.separator + "server-peers-list-TEST.conf"
+      confDir + File.separator + "server-peers-list-mock.conf"
     } else {
       confDir + File.separator + "server-peers-list.conf"
     }

--- a/be2-scala/src/main/scala/ch/epfl/pop/config/RuntimeEnvironment.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/config/RuntimeEnvironment.scala
@@ -65,4 +65,23 @@ object RuntimeEnvironment {
 
   lazy val appConf: Config = ConfigFactory.parseFile(new File(appConfFile))
 
+  // Regex from dataGreetLao.json
+  private val addressPattern = "^(ws|wss)://.*(:d{0,5})?/.*$"
+
+  def readServerPeers(): List[String] = {
+    val source =
+      try {
+        fromFile(serverPeersList)
+      } catch {
+        case ex: Throwable =>
+          println("RuntimeEnvironment: " + ex.toString)
+          return Nil
+      }
+
+    val addressList = source.getLines().map(_.trim).filter(_.matches(addressPattern)).toList
+    source.close()
+
+    addressList
+  }
+
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/config/RuntimeEnvironment.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/config/RuntimeEnvironment.scala
@@ -1,9 +1,9 @@
 package ch.epfl.pop.config
 
 import java.io.File
-
 import com.typesafe.config.{Config, ConfigFactory}
 
+import scala.io.Source.fromFile
 import scala.reflect.io.Directory
 import scala.sys.SystemProperties
 
@@ -40,7 +40,28 @@ object RuntimeEnvironment {
     }
   }
 
-  private lazy val appConfFile = getConfDir + File.separator + "application.conf"
+  private def testMode: Boolean = {
+    val testParam = sp("test")
+    if (testParam != null && testParam.trim.nonEmpty) {
+      testParam.toLowerCase match {
+        case "true" => true
+        case _      => false
+      }
+    } else {
+      false
+    }
+  }
+
+  private lazy val confDir: String = getConfDir
+  private lazy val appConfFile = confDir + File.separator + "application.conf"
+
+  lazy val isTestMode: Boolean = testMode
+  lazy val serverPeersList: String =
+    if (isTestMode) {
+      confDir + File.separator + "server-peers-list-TEST.conf"
+    } else {
+      confDir + File.separator + "server-peers-list.conf"
+    }
 
   lazy val appConf: Config = ConfigFactory.parseFile(new File(appConfFile))
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/config/server-peers-list.conf
+++ b/be2-scala/src/main/scala/ch/epfl/pop/config/server-peers-list.conf
@@ -1,0 +1,3 @@
+# List of endpoints peers the server can connect to
+# Example
+# ws://127.0.0.1:9001/server

--- a/be2-scala/src/main/scala/ch/epfl/pop/json/MessageDataProtocol.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/json/MessageDataProtocol.scala
@@ -153,7 +153,12 @@ object MessageDataProtocol extends DefaultJsonProtocol {
             lao.convertTo[Hash],
             frontend.convertTo[PublicKey],
             address,
-            peers.map(jsValue => jsValue.asJsObject.getFields(PARAM_ADDRESS).map(_.convertTo[String])).toList.flatten
+            peers.map(jsValue =>
+              jsValue.asJsObject.getFields(PARAM_ADDRESS) match {
+                case Seq(JsString(address)) => address
+                case _                      => throw new IllegalArgumentException(s"Can't parse json value $jsValue to get an address")
+              }
+            ).toList
           )
         case _ => throw new IllegalArgumentException(s"Can't parse json value $json to a GreetLao object")
       }

--- a/be2-scala/src/main/scala/ch/epfl/pop/json/MessageDataProtocol.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/json/MessageDataProtocol.scala
@@ -153,20 +153,22 @@ object MessageDataProtocol extends DefaultJsonProtocol {
             lao.convertTo[Hash],
             frontend.convertTo[PublicKey],
             address,
-            peers.map(_.convertTo[String]).toList
+            peers.map(jsValue => jsValue.asJsObject.getFields(PARAM_ADDRESS).map(_.convertTo[String])).toList.flatten
           )
         case _ => throw new IllegalArgumentException(s"Can't parse json value $json to a GreetLao object")
       }
     }
 
     override def write(obj: GreetLao): JsValue = {
-      var jsObjectContent: ListMap[String, JsValue] = ListMap[String, JsValue](
+      val jsObjectContent: ListMap[String, JsValue] = ListMap[String, JsValue](
         PARAM_OBJECT -> JsString(obj._object.toString),
         PARAM_ACTION -> JsString(obj.action.toString),
         PARAM_LAO -> obj.lao.toJson,
         PARAM_FRONTEND -> obj.frontend.toJson,
         PARAM_ADDRESS -> obj.address.toJson,
-        PARAM_PEERS -> obj.peers.toJson
+        PARAM_PEERS -> obj.peers.map(str =>
+          new JsObject(Map(PARAM_ADDRESS -> str.toJson))
+        ).toJson
       )
       JsObject(jsObjectContent)
     }

--- a/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentSuite.scala
@@ -1,6 +1,6 @@
 package ch.epfl.pop.config
 
-import ch.epfl.pop.config.RuntimeEnvironment.{readServerPeers, serverPeersListPath}
+import ch.epfl.pop.config.RuntimeEnvironment.readServerPeers
 import ch.epfl.pop.config.RuntimeEnvironmentTestingHelper.testWriteToServerPeersConfig
 import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuite}
 import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, equal}
@@ -19,9 +19,6 @@ class RuntimeEnvironmentSuite extends FunSuite {
     )
 
     testWriteToServerPeersConfig(addressList)
-
-    // Set the file to delete itself at jvm shutdown
-    new File(serverPeersListPath).deleteOnExit()
 
     // Verify it works as expected
     readServerPeers() should equal(addressList.tail)

--- a/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentSuite.scala
@@ -1,0 +1,27 @@
+package ch.epfl.pop.config
+
+import ch.epfl.pop.config.RuntimeEnvironment.readServerPeers
+import ch.epfl.pop.config.RuntimeEnvironmentTestingHelper.{deleteTestConfig, testWriteToServerPeersConfig}
+import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuite}
+import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, equal}
+
+class RuntimeEnvironmentSuite extends FunSuite {
+  test("readServerPeers() should only return the addresses that match the regex from the schema") {
+
+    // Values to add in the file
+    val addressList = List(
+      "http://127.0.0.1/",
+      "ws://127.0.0.1:7000/client",
+      "ws://127.0.0.1:8000/client",
+      "ws://127.0.0.1:9000/client"
+    )
+
+    testWriteToServerPeersConfig(addressList, RuntimeEnvironment.serverPeersList)
+
+    // Verify it works as expected
+    readServerPeers() should equal(addressList.tail)
+
+    // Delete the test file
+    deleteTestConfig()
+  }
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentSuite.scala
@@ -16,7 +16,7 @@ class RuntimeEnvironmentSuite extends FunSuite {
       "ws://127.0.0.1:9000/client"
     )
 
-    testWriteToServerPeersConfig(addressList, RuntimeEnvironment.serverPeersList)
+    testWriteToServerPeersConfig(addressList)
 
     // Verify it works as expected
     readServerPeers() should equal(addressList.tail)

--- a/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentSuite.scala
@@ -1,7 +1,7 @@
 package ch.epfl.pop.config
 
-import ch.epfl.pop.config.RuntimeEnvironment.readServerPeers
-import ch.epfl.pop.config.RuntimeEnvironmentTestingHelper.{deleteTestConfig, testWriteToServerPeersConfig}
+import ch.epfl.pop.config.RuntimeEnvironment.{readServerPeers, serverPeersListPath}
+import ch.epfl.pop.config.RuntimeEnvironmentTestingHelper.testWriteToServerPeersConfig
 import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuite}
 import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, equal}
 
@@ -14,7 +14,7 @@ class RuntimeEnvironmentSuite extends FunSuite {
     val addressList = List(
       "http://127.0.0.1/",
       "ws://127.0.0.1:7000/client",
-      "ws://127.0.0.1:8000/client",
+      "wss://127.0.0.1:8000/client",
       "ws://127.0.0.1:9000/client"
     )
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentSuite.scala
@@ -5,6 +5,8 @@ import ch.epfl.pop.config.RuntimeEnvironmentTestingHelper.{deleteTestConfig, tes
 import org.scalatest.funsuite.{AnyFunSuiteLike => FunSuite}
 import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, equal}
 
+import java.io.File
+
 class RuntimeEnvironmentSuite extends FunSuite {
   test("readServerPeers() should only return the addresses that match the regex from the schema") {
 
@@ -18,10 +20,10 @@ class RuntimeEnvironmentSuite extends FunSuite {
 
     testWriteToServerPeersConfig(addressList)
 
+    // Set the file to delete itself at jvm shutdown
+    new File(serverPeersListPath).deleteOnExit()
+
     // Verify it works as expected
     readServerPeers() should equal(addressList.tail)
-
-    // Delete the test file
-    deleteTestConfig()
   }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentTestingHelper.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentTestingHelper.scala
@@ -6,7 +6,7 @@ object RuntimeEnvironmentTestingHelper {
 
   private def ensureTestingMode(): Unit = {
     if (!RuntimeEnvironment.isTestMode) {
-      throw new ExceptionInInitializerError("Argument \"-Dtest\" missing")
+      throw new ExceptionInInitializerError("Mandatory argument \"-Dtest\" missing")
     }
   }
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentTestingHelper.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentTestingHelper.scala
@@ -1,5 +1,7 @@
 package ch.epfl.pop.config
 
+import ch.epfl.pop.config.RuntimeEnvironment.serverPeersListPath
+
 import java.io.{BufferedWriter, File, FileWriter}
 
 object RuntimeEnvironmentTestingHelper {
@@ -10,20 +12,23 @@ object RuntimeEnvironmentTestingHelper {
     }
   }
 
+  /** Write to the server-peers-mock.conf in tests only, the file is auto deleted after jvm shutdown
+    *
+    * @param list
+    *   the list of strings to write in to the mock config file
+    */
   def testWriteToServerPeersConfig(list: List[String]): Unit = {
     ensureTestingMode()
-    val file = new BufferedWriter(new FileWriter(RuntimeEnvironment.serverPeersListPath))
+    val file = new BufferedWriter(new FileWriter(serverPeersListPath))
     list.foreach {
       str =>
         file.write(str)
         file.newLine()
     }
     file.close()
-  }
 
-  def deleteTestConfig(): Unit = {
-    ensureTestingMode()
-    new File(RuntimeEnvironment.serverPeersListPath).delete()
+    // Set the file to delete itself on jvm shutdown
+    new File(serverPeersListPath).deleteOnExit()
   }
 
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentTestingHelper.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentTestingHelper.scala
@@ -1,0 +1,29 @@
+package ch.epfl.pop.config
+
+import java.io.{BufferedWriter, File, FileWriter}
+
+object RuntimeEnvironmentTestingHelper {
+
+  private def ensureTestingMode(): Unit = {
+    if (!RuntimeEnvironment.isTestMode) {
+      throw new ExceptionInInitializerError("Argument -Dtest=\"true\" missing")
+    }
+  }
+
+  def testWriteToServerPeersConfig(list: List[String], path: String): Unit = {
+    ensureTestingMode()
+    val file = new BufferedWriter(new FileWriter(path))
+    list.foreach {
+      str =>
+        file.write(str)
+        file.newLine()
+    }
+    file.close()
+  }
+
+  def deleteTestConfig(): Unit = {
+    ensureTestingMode()
+    new File(RuntimeEnvironment.serverPeersList).delete()
+  }
+
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentTestingHelper.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentTestingHelper.scala
@@ -10,9 +10,9 @@ object RuntimeEnvironmentTestingHelper {
     }
   }
 
-  def testWriteToServerPeersConfig(list: List[String], path: String): Unit = {
+  def testWriteToServerPeersConfig(list: List[String]): Unit = {
     ensureTestingMode()
-    val file = new BufferedWriter(new FileWriter(path))
+    val file = new BufferedWriter(new FileWriter(RuntimeEnvironment.serverPeersList))
     list.foreach {
       str =>
         file.write(str)

--- a/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentTestingHelper.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentTestingHelper.scala
@@ -12,7 +12,7 @@ object RuntimeEnvironmentTestingHelper {
 
   def testWriteToServerPeersConfig(list: List[String]): Unit = {
     ensureTestingMode()
-    val file = new BufferedWriter(new FileWriter(RuntimeEnvironment.serverPeersList))
+    val file = new BufferedWriter(new FileWriter(RuntimeEnvironment.serverPeersListPath))
     list.foreach {
       str =>
         file.write(str)
@@ -23,7 +23,7 @@ object RuntimeEnvironmentTestingHelper {
 
   def deleteTestConfig(): Unit = {
     ensureTestingMode()
-    new File(RuntimeEnvironment.serverPeersList).delete()
+    new File(RuntimeEnvironment.serverPeersListPath).delete()
   }
 
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentTestingHelper.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/config/RuntimeEnvironmentTestingHelper.scala
@@ -6,7 +6,7 @@ object RuntimeEnvironmentTestingHelper {
 
   private def ensureTestingMode(): Unit = {
     if (!RuntimeEnvironment.isTestMode) {
-      throw new ExceptionInInitializerError("Argument -Dtest=\"true\" missing")
+      throw new ExceptionInInitializerError("Argument \"-Dtest\" missing")
     }
   }
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/json/MessageDataProtocolSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/json/MessageDataProtocolSuite.scala
@@ -1,7 +1,7 @@
 package ch.epfl.pop.json
 
 import ch.epfl.pop.model.network.method.message.data.election._
-import ch.epfl.pop.model.network.method.message.data.lao.CreateLao
+import ch.epfl.pop.model.network.method.message.data.lao.{CreateLao, GreetLao}
 import ch.epfl.pop.model.objects._
 import org.scalatest.funsuite.{AnyFunSuite => FunSuite}
 import org.scalatest.matchers.should.Matchers
@@ -209,5 +209,25 @@ class MessageDataProtocolSuite extends FunSuite with Matchers {
 
     messageData shouldBe a[PostTransaction]
     messageData should equal(expected)
+  }
+
+  test("Parser correctly encodes and decode GreetLao") {
+    val expectedGreetLao = GreetLao(
+      Hash(Base64Data("p_EYbHyMv6sopI5QhEXBf40MO_eNoq7V_LygBd4c9RA=")),
+      PublicKey(Base64Data("J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=")),
+      "wss://popdemo.dedis.ch:8000/demo",
+      List("wss://popdemo.dedis.ch:8000/second-organizer-demo", "wss://popdemo.dedis.ch:8000/witness-demo")
+    )
+
+    val example = getExampleMessage("messageData/lao_greet/greeting.json")
+
+    val greetLaoFromExample = GreetLao.buildFromJson(example)
+    val buildGreetJson = MessageDataProtocol.GreetLaoFormat.write(expectedGreetLao)
+    val greetLaoFromBuiltJson = MessageDataProtocol.GreetLaoFormat.read(buildGreetJson)
+
+    greetLaoFromBuiltJson shouldBe a[GreetLao]
+    greetLaoFromExample shouldBe a[GreetLao]
+    greetLaoFromExample should equal(expectedGreetLao)
+    greetLaoFromBuiltJson should equal(expectedGreetLao)
   }
 }


### PR DESCRIPTION
This pr adds a list of peers in the scala-backend config file in order for tell the server where to connect for decentralized communications. 

To safely test config files, a new startup flag was added: -Dtest
This argument allows RuntimeEnvironment to work with `server-peers-list-TEST.conf` instead of the `server-peers-list.conf`, this will prevent the tests from completely breaking the original file while being able to test the api as-is.