### PR TITLE
Bug fixing

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.java
@@ -50,7 +50,8 @@ public class InviteFragment extends Fragment {
     InviteFragmentBinding binding = InviteFragmentBinding.inflate(inflater, container, false);
     laoViewModel = LaoActivity.obtainViewModel(requireActivity());
 
-    binding.laoPropertiesIdentifierText.setText(laoViewModel.getPublicKey().getEncoded());
+    // Display the LAO identifier, not the client's public key
+    binding.laoPropertiesIdentifierText.setText(laoViewModel.getLaoId());
     binding.laoPropertiesServerText.setText(networkManager.getCurrentUrl());
 
     try {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.java
@@ -50,7 +50,7 @@ public class InviteFragment extends Fragment {
     InviteFragmentBinding binding = InviteFragmentBinding.inflate(inflater, container, false);
     laoViewModel = LaoActivity.obtainViewModel(requireActivity());
 
-    // Display the LAO identifier, not the client's public key
+    // Display the LAO identifier, not the device public key
     binding.laoPropertiesIdentifierText.setText(laoViewModel.getLaoId());
     binding.laoPropertiesServerText.setText(networkManager.getCurrentUrl());
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/adapters/CastVoteViewPagerAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/election/adapters/CastVoteViewPagerAdapter.java
@@ -67,6 +67,12 @@ public class CastVoteViewPagerAdapter
           votes.put(question.getId(), listPosition);
           voteButton.setEnabled(areEveryQuestionChecked());
         });
+
+    // Ensure that the selection is not lost
+    Integer index = votes.get(question.getId());
+    if (index != null && index >= 0 && index < question.getBallotOptions().size()) {
+      holder.ballotsListView.setItemChecked(index, true);
+    }
   }
 
   @Override

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/MatcherUtils.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/MatcherUtils.java
@@ -2,6 +2,9 @@ package com.github.dedis.popstellar.testutils;
 
 import android.view.*;
 
+import androidx.test.espresso.matcher.BoundedMatcher;
+import androidx.viewpager2.widget.ViewPager2;
+
 import org.hamcrest.*;
 
 public class MatcherUtils {
@@ -26,6 +29,20 @@ public class MatcherUtils {
         return parent instanceof ViewGroup
             && parentMatcher.matches(parent)
             && view.equals(((ViewGroup) parent).getChildAt(position));
+      }
+    };
+  }
+
+  public static Matcher<View> PageMatcher(final int position) {
+    return new BoundedMatcher<View, ViewPager2>(ViewPager2.class) {
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("is at position " + position + " in ViewPager");
+      }
+
+      @Override
+      protected boolean matchesSafely(ViewPager2 viewPager) {
+        return viewPager.getCurrentItem() == position;
       }
     };
   }

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/InviteFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/InviteFragmentTest.java
@@ -81,6 +81,6 @@ public class InviteFragmentTest {
   public void displayedInfoIsCorrect() {
     roleText().check(matches(withText("Organizer")));
     laoNameText().check(matches(withText(LAO_NAME)));
-    identifierText().check(matches(withText(PK.getEncoded())));
+    identifierText().check(matches(withText(LAO.getId())));
   }
 }

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/CastVoteOpenBallotFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/CastVoteOpenBallotFragmentTest.java
@@ -38,14 +38,14 @@ import dagger.hilt.android.testing.*;
 import io.reactivex.subjects.BehaviorSubject;
 
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.action.ViewActions.swipeLeft;
+import static androidx.test.espresso.action.ViewActions.*;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.*;
 import static com.github.dedis.popstellar.model.objects.Election.generateElectionSetupId;
 import static com.github.dedis.popstellar.model.objects.event.EventState.CREATED;
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generateKeyPair;
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generatePoPToken;
+import static com.github.dedis.popstellar.testutils.MatcherUtils.PageMatcher;
 import static com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject.containerId;
 import static com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject.laoIdExtra;
 import static com.github.dedis.popstellar.testutils.pages.lao.event.election.CastVoteFragmentPageObject.*;
@@ -200,5 +200,14 @@ public class CastVoteOpenBallotFragmentTest {
 
     verify(messageSenderHelper.getMockedSender())
         .publish(any(), eq(ELECTION.getChannel()), any(CastVote.class));
+  }
+
+  @Test
+  public void swipeDoNotClearSelectionTest() {
+    onView(withText(ELECTION_BALLOT_TEXT11)).perform(click());
+    castVotePager().perform(swipeLeft());
+    castVotePager().perform(swipeRight());
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+    castVotePager().check(matches(PageMatcher(0)));
   }
 }


### PR DESCRIPTION
This PR:
- resolves #1547 showing the LAO identifier in the invite section instead of the personal public key, as in FE1.

- fixes #1546, by saving the selections of the casted vote.
