### PR TITLE
Fix unreadable Roll Call QRCode

### DIFF
--- a/fe1-web/src/core/components/QRCode.tsx
+++ b/fe1-web/src/core/components/QRCode.tsx
@@ -20,15 +20,15 @@ const styles = StyleSheet.create({
       assuming the qr code is a square, this means we can cover a width of 50%
       and a height of 50%. centering this gives us 25% margin on every side
 
-      The above computation might not take into account the area covered by the mouse
-      and some squares that are partially hidden by the overlay (MeKHell, 13.04.2023)
+      The above computation might not take into account the area cvered by
+      position, alignment and timing patterns which are not data
     */
     position: 'absolute',
     padding: '4',
-    top: '26%',
-    left: '26%',
-    right: '26%',
-    bottom: '26%',
+    top: '25%',
+    left: '25%',
+    right: '25%',
+    bottom: '25%',
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',

--- a/fe1-web/src/features/rollCall/components/RollCallOpen.tsx
+++ b/fe1-web/src/features/rollCall/components/RollCallOpen.tsx
@@ -171,8 +171,12 @@ const RollCallOpen = ({
       {!isOrganizer && (
         <>
           <Text style={Typography.paragraph}>{STRINGS.roll_call_open_attendee}</Text>
+          {/* Spaces are added in the QRCode's content to spread the data on the surface
+           *  See comment in QRCode.tsx for more information */}
           <QRCode
-            value={ScannablePopToken.encodePopToken({ pop_token: popToken })}
+            value={`${ScannablePopToken.encodePopToken({
+              pop_token: popToken,
+            })}                    `}
             overlayText={STRINGS.roll_call_qrcode_text}
           />
         </>

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
@@ -382,7 +382,7 @@ exports[`EventRollCall render correctly non organizers closed roll calls 1`] = `
                               >
                                 myRollCall
                               </Text>
-                              
+
 
                               <Text>
                                 location
@@ -403,7 +403,7 @@ exports[`EventRollCall render correctly non organizers closed roll calls 1`] = `
                                 <Text>
                                   2022-05-28
                                 </Text>
-                                
+
 
                                 <Text>
                                   00:00:00 - 00:00:00
@@ -1256,7 +1256,7 @@ exports[`EventRollCall render correctly non organizers created roll calls 1`] = 
                               >
                                 myRollCall
                               </Text>
-                              
+
 
                               <Text>
                                 location
@@ -1277,7 +1277,7 @@ exports[`EventRollCall render correctly non organizers created roll calls 1`] = 
                                 <Text>
                                   2022-05-28
                                 </Text>
-                                
+
 
                                 <Text>
                                   00:00:00 - 00:00:00
@@ -1682,7 +1682,7 @@ exports[`EventRollCall render correctly non organizers opened roll calls 1`] = `
                               >
                                 myRollCall
                               </Text>
-                              
+
 
                               <Text>
                                 location
@@ -1700,7 +1700,7 @@ exports[`EventRollCall render correctly non organizers opened roll calls 1`] = `
                               }
                             >
                               Ending
-                               
+
                               <time
                                 dateTime="2021-05-07T03:20:00.000Z"
                                 title="2021-05-07 03:20"
@@ -1723,7 +1723,7 @@ exports[`EventRollCall render correctly non organizers opened roll calls 1`] = `
                             </Text>
                             <qrcode
                               overlayText="Scan to add attendee"
-                              value="{"pop_token":""}"
+                              value="{"pop_token":""}                    "
                             />
                             <View
                               style={
@@ -2571,7 +2571,7 @@ exports[`EventRollCall render correctly non organizers re-opened roll calls 1`] 
                               >
                                 myRollCall
                               </Text>
-                              
+
 
                               <Text>
                                 location
@@ -2589,7 +2589,7 @@ exports[`EventRollCall render correctly non organizers re-opened roll calls 1`] 
                               }
                             >
                               Ending
-                               
+
                               <time
                                 dateTime="2021-05-07T03:20:00.000Z"
                                 title="2021-05-07 03:20"
@@ -2612,7 +2612,7 @@ exports[`EventRollCall render correctly non organizers re-opened roll calls 1`] 
                             </Text>
                             <qrcode
                               overlayText="Scan to add attendee"
-                              value="{"pop_token":""}"
+                              value="{"pop_token":""}                    "
                             />
                             <View
                               style={
@@ -3460,7 +3460,7 @@ exports[`EventRollCall render correctly organizers closed roll calls 1`] = `
                               >
                                 myRollCall
                               </Text>
-                              
+
 
                               <Text>
                                 location
@@ -3481,7 +3481,7 @@ exports[`EventRollCall render correctly organizers closed roll calls 1`] = `
                                 <Text>
                                   2022-05-28
                                 </Text>
-                                
+
 
                                 <Text>
                                   00:00:00 - 00:00:00
@@ -4424,7 +4424,7 @@ exports[`EventRollCall render correctly organizers created roll calls 1`] = `
                               >
                                 myRollCall
                               </Text>
-                              
+
 
                               <Text>
                                 location
@@ -4445,7 +4445,7 @@ exports[`EventRollCall render correctly organizers created roll calls 1`] = `
                                 <Text>
                                   2022-05-28
                                 </Text>
-                                
+
 
                                 <Text>
                                   00:00:00 - 00:00:00
@@ -4940,7 +4940,7 @@ exports[`EventRollCall render correctly organizers opened roll calls 1`] = `
                               >
                                 myRollCall
                               </Text>
-                              
+
 
                               <Text>
                                 location
@@ -4958,7 +4958,7 @@ exports[`EventRollCall render correctly organizers opened roll calls 1`] = `
                               }
                             >
                               Ending
-                               
+
                               <time
                                 dateTime="2021-05-07T03:20:00.000Z"
                                 title="2021-05-07 03:20"
@@ -5983,7 +5983,7 @@ exports[`EventRollCall render correctly organizers re-opened roll calls 1`] = `
                               >
                                 myRollCall
                               </Text>
-                              
+
 
                               <Text>
                                 location
@@ -6001,7 +6001,7 @@ exports[`EventRollCall render correctly organizers re-opened roll calls 1`] = `
                               }
                             >
                               Ending
-                               
+
                               <time
                                 dateTime="2021-05-07T03:20:00.000Z"
                                 title="2021-05-07 03:20"


### PR DESCRIPTION
This fix will resolve the issue where some QR Codes during Roll Call were not readable.

After some research, I think that the problem came, because we considered that error correction applied to the full QR Code where it only seems to apply to the data inside the QR Codes (without the timing, position, and alignment pattern).

This fix adds some white text after the json to force the QR Code to add more data and therefore spread the important data all over the QR Code.
