### PR TITLE
add getMessagesById reponses handler

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
@@ -9,6 +9,10 @@ import ch.epfl.pop.pubsub.{AskPatternConstants, ClientActor, PubSubMediator}
 import ch.epfl.pop.storage.DbActor
 import akka.stream.FlowShape
 
+/**
+ * This object's job is to handle responses it receives from other servers after sending a heartbeat.
+ * When receiving the missing messages, the server's job is to write them on the data base.
+ */
 object GetMessagesByIdResponseHandler extends AskPatternConstants {
 
   def graph(dbActorRef: ActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow.fromGraph(GraphDSL.create() {

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
@@ -84,10 +84,4 @@ object GetMessagesByIdResponseHandler extends AskPatternConstants {
     }
   }
 
-  private def retry[T](n: Int)(fn: => Future[T]): Future[T] = {
-    fn recoverWith {
-      case _ if n > 1 => retry(n - 1)(fn)
-    }
-  }
-
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
@@ -2,16 +2,25 @@ package ch.epfl.pop.pubsub.graph.handlers
 
 import akka.NotUsed
 import akka.actor.ActorRef
-import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition, Sink}
-import ch.epfl.pop.model.network.{JsonRpcRequest, JsonRpcResponse}
-import ch.epfl.pop.pubsub.graph.{ErrorCodes, GraphMessage, PipelineError}
-import ch.epfl.pop.pubsub.{AskPatternConstants, ClientActor, PubSubMediator}
+import akka.pattern.AskableActorRef
+import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition}
+import ch.epfl.pop.model.network.JsonRpcResponse
+import ch.epfl.pop.pubsub.graph.GraphMessage
+import ch.epfl.pop.pubsub.AskPatternConstants
 import ch.epfl.pop.storage.DbActor
 import akka.stream.FlowShape
+import ch.epfl.pop.model.network.method.message.Message
+import ch.epfl.pop.model.objects.Channel
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 /** This object's job is to handle responses it receives from other servers after sending a heartbeat. When receiving the missing messages, the server's job is to write them on the data base.
   */
 object GetMessagesByIdResponseHandler extends AskPatternConstants {
+
+  private final val MAX_ATTEMPT : Int = 3
+
 
   def graph(dbActorRef: ActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow.fromGraph(GraphDSL.create() {
     implicit builder: GraphDSL.Builder[NotUsed] =>
@@ -29,7 +38,7 @@ object GetMessagesByIdResponseHandler extends AskPatternConstants {
           {
             case Right(jsonRpcMessage: JsonRpcResponse) => jsonRpcMessage.result match {
                 case Some(result) => result.resultMap match {
-                    case Some(map) => portResponseHandler
+                    case Some(_) => portResponseHandler
                     case _         => portPipelineError
                   }
                 case _ => portPipelineError
@@ -56,11 +65,23 @@ object GetMessagesByIdResponseHandler extends AskPatternConstants {
       val receivedResponse = jsonRpcMessage.result.get.resultMap.get
       receivedResponse.keys.foreach(channel => {
         receivedResponse(channel).foreach(message => {
-          dbActorRef ! DbActor.Write(channel, message)
+          writeOnDb(channel,message,dbActorRef)
         })
       })
       Right(jsonRpcMessage)
     case value @ _ => value
   }.filter(_ => false)
+
+  private def writeOnDb(channel : Channel, message : Message, dbActorRef: AskableActorRef): Unit = {
+    retry(MAX_ATTEMPT){
+      dbActorRef ? DbActor.Write(channel, message)
+    }
+  }
+
+  private def retry[T](n: Int)(fn: => Future[T]): Future[T] = {
+    fn recoverWith {
+      case _ if n > 1 => retry(n - 1)(fn)
+    }
+  }
 
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
@@ -39,9 +39,9 @@ object GetMessagesByIdResponseHandler extends AskPatternConstants {
             case Right(jsonRpcMessage: JsonRpcResponse) => jsonRpcMessage.result match {
                 case Some(result) => result.resultMap match {
                     case Some(_) => portResponseHandler
-                    case _         => portPipelineError
+                    case _       => portPipelineError
                   }
-                case _         => portPipelineError
+                case _ => portPipelineError
               }
             case _ => portPipelineError // Pipeline error goes directly in handlerMerger
           }
@@ -71,7 +71,7 @@ object GetMessagesByIdResponseHandler extends AskPatternConstants {
     case value @ _ => value
   }.filter(_ => false) // instead of implementing a Sink[GraphMessage], we chose to implement it as a Flow and filter every single outgoing graphMessage
 
- @tailrec
+  @tailrec
   private def writeOnDb(channel: Channel, message: Message, dbActorRef: AskableActorRef, remainingAttempts: Int): Unit = {
     if (remainingAttempts != 0) {
       val ask = dbActorRef ? DbActor.WriteAndPropagate(channel, message)

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
@@ -1,0 +1,62 @@
+package ch.epfl.pop.pubsub.graph.handlers
+
+import akka.NotUsed
+import akka.actor.ActorRef
+import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition, Sink}
+import ch.epfl.pop.model.network.{JsonRpcRequest, JsonRpcResponse}
+import ch.epfl.pop.pubsub.graph.{ErrorCodes, GraphMessage, PipelineError}
+import ch.epfl.pop.pubsub.{AskPatternConstants, ClientActor, PubSubMediator}
+import ch.epfl.pop.storage.DbActor
+import akka.stream.FlowShape
+
+object GetMessagesByIdResponseHandler extends AskPatternConstants {
+
+  def graph(dbActorRef: ActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow.fromGraph(GraphDSL.create() {
+    implicit builder: GraphDSL.Builder[NotUsed] =>
+      {
+        import GraphDSL.Implicits._
+
+        /* partitioner port numbers */
+        val portPipelineError = 0
+        val portResponseHandler = 1
+        val totalPorts = 2
+
+        /* building blocks */
+        val handlerPartitioner = builder.add(Partition[GraphMessage](
+          totalPorts,
+          {
+            case Right(jsonRpcMessage: JsonRpcResponse) => jsonRpcMessage.result match {
+                case Some(result) => result.resultMap match {
+                    case Some(map) => portResponseHandler
+                    case _         => portPipelineError
+                  }
+                case _ => portPipelineError
+              }
+            case _ => portPipelineError // Pipeline error goes directly in handlerMerger
+          }
+        ))
+
+        val responseHandler = builder.add(GetMessagesByIdResponseHandler.responseHandler(dbActorRef))
+        val handlerMerger = builder.add(Merge[GraphMessage](totalPorts))
+
+        /* glue the components together */
+        handlerPartitioner.out(portPipelineError) ~> handlerMerger
+        handlerPartitioner.out(portResponseHandler) ~> responseHandler
+
+        /* close the shape */
+        FlowShape(handlerPartitioner.in, handlerMerger.out)
+
+      }
+  })
+
+  private def responseHandler(dbActorRef: ActorRef): Sink[GraphMessage, NotUsed] = Flow[GraphMessage].collect {
+    case Right(jsonRpcMessage: JsonRpcResponse) =>
+      val receivedResponse = jsonRpcMessage.result.get.resultMap.get
+      receivedResponse.keys.foreach(channel => {
+        receivedResponse(channel).foreach(message => {
+          dbActorRef ! DbActor.Write(channel, message)
+        })
+      })
+  }.to(Sink.ignore)
+
+}

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
@@ -14,7 +14,7 @@ import ch.epfl.pop.model.objects.{Channel, DbActorNAckException}
 
 import scala.annotation.tailrec
 import scala.concurrent.Await
-import scala.util.Success
+import scala.util.Failure
 
 /** This object's job is to handle responses it receives from other servers after sending a heartbeat. When receiving the missing messages, the server's job is to write them on the data base.
   */
@@ -76,7 +76,7 @@ object GetMessagesByIdResponseHandler extends AskPatternConstants {
     if (remainingAttempts != 0) {
       val ask = dbActorRef ? DbActor.WriteAndPropagate(channel, message)
       Await.ready(ask, duration).value match {
-        case Some(Success(DbActorNAckException(_, _))) =>
+        case Some(Failure(_: DbActorNAckException)) =>
           writeOnDb(channel, message, dbActorRef, remainingAttempts - 1)
         case _ =>
       }

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
@@ -15,6 +15,7 @@ import ch.epfl.pop.model.objects.{Channel, DbActorNAckException}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, Future}
 import scala.util.Success
+import scala.util.control.Breaks.break
 
 /** This object's job is to handle responses it receives from other servers after sending a heartbeat. When receiving the missing messages, the server's job is to write them on the data base.
   */

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
@@ -6,12 +6,13 @@ import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.testkit.{TestKit, TestProbe}
 import ch.epfl.pop.model.network.{JsonRpcResponse, ResultObject}
 import ch.epfl.pop.model.network.method.message.Message
-import ch.epfl.pop.model.objects.{Base64Data, Channel, Hash}
+import ch.epfl.pop.model.objects.{Base64Data, Channel, DbActorNAckException, Hash}
 import ch.epfl.pop.pubsub.AskPatternConstants
 import ch.epfl.pop.pubsub.graph.GraphMessage
 import ch.epfl.pop.pubsub.graph.validators.RpcValidator
 import ch.epfl.pop.storage.DbActor
 import org.scalatest.funsuite.AnyFunSuiteLike
+
 import scala.concurrent.Await
 
 class GetMessagesByIdResponseHandlerSuite extends TestKit(ActorSystem("GetMessagesByIdResponseHandlerSuiteSystem")) with AnyFunSuiteLike with AskPatternConstants {
@@ -22,9 +23,15 @@ class GetMessagesByIdResponseHandlerSuite extends TestKit(ActorSystem("GetMessag
         testProbe ! (channel, message)
     }
   }
+  class FailingTestDb(testProbe: ActorRef) extends Actor {
+    override def receive: Receive = {
+      case DbActor.Write(channel, message) =>
+        testProbe ! (channel, message)
+        throw(DbActorNAckException(0,""))
+    }
+  }
 
   val testProbe = TestProbe()
-  final val boxUnderTest: Flow[GraphMessage, GraphMessage, NotUsed] = GetMessagesByIdResponseHandler.graph(system.actorOf(Props(new TestDb(testProbe.ref))))
   final val CHANNEL1: Channel = Channel("/root/wex/lao1Id")
   final val CHANNEL2: Channel = Channel("/root/wex/lao2Id")
   final val MESSAGE1_ID: Hash = Hash(Base64Data.encode("message1Id"))
@@ -33,7 +40,9 @@ class GetMessagesByIdResponseHandlerSuite extends TestKit(ActorSystem("GetMessag
   final val MESSAGE2: Message = Message(null, null, null, MESSAGE2_ID, null, null)
   final val missingMessages = Map((CHANNEL1, Set(MESSAGE1)), (CHANNEL2, Set(MESSAGE2)))
   final val receivedResponse: JsonRpcResponse = JsonRpcResponse(RpcValidator.JSON_RPC_VERSION, new ResultObject(missingMessages), None)
+
   test("receiving a get messages by id response sends a write message to the data base") {
+    val boxUnderTest: Flow[GraphMessage, GraphMessage, NotUsed] = GetMessagesByIdResponseHandler.graph(system.actorOf(Props(new TestDb(testProbe.ref))))
     val input: List[GraphMessage] = List(Right(receivedResponse))
     val source = Source(input)
     val s = source.via(boxUnderTest).runWith(Sink.seq[GraphMessage])
@@ -41,4 +50,13 @@ class GetMessagesByIdResponseHandlerSuite extends TestKit(ActorSystem("GetMessag
     testProbe.expectMsgAllOf((CHANNEL1, MESSAGE1), (CHANNEL2, MESSAGE2))
   }
 
+
+  test("failing to write a get messages by id response in the data base retries exactly three times before giving up") {
+    val boxUnderTest: Flow[GraphMessage, GraphMessage, NotUsed] = GetMessagesByIdResponseHandler.graph(system.actorOf(Props(new FailingTestDb(testProbe.ref))))
+    val input: List[GraphMessage] = List(Right(receivedResponse))
+    val source = Source(input)
+    val s = source.via(boxUnderTest).runWith(Sink.seq[GraphMessage])
+    Await.ready(s, duration)
+    testProbe.expectMsgAllOf((CHANNEL1, MESSAGE1),(CHANNEL1, MESSAGE1),(CHANNEL1, MESSAGE1),(CHANNEL2, MESSAGE2),(CHANNEL2, MESSAGE2),(CHANNEL2, MESSAGE2))
+  }
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
@@ -28,8 +28,7 @@ class GetMessagesByIdResponseHandlerSuite extends TestKit(ActorSystem("GetMessag
     override def receive: Receive = {
       case DbActor.WriteAndPropagate(channel, message) =>
         testProbe ! (channel, message)
-        sender() ! Status.Failure(DbActorNAckException(ErrorCodes.INVALID_ACTION.id,
-          s"channel '$channel' does not exist in db"))
+        sender() ! Status.Failure(DbActorNAckException(ErrorCodes.INVALID_ACTION.id, s"channel '$channel' does not exist in db"))
     }
   }
 
@@ -39,8 +38,7 @@ class GetMessagesByIdResponseHandlerSuite extends TestKit(ActorSystem("GetMessag
       case DbActor.WriteAndPropagate(channel, message) =>
         if (numberOfTrials == 0) {
           testProbe ! (channel, message)
-          sender() ! Status.Failure(DbActorNAckException(ErrorCodes.INVALID_ACTION.id,
-            s"channel '$channel' does not exist in db"))
+          sender() ! Status.Failure(DbActorNAckException(ErrorCodes.INVALID_ACTION.id, s"channel '$channel' does not exist in db"))
           context.become(counter(numberOfTrials + 1))
         } else {
           testProbe ! (channel, message)

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
@@ -19,20 +19,20 @@ class GetMessagesByIdResponseHandlerSuite extends TestKit(ActorSystem("GetMessag
 
   class TestDb(testProbe: ActorRef) extends Actor {
     override def receive: Receive = {
-      case DbActor.Write(channel, message) =>
+      case DbActor.WriteAndPropagate(channel, message) =>
         testProbe ! (channel, message)
         sender() ! DbActor.DbActorAck()
     }
   }
   class FailingTestDb(testProbe: ActorRef) extends Actor {
     override def receive: Receive = {
-      case DbActor.Write(channel, message) =>
+      case DbActor.WriteAndPropagate(channel, message) =>
         testProbe ! (channel, message)
         sender() ! DbActorNAckException(0, "")
     }
   }
 
-  val testProbe = TestProbe()
+  private val testProbe = TestProbe()
   final val CHANNEL1: Channel = Channel("/root/wex/lao1Id")
   final val CHANNEL2: Channel = Channel("/root/wex/lao2Id")
   final val MESSAGE1_ID: Hash = Hash(Base64Data.encode("message1Id"))

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
@@ -21,6 +21,7 @@ class GetMessagesByIdResponseHandlerSuite extends TestKit(ActorSystem("GetMessag
     override def receive: Receive = {
       case DbActor.Write(channel, message) =>
         testProbe ! (channel, message)
+        sender() ! DbActor.DbActorAck()
     }
   }
   class FailingTestDb(testProbe: ActorRef) extends Actor {

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
@@ -1,0 +1,21 @@
+package ch.epfl.pop.pubsub.graph.handlers
+
+import akka.NotUsed
+import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.pattern.AskableActorRef
+import akka.stream.scaladsl.Flow
+import akka.testkit.TestKit
+import ch.epfl.pop.pubsub.AskPatternConstants
+import ch.epfl.pop.pubsub.graph.GraphMessage
+import org.scalatest.funsuite.AnyFunSuiteLike
+
+class GetMessagesByIdResponseHandlerSuite extends TestKit(ActorSystem("GetMessagesByIdResponseHandlerSuiteSystem")) with AnyFunSuiteLike with AskPatternConstants {
+  final val toyDbActorRef: ActorRef = system.actorOf(Props(new ToyDbActor))
+  final val boxUnderTest: Flow[GraphMessage, GraphMessage, NotUsed] = GetMessagesByIdResponseHandler.graph(toyDbActorRef)
+
+  test("receiving a get messages by id response sends a write message to the data base"){
+
+  }
+
+
+}

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
@@ -1,21 +1,44 @@
 package ch.epfl.pop.pubsub.graph.handlers
 
 import akka.NotUsed
-import akka.actor.{ActorRef, ActorSystem, Props}
-import akka.pattern.AskableActorRef
-import akka.stream.scaladsl.Flow
-import akka.testkit.TestKit
+import akka.actor.{Actor, ActorRef, ActorSystem, Props}
+import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.testkit.{TestKit, TestProbe}
+import ch.epfl.pop.model.network.{JsonRpcResponse, ResultObject}
+import ch.epfl.pop.model.network.method.message.Message
+import ch.epfl.pop.model.objects.{Base64Data, Channel, Hash}
 import ch.epfl.pop.pubsub.AskPatternConstants
 import ch.epfl.pop.pubsub.graph.GraphMessage
+import ch.epfl.pop.pubsub.graph.validators.RpcValidator
+import ch.epfl.pop.storage.DbActor
 import org.scalatest.funsuite.AnyFunSuiteLike
+import scala.concurrent.Await
 
 class GetMessagesByIdResponseHandlerSuite extends TestKit(ActorSystem("GetMessagesByIdResponseHandlerSuiteSystem")) with AnyFunSuiteLike with AskPatternConstants {
-  final val toyDbActorRef: ActorRef = system.actorOf(Props(new ToyDbActor))
-  final val boxUnderTest: Flow[GraphMessage, GraphMessage, NotUsed] = GetMessagesByIdResponseHandler.graph(toyDbActorRef)
 
-  test("receiving a get messages by id response sends a write message to the data base"){
-
+  class TestDb(testProbe: ActorRef) extends Actor {
+    override def receive: Receive = {
+      case DbActor.Write(channel, message) =>
+        testProbe ! (channel, message)
+    }
   }
 
+  val testProbe = TestProbe()
+  final val boxUnderTest: Flow[GraphMessage, GraphMessage, NotUsed] = GetMessagesByIdResponseHandler.graph(system.actorOf(Props(new TestDb(testProbe.ref))))
+  final val CHANNEL1: Channel = Channel("/root/wex/lao1Id")
+  final val CHANNEL2: Channel = Channel("/root/wex/lao2Id")
+  final val MESSAGE1_ID: Hash = Hash(Base64Data.encode("message1Id"))
+  final val MESSAGE2_ID: Hash = Hash(Base64Data.encode("message2Id"))
+  final val MESSAGE1: Message = Message(null, null, null, MESSAGE1_ID, null, null)
+  final val MESSAGE2: Message = Message(null, null, null, MESSAGE2_ID, null, null)
+  final val missingMessages = Map((CHANNEL1, Set(MESSAGE1)), (CHANNEL2, Set(MESSAGE2)))
+  final val receivedResponse: JsonRpcResponse = JsonRpcResponse(RpcValidator.JSON_RPC_VERSION, new ResultObject(missingMessages), None)
+  test("receiving a get messages by id response sends a write message to the data base") {
+    val input: List[GraphMessage] = List(Right(receivedResponse))
+    val source = Source(input)
+    val s = source.via(boxUnderTest).runWith(Sink.seq[GraphMessage])
+    Await.ready(s, duration)
+    testProbe.expectMsgAllOf((CHANNEL1, MESSAGE1), (CHANNEL2, MESSAGE2))
+  }
 
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
@@ -42,7 +42,7 @@ class GetMessagesByIdResponseHandlerSuite extends TestKit(ActorSystem("GetMessag
   final val missingMessages = Map((CHANNEL1, Set(MESSAGE1)), (CHANNEL2, Set(MESSAGE2)))
   final val receivedResponse: JsonRpcResponse = JsonRpcResponse(RpcValidator.JSON_RPC_VERSION, new ResultObject(missingMessages), None)
 
-  test("receiving a get messages by id response sends a write message to the data base") {
+  test("by receiving a get_messages_by_id response, it sends a write message to the database") {
     val boxUnderTest: Flow[GraphMessage, GraphMessage, NotUsed] = GetMessagesByIdResponseHandler.graph(system.actorOf(Props(new TestDb(testProbe.ref))))
     val input: List[GraphMessage] = List(Right(receivedResponse))
     val source = Source(input)
@@ -51,7 +51,7 @@ class GetMessagesByIdResponseHandlerSuite extends TestKit(ActorSystem("GetMessag
     testProbe.expectMsgAllOf((CHANNEL1, MESSAGE1), (CHANNEL2, MESSAGE2))
   }
 
-  test("failing to write a get messages by id response in the data base retries exactly three times before giving up") {
+  test("by failing to write a  get_messages_by_id response in the database, it retries exactly three times before giving up") {
     val boxUnderTest: Flow[GraphMessage, GraphMessage, NotUsed] = GetMessagesByIdResponseHandler.graph(system.actorOf(Props(new FailingTestDb(testProbe.ref))))
     val input: List[GraphMessage] = List(Right(receivedResponse))
     val source = Source(input)

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandlerSuite.scala
@@ -86,7 +86,7 @@ class GetMessagesByIdResponseHandlerSuite extends TestKit(ActorSystem("GetMessag
     testProbe.expectNoMessage()
   }
 
-  test("by succeeding to write on the db, it doesn't retry to write on it") {
+  test("by succeeding to write a get_messages_by_id on the db, it doesn't retry to write on it") {
     val boxUnderTest: Flow[GraphMessage, GraphMessage, NotUsed] = GetMessagesByIdResponseHandler.graph(system.actorOf(Props(new FailingThenSucceedingTestDb(testProbe.ref))))
     val input: List[GraphMessage] = List(Right(receivedResponse))
     val source = Source(input)


### PR DESCRIPTION
This pull request adds the handler for responses the server gets after sending a getMessagesById to another server. What it does basically is to simply write on the db the received missing messages.