### PR TITLE
Remove catchup and broadcasts between servers

### DIFF
--- a/be1-go/channel/mod.go
+++ b/be1-go/channel/mod.go
@@ -44,13 +44,13 @@ func NewSockets() Sockets {
 	}
 }
 
-// Sockets provides thread-funcionalities around a socket store.
+// Sockets provides thread-functionalities around a socket store.
 type Sockets struct {
 	sync.RWMutex
 	store map[string]socket.Socket
 }
 
-// Len returns the numbre of sockets.
+// Len returns the number of sockets.
 func (s *Sockets) Len() int {
 	return len(s.store)
 }

--- a/be1-go/cli/mod.go
+++ b/be1-go/cli/mod.go
@@ -137,10 +137,7 @@ func connectToSocket(address string, h hub.Hub,
 	go remoteSocket.WritePump()
 	go remoteSocket.ReadPump()
 
-	err = h.NotifyNewServer(remoteSocket)
-	if err != nil {
-		return xerrors.Errorf("error while trying to catchup to server: %v", err)
-	}
+	h.NotifyNewServer(remoteSocket)
 
 	return nil
 }

--- a/be1-go/hub/mod.go
+++ b/be1-go/hub/mod.go
@@ -11,7 +11,7 @@ import (
 // and handle clients.
 type Hub interface {
 	// NotifyNewServer add a socket for the hub to send message to other servers
-	NotifyNewServer(socket.Socket) error
+	NotifyNewServer(socket.Socket)
 
 	// Start invokes the processing loop for the hub.
 	Start()

--- a/be1-go/hub/standard_hub/message_handling.go
+++ b/be1-go/hub/standard_hub/message_handling.go
@@ -73,13 +73,13 @@ func (h *Hub) handleRootChannelPublishMessage(sock socket.Socket, publish method
 	}
 
 	h.rootInbox.StoreMessage(publish.Params.Message)
-	h.globalInbox.StoreMessage(publish.Params.Message)
+	h.hubInbox.StoreMessage(publish.Params.Message)
 	h.addMessageId(publish.Params.Channel, publish.Params.Message.MessageID)
 
 	return nil
 }
 
-// handleRootChannelPublishMesssage handles an incoming publish message on the root channel.
+// handleRootChannelPublishMessage handles an incoming publish message on the root channel.
 func (h *Hub) handleRootChannelBroadcastMessage(sock socket.Socket,
 	broadcast method.Broadcast) error {
 
@@ -138,7 +138,7 @@ func (h *Hub) handleRootChannelBroadcastMessage(sock socket.Socket,
 	}
 
 	h.rootInbox.StoreMessage(broadcast.Params.Message)
-	h.globalInbox.StoreMessage(broadcast.Params.Message)
+	h.hubInbox.StoreMessage(broadcast.Params.Message)
 	h.addMessageId(broadcast.Params.Channel, broadcast.Params.Message.MessageID)
 
 	return nil
@@ -304,7 +304,6 @@ func (h *Hub) handlePublish(socket socket.Socket, byteMessage []byte) (int, erro
 			return publish.ID, err
 		}
 		h.hubInbox.StoreMessage(publish.Params.Message)
-		h.globalInbox.StoreMessage(publish.Params.Message)
 		h.addMessageId(publish.Params.Channel, publish.Params.Message.MessageID)
 		return publish.ID, nil
 	}
@@ -325,7 +324,6 @@ func (h *Hub) handlePublish(socket socket.Socket, byteMessage []byte) (int, erro
 	}
 
 	h.hubInbox.StoreMessage(publish.Params.Message)
-	h.globalInbox.StoreMessage(publish.Params.Message)
 	h.addMessageId(publish.Params.Channel, publish.Params.Message.MessageID)
 
 	return publish.ID, nil
@@ -356,7 +354,6 @@ func (h *Hub) handleBroadcast(socket socket.Socket, byteMessage []byte) error {
 		return nil
 	}
 	h.hubInbox.StoreMessage(broadcast.Params.Message)
-	h.globalInbox.StoreMessage(broadcast.Params.Message)
 	h.addMessageId(broadcast.Params.Channel, broadcast.Params.Message.MessageID)
 
 	h.Unlock()
@@ -524,7 +521,7 @@ func (h *Hub) getMissingMessages(missingIds map[string][]string) (map[string][]m
 	missingMsgs := make(map[string][]message.Message)
 	for channelId, messageIds := range missingIds {
 		for _, messageId := range messageIds {
-			msg, exists := h.globalInbox.GetMessage(messageId)
+			msg, exists := h.hubInbox.GetMessage(messageId)
 			if !exists {
 				return nil, xerrors.Errorf("Message %s not found in hub inbox", messageId)
 			}
@@ -565,7 +562,6 @@ func (h *Hub) handleReceivedMessage(socket socket.Socket, publish method.Publish
 
 	h.Lock()
 	h.hubInbox.StoreMessage(publish.Params.Message)
-	h.globalInbox.StoreMessage(publish.Params.Message)
 	h.addMessageId(publish.Params.Channel, publish.Params.Message.MessageID)
 	h.Unlock()
 

--- a/be1-go/hub/standard_hub/mod.go
+++ b/be1-go/hub/standard_hub/mod.go
@@ -98,7 +98,6 @@ type Hub struct {
 func newQueries() queries {
 	return queries{
 		state:                  make(map[int]*bool),
-		catchupQueries:         make(map[int]method.Catchup),
 		getMessagesByIdQueries: make(map[int]method.GetMessagesById),
 	}
 }
@@ -109,8 +108,6 @@ type queries struct {
 	// state stores the ID of the server's queries and their state. False for a
 	// query not yet answered, else true.
 	state map[int]*bool
-	// catchupQueries stores the server's catchup queries by their ID.
-	catchupQueries map[int]method.Catchup
 	// getMessagesByIdQueries stores the server's getMessagesByIds queries by their ID.
 	getMessagesByIdQueries map[int]method.GetMessagesById
 	// nextID store the ID of the next query

--- a/be1-go/hub/standard_hub/mod_test.go
+++ b/be1-go/hub/standard_hub/mod_test.go
@@ -35,8 +35,7 @@ func Test_Add_Server_Socket(t *testing.T) {
 
 	sock := &fakeSocket{id: "fakeID"}
 
-	err = hub.NotifyNewServer(sock)
-	require.NoError(t, err)
+	hub.NotifyNewServer(sock)
 	require.NotNil(t, hub.queries.catchupQueries[0])
 	require.Equal(t, 1, hub.queries.nextID)
 }

--- a/be1-go/hub/standard_hub/mod_test.go
+++ b/be1-go/hub/standard_hub/mod_test.go
@@ -801,12 +801,10 @@ func Test_Handle_Answer(t *testing.T) {
 
 	queryState := false
 	hub.queries.state[1] = &queryState
-	hub.queries.catchupQueries[1] = method.Catchup{
-		Params: struct {
-			Channel string "json:\"channel\""
-		}{
-			Channel: "/root",
-		},
+	hub.queries.getMessagesByIdQueries[1] = method.GetMessagesById{
+		Base:   query.Base{},
+		ID:     1,
+		Params: nil,
 	}
 
 	sock := &fakeSocket{}

--- a/be1-go/hub/standard_hub/mod_test.go
+++ b/be1-go/hub/standard_hub/mod_test.go
@@ -1536,9 +1536,9 @@ func Test_Send_Heartbeat_Message(t *testing.T) {
 
 	hub.serverSockets.Upsert(sock)
 
-	hub.globalInbox.StoreMessage(msg1)
-	hub.globalInbox.StoreMessage(msg2)
-	hub.globalInbox.StoreMessage(msg3)
+	hub.hubInbox.StoreMessage(msg1)
+	hub.hubInbox.StoreMessage(msg2)
+	hub.hubInbox.StoreMessage(msg3)
 
 	hub.messageIdsByChannel["/root"] = idsRoot
 	hub.messageIdsByChannel["/root/channel1"] = idsChannel1
@@ -1572,7 +1572,7 @@ func Test_Handle_Heartbeat(t *testing.T) {
 	hub, err := NewHub(keypair.public, "", nolog, nil)
 	require.NoError(t, err)
 
-	hub.globalInbox.StoreMessage(msg1)
+	hub.hubInbox.StoreMessage(msg1)
 
 	hub.messageIdsByChannel["/root"] = []string{msg1.MessageID}
 
@@ -1636,9 +1636,9 @@ func Test_Handle_GetMessagesById(t *testing.T) {
 
 	hub.serverSockets.Upsert(sock)
 
-	hub.globalInbox.StoreMessage(msg1)
-	hub.globalInbox.StoreMessage(msg2)
-	hub.globalInbox.StoreMessage(msg3)
+	hub.hubInbox.StoreMessage(msg1)
+	hub.hubInbox.StoreMessage(msg2)
+	hub.hubInbox.StoreMessage(msg3)
 
 	hub.messageIdsByChannel["/root"] = idsRoot
 	hub.messageIdsByChannel["/root/channel1"] = idsChannel1

--- a/be1-go/network/server.go
+++ b/be1-go/network/server.go
@@ -130,13 +130,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		go server.ReadPump()
 		go server.WritePump()
 
-		err = s.hub.NotifyNewServer(server)
-		if err != nil {
-			s.log.Err(err).Msg("error while trying to catchup to server")
-
-			http.Error(w, "failed to add socket: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
+		s.hub.NotifyNewServer(server)
 	}
 }
 


### PR DESCRIPTION
This PR removes catchups and broadcasts between servers on the go backend as they are not useful anymore since the merge of the heartbeat and getMessagesById features.
It adapts or deletes some previous tests that assume catchups and broadcasts between servers.
Finally, it removes the globalInbox and leaves only the hubInbox since we only need that one now that we don't have broadcasts between servers anymore.

On the heartbeat / getMessagesById feature side it:
- Adds sending a heartbeat message after receiving a publish message 
- Changes the delay of sending a heartbeat message to 30 seconds 
- Removes the updateRecord method as it appears to be useless