### PR TITLE
Display witness messages

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/WitnessMessage.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/WitnessMessage.java
@@ -7,6 +7,7 @@ import com.github.dedis.popstellar.model.objects.security.MessageID;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /** Class to model a message that needs to be signed by witnesses */
@@ -92,5 +93,25 @@ public class WitnessMessage implements Copyable<WitnessMessage> {
         + description
         + '\''
         + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof WitnessMessage)) {
+      return false;
+    }
+    WitnessMessage that = (WitnessMessage) o;
+    return messageId.equals(that.messageId)
+        && Objects.equals(witnesses, that.witnesses)
+        && Objects.equals(title, that.title)
+        && Objects.equals(description, that.description);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(messageId, witnesses, title, description);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/WitnessMessage.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/WitnessMessage.java
@@ -1,9 +1,11 @@
 package com.github.dedis.popstellar.model.objects;
 
 import androidx.annotation.NonNull;
+
 import com.github.dedis.popstellar.model.Copyable;
 import com.github.dedis.popstellar.model.objects.security.MessageID;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
+
 import java.util.HashSet;
 import java.util.Set;
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/WitnessMessage.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/WitnessMessage.java
@@ -1,11 +1,9 @@
 package com.github.dedis.popstellar.model.objects;
 
 import androidx.annotation.NonNull;
-
 import com.github.dedis.popstellar.model.Copyable;
 import com.github.dedis.popstellar.model.objects.security.MessageID;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
-
 import java.util.HashSet;
 import java.util.Set;
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/ConnectingActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/ConnectingActivity.java
@@ -129,6 +129,9 @@ public class ConnectingActivity extends AppCompatActivity {
       List<PublicKey> witnesses =
           witnessesList.stream().map(PublicKey::new).collect(Collectors.toList());
 
+      // Add the organizer to the list of witnesses
+      witnesses.add(keyManager.getMainPublicKey());
+
       CreateLao createLao = new CreateLao(laoName, keyManager.getMainPublicKey(), witnesses);
       Lao lao = new Lao(createLao.getId());
       Timber.tag(TAG).d("Creating Lao %s", lao.getId());

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
@@ -5,11 +5,9 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.*;
 import android.widget.ArrayAdapter;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.LaoCreateFragmentBinding;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
@@ -17,13 +15,11 @@ import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 import com.github.dedis.popstellar.ui.lao.witness.WitnessingViewModel;
 import com.github.dedis.popstellar.ui.qrcode.QrScannerFragment;
 import com.github.dedis.popstellar.ui.qrcode.ScanningAction;
-
+import dagger.hilt.android.AndroidEntryPoint;
 import java.util.List;
 import java.util.Objects;
-
+import java.util.stream.Collectors;
 import javax.inject.Inject;
-
-import dagger.hilt.android.AndroidEntryPoint;
 import timber.log.Timber;
 
 /** Fragment used to display the Launch UI */
@@ -118,14 +114,17 @@ public final class LaoCreateFragment extends Fragment {
         });
 
     // No need to have a LiveData as the fragment is recreated upon exiting the scanner
-    List<PublicKey> witnesses = witnessingViewModel.getScannedWitnesses();
+    List<String> witnesses =
+        witnessingViewModel.getScannedWitnesses().stream()
+            .map(publicKey -> publicKey.getEncoded())
+            .collect(Collectors.toList());
 
     // Show the witnesses title only if there's at least one witness
     if (!witnesses.isEmpty()) {
       binding.witnessesTitle.setVisibility(View.VISIBLE);
     }
 
-    ArrayAdapter<PublicKey> witnessesListAdapter =
+    ArrayAdapter<String> witnessesListAdapter =
         new ArrayAdapter<>(requireContext(), android.R.layout.simple_list_item_1, witnesses);
     binding.witnessesList.setAdapter(witnessesListAdapter);
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
@@ -12,7 +12,6 @@ import androidx.fragment.app.Fragment;
 
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.LaoCreateFragmentBinding;
-import com.github.dedis.popstellar.model.objects.security.Base64URLData;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 import com.github.dedis.popstellar.ui.lao.witness.WitnessingViewModel;
@@ -122,7 +121,7 @@ public final class LaoCreateFragment extends Fragment {
     // No need to have a LiveData as the fragment is recreated upon exiting the scanner
     List<String> witnesses =
         witnessingViewModel.getScannedWitnesses().stream()
-            .map(Base64URLData::getEncoded)
+            .map(PublicKey::getEncoded)
             .collect(Collectors.toList());
 
     // Show the witnesses title only if there's at least one witness

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment;
 
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.LaoCreateFragmentBinding;
+import com.github.dedis.popstellar.model.objects.security.Base64URLData;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 import com.github.dedis.popstellar.ui.lao.witness.WitnessingViewModel;
@@ -121,7 +122,7 @@ public final class LaoCreateFragment extends Fragment {
     // No need to have a LiveData as the fragment is recreated upon exiting the scanner
     List<String> witnesses =
         witnessingViewModel.getScannedWitnesses().stream()
-            .map(publicKey -> publicKey.getEncoded())
+            .map(Base64URLData::getEncoded)
             .collect(Collectors.toList());
 
     // Show the witnesses title only if there's at least one witness

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
@@ -5,9 +5,11 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.*;
 import android.widget.ArrayAdapter;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.LaoCreateFragmentBinding;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
@@ -15,11 +17,14 @@ import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 import com.github.dedis.popstellar.ui.lao.witness.WitnessingViewModel;
 import com.github.dedis.popstellar.ui.qrcode.QrScannerFragment;
 import com.github.dedis.popstellar.ui.qrcode.ScanningAction;
-import dagger.hilt.android.AndroidEntryPoint;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
 import javax.inject.Inject;
+
+import dagger.hilt.android.AndroidEntryPoint;
 import timber.log.Timber;
 
 /** Fragment used to display the Launch UI */

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
@@ -1,5 +1,7 @@
 package com.github.dedis.popstellar.ui.lao.event.rollcall;
 
+import static com.github.dedis.popstellar.utility.Constants.*;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.pm.ActivityInfo;
@@ -9,11 +11,9 @@ import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.view.*;
 import android.widget.*;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.content.res.AppCompatResources;
-
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.RollCallFragmentBinding;
 import com.github.dedis.popstellar.model.objects.RollCall;
@@ -32,19 +32,13 @@ import com.github.dedis.popstellar.utility.Constants;
 import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.error.keys.KeyException;
 import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
-
-import net.glxn.qrgen.android.QRCode;
-
+import dagger.hilt.android.AndroidEntryPoint;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import javax.inject.Inject;
-
-import dagger.hilt.android.AndroidEntryPoint;
+import net.glxn.qrgen.android.QRCode;
 import timber.log.Timber;
-
-import static com.github.dedis.popstellar.utility.Constants.*;
 
 @AndroidEntryPoint
 public class RollCallFragment extends AbstractEventFragment {
@@ -96,11 +90,15 @@ public class RollCallFragment extends AbstractEventFragment {
 
     // Set the description dropdown
     binding.rollCallDescriptionCard.setOnClickListener(
-        v -> handleExpandArrow(binding.rollCallDescriptionArrow, binding.rollCallDescriptionText));
+        v ->
+            ActivityUtils.handleExpandArrow(
+                binding.rollCallDescriptionArrow, binding.rollCallDescriptionText));
 
     // Set the location dropdown
     binding.rollCallLocationCard.setOnClickListener(
-        v -> handleExpandArrow(binding.rollCallLocationArrow, binding.rollCallLocationText));
+        v ->
+            ActivityUtils.handleExpandArrow(
+                binding.rollCallLocationArrow, binding.rollCallLocationText));
 
     binding.rollCallManagementButton.setOnClickListener(
         v -> {
@@ -343,24 +341,6 @@ public class RollCallFragment extends AbstractEventFragment {
             .withColor(ActivityUtils.getQRCodeColor(requireContext()), Color.TRANSPARENT)
             .bitmap();
     binding.rollCallPkQrCode.setImageBitmap(myBitmap);
-  }
-
-  /** Callback function for the card listener to expand and shrink a text box */
-  private void handleExpandArrow(ImageView arrow, TextView text) {
-    float newRotation;
-    int visibility;
-    // If the arrow is pointing up, then rotate down and make visible the text
-    if (arrow.getRotation() == ORIENTATION_UP) {
-      newRotation = ORIENTATION_DOWN;
-      visibility = View.VISIBLE;
-    } else { // Otherwise rotate up and hide the text
-      newRotation = ORIENTATION_UP;
-      visibility = View.GONE;
-    }
-
-    // Use an animation to rotate smoothly
-    arrow.animate().rotation(newRotation).setDuration(300).start();
-    text.setVisibility(visibility);
   }
 
   private EnumMap<EventState, Integer> buildManagementTextMap() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.java
@@ -1,7 +1,5 @@
 package com.github.dedis.popstellar.ui.lao.event.rollcall;
 
-import static com.github.dedis.popstellar.utility.Constants.*;
-
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.pm.ActivityInfo;
@@ -11,9 +9,11 @@ import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.view.*;
 import android.widget.*;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.content.res.AppCompatResources;
+
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.RollCallFragmentBinding;
 import com.github.dedis.popstellar.model.objects.RollCall;
@@ -32,13 +32,19 @@ import com.github.dedis.popstellar.utility.Constants;
 import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.error.keys.KeyException;
 import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
-import dagger.hilt.android.AndroidEntryPoint;
+
+import net.glxn.qrgen.android.QRCode;
+
 import java.util.EnumMap;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import javax.inject.Inject;
-import net.glxn.qrgen.android.QRCode;
+
+import dagger.hilt.android.AndroidEntryPoint;
 import timber.log.Timber;
+
+import static com.github.dedis.popstellar.utility.Constants.*;
 
 @AndroidEntryPoint
 public class RollCallFragment extends AbstractEventFragment {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragment.java
@@ -15,7 +15,6 @@ import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import java.util.ArrayList;
 
 import dagger.hilt.android.AndroidEntryPoint;
-
 import timber.log.Timber;
 
 @AndroidEntryPoint

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragment.java
@@ -3,18 +3,14 @@ package com.github.dedis.popstellar.ui.lao.witness;
 import android.os.Bundle;
 import android.view.*;
 import android.widget.ListView;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-
 import com.github.dedis.popstellar.databinding.WitnessMessageFragmentBinding;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
-
-import java.util.ArrayList;
-
 import dagger.hilt.android.AndroidEntryPoint;
+import java.util.ArrayList;
 import timber.log.Timber;
 
 @AndroidEntryPoint

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragment.java
@@ -3,14 +3,19 @@ package com.github.dedis.popstellar.ui.lao.witness;
 import android.os.Bundle;
 import android.view.*;
 import android.widget.ListView;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+
 import com.github.dedis.popstellar.databinding.WitnessMessageFragmentBinding;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
-import dagger.hilt.android.AndroidEntryPoint;
+
 import java.util.ArrayList;
+
+import dagger.hilt.android.AndroidEntryPoint;
+
 import timber.log.Timber;
 
 @AndroidEntryPoint

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
@@ -28,11 +28,13 @@ public class WitnessMessageListViewAdapter extends BaseAdapter {
   private List<WitnessMessage> messages;
 
   private final FragmentActivity activity;
+  private boolean isWitness;
   private static final String NO_SIGNATURES = "No signatures yet";
 
   public WitnessMessageListViewAdapter(List<WitnessMessage> messages, FragmentActivity activity) {
     laoViewModel = LaoActivity.obtainViewModel(activity);
     witnessingViewModel = LaoActivity.obtainWitnessingViewModel(activity, laoViewModel.getLaoId());
+    isWitness = Boolean.TRUE.equals(laoViewModel.isWitness().getValue());
     this.activity = activity;
     setList(messages);
   }
@@ -82,14 +84,14 @@ public class WitnessMessageListViewAdapter extends BaseAdapter {
       throw new IllegalStateException("Binding could not be found in the view");
     }
 
-    WitnessMessage message = messages.get(position);
+    WitnessMessage witnessMessage = messages.get(position);
 
     // Set message title and description
-    binding.messageTitle.setText(message.getTitle());
-    binding.messageDescriptionText.setText(message.getDescription());
+    binding.messageTitle.setText(witnessMessage.getTitle());
+    binding.messageDescriptionText.setText(witnessMessage.getDescription());
 
     // Set witness signatures text
-    String formattedSignatures = formatPublicKeys(message.getWitnesses());
+    String formattedSignatures = formatPublicKeys(witnessMessage.getWitnesses());
     binding.witnessesText.setText(formattedSignatures);
 
     // Set message description dropdown
@@ -102,41 +104,46 @@ public class WitnessMessageListViewAdapter extends BaseAdapter {
     binding.signaturesCard.setOnClickListener(
         v -> ActivityUtils.handleExpandArrow(binding.signaturesArrow, binding.witnessesText));
 
-    Context context = parent.getContext();
-    View.OnClickListener listener =
-        v -> {
-          AlertDialog.Builder adb = new AlertDialog.Builder(context);
+    if (isWitness) {
+      Context context = parent.getContext();
+      View.OnClickListener listener = setUpSignButtonClickListener(context, witnessMessage);
+      binding.signMessageButton.setOnClickListener(listener);
+    } else {
+      // Don't show the sign button if the user is not a witness
+      binding.signMessageButton.setVisibility(View.GONE);
+    }
 
-          if (Boolean.TRUE.equals(laoViewModel.isWitness().getValue())) {
-            adb.setTitle(R.string.sign_message);
-            adb.setMessage(
-                String.format(
-                    context.getString(R.string.confirm_to_sign),
-                    messages.get(position).getMessageId()));
-            adb.setNegativeButton(R.string.cancel, null);
-            adb.setPositiveButton(
-                R.string.confirm,
-                (dialog, which) ->
-                    laoViewModel.addDisposable(
-                        witnessingViewModel
-                            .signMessage(messages.get(position))
-                            .subscribe(
-                                () -> {},
-                                error ->
-                                    ErrorUtils.logAndShow(
-                                        activity, TAG, error, R.string.error_sign_message))));
-          } else {
-            adb.setTitle(R.string.not_a_witness);
-            adb.setMessage(R.string.not_a_witness_explanation);
-            adb.setCancelable(false);
-            adb.setPositiveButton(R.string.ok, (dialog, which) -> {});
-          }
-          adb.show();
-        };
-    binding.signMessageButton.setOnClickListener(listener);
     binding.setLifecycleOwner(activity);
 
     return binding.getRoot();
+  }
+
+  private View.OnClickListener setUpSignButtonClickListener(
+      Context context, WitnessMessage message) {
+    return v -> {
+      AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(context);
+
+      dialogBuilder.setTitle(R.string.sign_message);
+      dialogBuilder.setMessage(
+          String.format(
+              context.getString(R.string.confirm_to_sign), message.getMessageId().getEncoded()));
+
+      dialogBuilder.setNegativeButton(R.string.cancel, null);
+
+      dialogBuilder.setPositiveButton(
+          R.string.confirm,
+          (dialog, which) ->
+              laoViewModel.addDisposable(
+                  witnessingViewModel
+                      .signMessage(message)
+                      .subscribe(
+                          () -> {},
+                          error ->
+                              ErrorUtils.logAndShow(
+                                  activity, TAG, error, R.string.error_sign_message))));
+
+      dialogBuilder.show();
+    };
   }
 
   private static String formatPublicKeys(Set<PublicKey> witnesses) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
@@ -142,9 +142,7 @@ public class WitnessMessageListViewAdapter extends BaseAdapter {
                   witnessingViewModel
                       .signMessage(message)
                       .subscribe(
-                          () -> {
-                            Timber.tag(TAG).d("Witness message successfully signed");
-                          },
+                          () -> Timber.tag(TAG).d("Witness message successfully signed"),
                           error ->
                               ErrorUtils.logAndShow(
                                   activity, TAG, error, R.string.error_sign_message))));

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
@@ -109,8 +109,7 @@ public class WitnessMessageListViewAdapter extends BaseAdapter {
     binding.signaturesCard.setOnClickListener(
         v -> ActivityUtils.handleExpandArrow(binding.signaturesArrow, binding.witnessesText));
 
-    // Display the sign button for witnesses and the organizer
-    if (isWitness || laoViewModel.isOrganizer()) {
+    if (isWitness) {
       Context context = parent.getContext();
       View.OnClickListener listener = setUpSignButtonClickListener(context, witnessMessage);
       binding.signMessageButton.setOnClickListener(listener);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
@@ -11,6 +11,7 @@ import androidx.fragment.app.FragmentActivity;
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.WitnessMessageLayoutBinding;
 import com.github.dedis.popstellar.model.objects.WitnessMessage;
+import com.github.dedis.popstellar.model.objects.security.Base64URLData;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
@@ -20,8 +21,6 @@ import com.github.dedis.popstellar.utility.error.ErrorUtils;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-/** Adapter to show the messages that have to be signed by the witnesses */
 
 /** Adapter to show the messages that have to be signed by the witnesses */
 public class WitnessMessageListViewAdapter extends BaseAdapter {
@@ -155,9 +154,7 @@ public class WitnessMessageListViewAdapter extends BaseAdapter {
     if (witnesses.isEmpty()) {
       return NO_SIGNATURES;
     } else {
-      return witnesses.stream()
-          .map(publicKey -> publicKey.getEncoded())
-          .collect(Collectors.joining("\n"));
+      return witnesses.stream().map(Base64URLData::getEncoded).collect(Collectors.joining("\n"));
     }
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
@@ -4,17 +4,14 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.view.*;
 import android.widget.BaseAdapter;
-
 import androidx.databinding.DataBindingUtil;
 import androidx.fragment.app.FragmentActivity;
-
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.WitnessMessageLayoutBinding;
 import com.github.dedis.popstellar.model.objects.WitnessMessage;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
-
 import java.util.List;
 
 /** Adapter to show the messages that have to be signed by the witnesses */
@@ -79,6 +76,10 @@ public class WitnessMessageListViewAdapter extends BaseAdapter {
     if (binding == null) {
       throw new IllegalStateException("Binding could not be find in the view");
     }
+
+    WitnessMessage message = messages.get(position);
+    binding.messageTitle.setText(message.getTitle());
+    binding.messageDescription.setText(message.getDescription());
 
     Context context = parent.getContext();
     View.OnClickListener listener =

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
@@ -4,8 +4,10 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.view.*;
 import android.widget.BaseAdapter;
+
 import androidx.databinding.DataBindingUtil;
 import androidx.fragment.app.FragmentActivity;
+
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.WitnessMessageLayoutBinding;
 import com.github.dedis.popstellar.model.objects.WitnessMessage;
@@ -14,9 +16,12 @@ import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
 import com.github.dedis.popstellar.utility.ActivityUtils;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
+
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+/** Adapter to show the messages that have to be signed by the witnesses */
 
 /** Adapter to show the messages that have to be signed by the witnesses */
 public class WitnessMessageListViewAdapter extends BaseAdapter {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
@@ -109,7 +109,8 @@ public class WitnessMessageListViewAdapter extends BaseAdapter {
     binding.signaturesCard.setOnClickListener(
         v -> ActivityUtils.handleExpandArrow(binding.signaturesArrow, binding.witnessesText));
 
-    if (isWitness) {
+    // Display the sign button for witnesses and the organizer
+    if (isWitness || laoViewModel.isOrganizer()) {
       Context context = parent.getContext();
       View.OnClickListener listener = setUpSignButtonClickListener(context, witnessMessage);
       binding.signMessageButton.setOnClickListener(listener);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapter.java
@@ -11,7 +11,6 @@ import androidx.fragment.app.FragmentActivity;
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.WitnessMessageLayoutBinding;
 import com.github.dedis.popstellar.model.objects.WitnessMessage;
-import com.github.dedis.popstellar.model.objects.security.Base64URLData;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
@@ -21,6 +20,8 @@ import com.github.dedis.popstellar.utility.error.ErrorUtils;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import timber.log.Timber;
 
 /** Adapter to show the messages that have to be signed by the witnesses */
 public class WitnessMessageListViewAdapter extends BaseAdapter {
@@ -141,7 +142,9 @@ public class WitnessMessageListViewAdapter extends BaseAdapter {
                   witnessingViewModel
                       .signMessage(message)
                       .subscribe(
-                          () -> {},
+                          () -> {
+                            Timber.tag(TAG).d("Witness message successfully signed");
+                          },
                           error ->
                               ErrorUtils.logAndShow(
                                   activity, TAG, error, R.string.error_sign_message))));
@@ -154,7 +157,7 @@ public class WitnessMessageListViewAdapter extends BaseAdapter {
     if (witnesses.isEmpty()) {
       return NO_SIGNATURES;
     } else {
-      return witnesses.stream().map(Base64URLData::getEncoded).collect(Collectors.joining("\n"));
+      return witnesses.stream().map(PublicKey::getEncoded).collect(Collectors.joining("\n"));
     }
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/ActivityUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/ActivityUtils.java
@@ -1,26 +1,28 @@
 package com.github.dedis.popstellar.utility;
 
+import static com.github.dedis.popstellar.utility.Constants.ORIENTATION_DOWN;
+import static com.github.dedis.popstellar.utility.Constants.ORIENTATION_UP;
+
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Color;
-
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.*;
-
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.model.objects.Channel;
 import com.github.dedis.popstellar.model.objects.Wallet;
 import com.github.dedis.popstellar.repository.local.PersistentData;
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
-
 import java.io.*;
 import java.security.GeneralSecurityException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Supplier;
-
 import timber.log.Timber;
 
 public class ActivityUtils {
@@ -176,5 +178,23 @@ public class ActivityUtils {
       return Color.WHITE;
     }
     return Color.BLACK;
+  }
+
+  /** Callback function for the card listener to expand and shrink a text box */
+  public static void handleExpandArrow(ImageView arrow, TextView text) {
+    float newRotation;
+    int visibility;
+    // If the arrow is pointing up, then rotate down and make visible the text
+    if (arrow.getRotation() == ORIENTATION_UP) {
+      newRotation = ORIENTATION_DOWN;
+      visibility = View.VISIBLE;
+    } else { // Otherwise rotate up and hide the text
+      newRotation = ORIENTATION_UP;
+      visibility = View.GONE;
+    }
+
+    // Use an animation to rotate smoothly
+    arrow.animate().rotation(newRotation).setDuration(300).start();
+    text.setVisibility(visibility);
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/ActivityUtils.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/ActivityUtils.java
@@ -6,23 +6,27 @@ import static com.github.dedis.popstellar.utility.Constants.ORIENTATION_UP;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Color;
+
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.*;
+
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.model.objects.Channel;
 import com.github.dedis.popstellar.model.objects.Wallet;
 import com.github.dedis.popstellar.repository.local.PersistentData;
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 import com.github.dedis.popstellar.utility.error.ErrorUtils;
+
 import java.io.*;
 import java.security.GeneralSecurityException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Supplier;
+
 import timber.log.Timber;
 
 public class ActivityUtils {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
@@ -24,6 +24,9 @@ public final class ElectionHandler {
   private final MessageRepository messageRepo;
   private final ElectionRepository electionRepository;
 
+  private static final String ELECTION_NAME = "Election Name : ";
+  private static final String MESSAGE_ID = "Message ID : ";
+
   @Inject
   public ElectionHandler(
       MessageRepository messageRepo, LAORepository laoRepo, ElectionRepository electionRepository) {
@@ -252,17 +255,21 @@ public final class ElectionHandler {
     WitnessMessage message = new WitnessMessage(messageId);
     message.setTitle("New Election Setup");
     message.setDescription(
-        "Name : "
+        ELECTION_NAME
+            + "\n"
             + election.getName()
-            + "\n"
+            + "\n\n"
             + "Election ID : "
+            + "\n"
             + election.getId()
-            + "\n"
+            + "\n\n"
             + "Question : "
-            + election.getElectionQuestions().get(0).getQuestion()
             + "\n"
+            + election.getElectionQuestions().get(0).getQuestion()
+            + "\n\n"
             + "Message ID : "
-            + messageId);
+            + "\n"
+            + messageId.getEncoded());
     return message;
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/ElectionHandler.java
@@ -26,6 +26,8 @@ public final class ElectionHandler {
 
   private static final String ELECTION_NAME = "Election Name : ";
   private static final String MESSAGE_ID = "Message ID : ";
+  private static final String ELECTION_ID = "Election ID : ";
+  private static final String QUESTION = "Question : ";
 
   @Inject
   public ElectionHandler(
@@ -259,15 +261,15 @@ public final class ElectionHandler {
             + "\n"
             + election.getName()
             + "\n\n"
-            + "Election ID : "
+            + ELECTION_ID
             + "\n"
             + election.getId()
             + "\n\n"
-            + "Question : "
+            + QUESTION
             + "\n"
             + election.getElectionQuestions().get(0).getQuestion()
             + "\n\n"
-            + "Message ID : "
+            + MESSAGE_ID
             + "\n"
             + messageId.getEncoded());
     return message;

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.utility.handler.data;
 
 import android.annotation.SuppressLint;
-
 import com.github.dedis.popstellar.model.network.method.message.PublicKeySignaturePair;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.*;
 import com.github.dedis.popstellar.model.objects.*;
@@ -11,11 +10,8 @@ import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.repository.*;
 import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.security.KeyManager;
-
 import java.util.*;
-
 import javax.inject.Inject;
-
 import timber.log.Timber;
 
 /** Lao messages handler class */
@@ -27,6 +23,12 @@ public final class LaoHandler {
   private final LAORepository laoRepo;
   private final KeyManager keyManager;
   private final ServerRepository serverRepo;
+
+  private static final String OLD_NAME = "Old Lao Name : ";
+  private static final String NEW_NAME = "New Lao Name : ";
+  private static final String LAO_NAME = "Lao Name : ";
+  private static final String MESSAGE_ID = "Message ID : ";
+  private static final String WITNESS_ID = "New Witness ID : ";
 
   @Inject
   public LaoHandler(
@@ -193,13 +195,16 @@ public final class LaoHandler {
     WitnessMessage message = new WitnessMessage(messageId);
     message.setTitle("Update Lao Name ");
     message.setDescription(
-        "Old Name : "
+        OLD_NAME
+            + "\n"
             + laoView.getName()
+            + "\n\n"
+            + NEW_NAME
             + "\n"
-            + "New Name : "
             + updateLao.getName()
+            + "\n\n"
+            + MESSAGE_ID
             + "\n"
-            + "Message ID : "
             + messageId);
     return message;
   }
@@ -210,14 +215,17 @@ public final class LaoHandler {
     List<PublicKey> tempList = new ArrayList<>(updateLao.getWitnesses());
     message.setTitle("Update Lao Witnesses");
     message.setDescription(
-        "Lao Name : "
+        LAO_NAME
+            + "\n"
             + laoView.getName()
+            + "\n\n"
+            + WITNESS_ID
             + "\n"
-            + "Message ID : "
-            + messageId
+            + tempList.get(tempList.size() - 1)
+            + "\n\n"
+            + MESSAGE_ID
             + "\n"
-            + "New Witness ID : "
-            + tempList.get(tempList.size() - 1));
+            + messageId);
     return message;
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
@@ -1,6 +1,7 @@
 package com.github.dedis.popstellar.utility.handler.data;
 
 import android.annotation.SuppressLint;
+
 import com.github.dedis.popstellar.model.network.method.message.PublicKeySignaturePair;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.*;
 import com.github.dedis.popstellar.model.objects.*;
@@ -10,8 +11,11 @@ import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.repository.*;
 import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.security.KeyManager;
+
 import java.util.*;
+
 import javax.inject.Inject;
+
 import timber.log.Timber;
 
 /** Lao messages handler class */

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/MeetingHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/MeetingHandler.java
@@ -9,8 +9,11 @@ import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.repository.LAORepository;
 import com.github.dedis.popstellar.repository.MeetingRepository;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
+
 import java.util.ArrayList;
+
 import javax.inject.Inject;
+
 import timber.log.Timber;
 
 public class MeetingHandler {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/MeetingHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/MeetingHandler.java
@@ -9,11 +9,8 @@ import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.repository.LAORepository;
 import com.github.dedis.popstellar.repository.MeetingRepository;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
-
 import java.util.ArrayList;
-
 import javax.inject.Inject;
-
 import timber.log.Timber;
 
 public class MeetingHandler {
@@ -22,6 +19,8 @@ public class MeetingHandler {
 
   private static final String MEETING_NAME = "Meeting Name : ";
   private static final String MESSAGE_ID = "Message ID : ";
+  private static final String MEETING_ID = "Meeting ID : ";
+  private static final String MODIFICATION_ID = "Modification ID : ";
 
   private final LAORepository laoRepo;
   private final MeetingRepository meetingRepo;
@@ -102,12 +101,15 @@ public class MeetingHandler {
     message.setTitle("New Meeting was created");
     message.setDescription(
         MEETING_NAME
+            + "\n"
             + meeting.getName()
+            + "\n\n"
+            + MEETING_ID
             + "\n"
-            + "Meeting ID : "
             + meeting.getId()
-            + "\n"
+            + "\n\n"
             + MESSAGE_ID
+            + "\n"
             + messageId);
 
     return message;
@@ -118,15 +120,19 @@ public class MeetingHandler {
     message.setTitle("A meeting was modified");
     message.setDescription(
         MEETING_NAME
+            + "\n"
             + meeting.getName()
+            + "\n\n"
+            + MEETING_ID
             + "\n"
-            + "Meeting ID : "
             + meeting.getId()
+            + "\n\n"
+            + MODIFICATION_ID
             + "\n"
-            + "Modification ID : "
             + meeting.getModificationId()
-            + "\n"
+            + "\n\n"
             + MESSAGE_ID
+            + "\n"
             + messageId);
 
     return message;

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.java
@@ -1,7 +1,6 @@
 package com.github.dedis.popstellar.utility.handler.data;
 
 import android.annotation.SuppressLint;
-
 import com.github.dedis.popstellar.model.network.method.message.data.rollcall.*;
 import com.github.dedis.popstellar.model.objects.*;
 import com.github.dedis.popstellar.model.objects.event.EventState;
@@ -12,11 +11,8 @@ import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.repository.*;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 import com.github.dedis.popstellar.utility.error.UnknownRollCallException;
-
 import java.util.Set;
-
 import javax.inject.Inject;
-
 import timber.log.Timber;
 
 /** Roll Call messages handler class */
@@ -182,48 +178,57 @@ public final class RollCallHandler {
     message.setTitle("New Roll Call was created");
     message.setDescription(
         ROLL_CALL_NAME
+            + "\n"
             + rollCall.getName()
-            + "\n"
+            + "\n\n"
             + "Roll Call ID : "
+            + "\n"
             + rollCall.getId()
-            + "\n"
+            + "\n\n"
             + "Location : "
-            + rollCall.getLocation()
             + "\n"
+            + rollCall.getLocation()
+            + "\n\n"
             + MESSAGE_ID
-            + messageId);
+            + "\n"
+            + messageId.getEncoded());
 
     return message;
   }
 
   public static WitnessMessage openRollCallWitnessMessage(MessageID messageId, RollCall rollCall) {
     WitnessMessage message = new WitnessMessage(messageId);
-    message.setTitle("A Roll Call was opened");
+    message.setTitle("Roll Call was opened");
     message.setDescription(
         ROLL_CALL_NAME
+            + "\n"
             + rollCall.getName()
+            + "\n\n"
+            + "Updated Roll Call ID :"
             + "\n"
-            + "Updated ID : "
             + rollCall.getId()
-            + "\n"
+            + "\n\n"
             + MESSAGE_ID
-            + messageId);
+            + "\n"
+            + messageId.getEncoded());
 
     return message;
   }
 
   public static WitnessMessage closeRollCallWitnessMessage(MessageID messageId, RollCall rollCall) {
     WitnessMessage message = new WitnessMessage(messageId);
-    message.setTitle("A Roll Call was closed");
+    message.setTitle("Roll Call was closed");
     message.setDescription(
         ROLL_CALL_NAME
+            + "\n"
             + rollCall.getName()
-            + "\n"
-            + "Updated ID : "
+            + "\n\n"
+            + "Updated Roll Call ID : "
             + rollCall.getId()
-            + "\n"
+            + "\n\n"
             + MESSAGE_ID
-            + messageId);
+            + "\n"
+            + messageId.getEncoded());
 
     return message;
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.java
@@ -1,6 +1,7 @@
 package com.github.dedis.popstellar.utility.handler.data;
 
 import android.annotation.SuppressLint;
+
 import com.github.dedis.popstellar.model.network.method.message.data.rollcall.*;
 import com.github.dedis.popstellar.model.objects.*;
 import com.github.dedis.popstellar.model.objects.event.EventState;
@@ -11,8 +12,11 @@ import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.repository.*;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 import com.github.dedis.popstellar.utility.error.UnknownRollCallException;
+
 import java.util.Set;
+
 import javax.inject.Inject;
+
 import timber.log.Timber;
 
 /** Roll Call messages handler class */

--- a/fe2-android/app/src/main/res/layout/home_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/home_fragment.xml
@@ -28,7 +28,7 @@
 
     <Button
       android:id="@+id/home_join_button"
-      android:layout_width="@dimen/standard_button_width"
+      android:layout_width="@dimen/small_button_width"
       android:layout_height="@dimen/standard_button_height"
       android:drawableLeft="@drawable/qr_code_button_icon"
       android:text="@string/join"
@@ -43,18 +43,18 @@
       style="@style/button_style_outlined"
       android:layout_width="wrap_content"
       android:layout_height="@dimen/standard_button_height"
+      android:layout_marginBottom="28dp"
       android:drawableLeft="@drawable/qr_code_button_icon_blue"
       android:text="@string/witness"
-      android:layout_marginBottom="@dimen/home_button_vertical_margin"
       app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintStart_toEndOf="@id/home_create_button"
       app:layout_constraintEnd_toStartOf="@id/home_join_button"
+      app:layout_constraintHorizontal_bias="0.489"
+      app:layout_constraintStart_toEndOf="@id/home_create_button"
       tools:ignore="RtlHardcoded" />
-
     <Button
       android:id="@+id/home_create_button"
       android:text="@string/create"
-      android:layout_width="@dimen/standard_button_width"
+      android:layout_width="@dimen/small_button_width"
       android:layout_height="@dimen/standard_button_height"
       android:layout_marginStart="@dimen/home_button_horizontal_margin"
       android:layout_marginBottom="@dimen/home_button_vertical_margin"

--- a/fe2-android/app/src/main/res/layout/witness_message_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/witness_message_fragment.xml
@@ -26,7 +26,7 @@
           android:layout_height="match_parent"
           android:layout_marginLeft="@dimen/margin_button"
           android:layout_marginRight="@dimen/margin_button"
-          android:divider="@color/white"
+          android:divider="@color/background_gray"
           android:dividerHeight="@dimen/margin_top" />
       </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
     </LinearLayout>

--- a/fe2-android/app/src/main/res/layout/witness_message_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/witness_message_fragment.xml
@@ -24,9 +24,9 @@
           android:id="@+id/witness_message_list"
           android:layout_width="match_parent"
           android:layout_height="match_parent"
+          android:divider="@color/background_gray"
           android:layout_marginLeft="@dimen/margin_button"
           android:layout_marginRight="@dimen/margin_button"
-          android:divider="@color/background_gray"
           android:dividerHeight="@dimen/margin_top" />
       </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
     </LinearLayout>

--- a/fe2-android/app/src/main/res/layout/witness_message_layout.xml
+++ b/fe2-android/app/src/main/res/layout/witness_message_layout.xml
@@ -20,6 +20,7 @@
         android:id="@+id/sign_message_button"
         android:layout_width="@dimen/standard_button_width"
         android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/margin_top"
         android:text="@string/Sign"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -51,6 +52,7 @@
           android:textColor="@color/black"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/margin_top"
           android:layout_marginHorizontal="@dimen/margin_text_small"
           android:textSize="@dimen/history_card_title" />
 

--- a/fe2-android/app/src/main/res/layout/witness_message_layout.xml
+++ b/fe2-android/app/src/main/res/layout/witness_message_layout.xml
@@ -90,6 +90,7 @@
           android:textColor="@color/black"
           android:layout_margin="@dimen/witnessing_expand_text_margin"
           android:visibility="gone"
+          android:paddingBottom="@dimen/message_card_margin"
           app:layout_constraintTop_toBottomOf="@id/message_description_card" />
 
         <TextView

--- a/fe2-android/app/src/main/res/layout/witness_message_layout.xml
+++ b/fe2-android/app/src/main/res/layout/witness_message_layout.xml
@@ -70,6 +70,7 @@
               app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
+              android:id="@+id/message_description_title"
               style="@style/text_high_emphasis"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"

--- a/fe2-android/app/src/main/res/layout/witness_message_layout.xml
+++ b/fe2-android/app/src/main/res/layout/witness_message_layout.xml
@@ -1,40 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
 
-  <LinearLayout
+  <com.google.android.material.card.MaterialCardView
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal">
+    app:cardElevation="@dimen/card_view_elevation"
+    android:layout_margin="@dimen/main_horizontal_margin"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    app:cardCornerRadius="@dimen/corner_radius_small">
 
-    <LinearLayout
-      android:id="@+id/witness_message_layout"
-      android:layout_width="256dp"
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:orientation="vertical">
+      android:paddingVertical="@dimen/padding_standard">
 
-      <TextView
-        android:id="@+id/message_title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/margin_text"
-        android:gravity="center"
-        android:textSize="18sp"
-        android:textStyle="bold" />
+      <Button
+        android:id="@+id/sign_message_button"
+        android:layout_width="@dimen/standard_button_width"
+        android:layout_height="match_parent"
+        android:text="@string/Sign"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/witness_message_layout" />
 
-      <TextView
-        android:id="@+id/message_description"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/margin_text"
-        android:textSize="13sp" />
+      <LinearLayout
+        android:id="@+id/witness_message_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
-    </LinearLayout>
+        <TextView
+          android:id="@+id/message_title"
+          android:text="empty"
+          android:textColor="@color/black"
+          android:textStyle="bold"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginHorizontal="@dimen/margin_text_small"
+          android:gravity="center"
+          android:textSize="@dimen/size_body" />
 
-    <Button
-      android:id="@+id/sign_message_button"
-      android:layout_width="153dp"
-      android:layout_height="match_parent" />
+        <TextView
+          android:id="@+id/message_description"
+          android:text="empty"
+          android:textColor="@color/black"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginHorizontal="@dimen/margin_text_small"
+          android:textSize="@dimen/history_card_title" />
 
-  </LinearLayout>
+      </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+  </com.google.android.material.card.MaterialCardView>
 
 </layout>

--- a/fe2-android/app/src/main/res/layout/witness_message_layout.xml
+++ b/fe2-android/app/src/main/res/layout/witness_message_layout.xml
@@ -27,14 +27,12 @@
         app:layout_constraintTop_toBottomOf="@+id/message_metadata_container" />
 
       <TextView
+        style="@style/text_medium_title"
         android:id="@+id/message_title"
-        android:textStyle="bold"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/message_card_margin"
         android:layout_marginHorizontal="@dimen/margin_text_small"
-        android:textColor="@color/black"
-        android:textSize="16dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 

--- a/fe2-android/app/src/main/res/layout/witness_message_layout.xml
+++ b/fe2-android/app/src/main/res/layout/witness_message_layout.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:tools="http://schemas.android.com/tools"
+  xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <com.google.android.material.card.MaterialCardView
@@ -13,50 +14,135 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
+      android:layout_height="wrap_content"
       android:paddingVertical="@dimen/padding_standard">
 
       <Button
         android:id="@+id/sign_message_button"
         android:layout_width="@dimen/standard_button_width"
         android:layout_height="match_parent"
-        android:layout_marginTop="@dimen/margin_top"
         android:text="@string/Sign"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/witness_message_layout" />
+        app:layout_constraintTop_toBottomOf="@+id/message_metadata_container" />
 
-      <LinearLayout
-        android:id="@+id/witness_message_layout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
+      <TextView
+        android:id="@+id/message_title"
+        android:textStyle="bold"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/message_card_margin"
+        android:layout_marginHorizontal="@dimen/margin_text_small"
+        android:textColor="@color/black"
+        android:textSize="16dp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toTopOf="parent" />
+
+      <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/message_metadata_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingVertical="@dimen/padding_standard"
+        app:layout_constraintTop_toBottomOf="@id/message_title">
+
+        <com.google.android.material.card.MaterialCardView
+          android:id="@+id/message_description_card"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:clickable="true"
+          android:layout_margin="@dimen/margin_top"
+          app:cardCornerRadius="@dimen/message_card_corner_radius"
+          app:layout_constraintTop_toTopOf="parent">
+
+          <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingVertical="@dimen/padding_standard">
+
+            <ImageView
+              android:id="@+id/message_description_arrow"
+              android:layout_width="@dimen/expand_arrow_image_side"
+              android:layout_height="@dimen/expand_arrow_image_side"
+              android:layout_marginEnd="@dimen/expand_arrow_end_margin"
+              android:contentDescription="@string/event_right_arrow"
+              android:src="@drawable/ic_arrow_expand"
+              app:layout_constraintBottom_toBottomOf="parent"
+              app:layout_constraintEnd_toEndOf="parent"
+              app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+              style="@style/text_high_emphasis"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:text="@string/message_description_title"
+              android:layout_marginStart="@dimen/message_card_margin"
+              app:layout_constraintBottom_toBottomOf="parent"
+              app:layout_constraintStart_toStartOf="parent"
+              app:layout_constraintTop_toTopOf="parent" />
+
+          </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.card.MaterialCardView>
 
         <TextView
-          android:id="@+id/message_title"
-          android:text="empty"
+          android:id="@+id/message_description_text"
+          android:layout_width="match_parent"
+          android:layout_height="match_parent"
           android:textColor="@color/black"
-          android:textStyle="bold"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginHorizontal="@dimen/margin_text_small"
-          android:gravity="center"
-          android:textSize="@dimen/size_body" />
+          android:layout_margin="@dimen/witnessing_expand_text_margin"
+          android:visibility="gone"
+          app:layout_constraintTop_toBottomOf="@id/message_description_card" />
 
         <TextView
-          android:id="@+id/message_description"
-          android:text="empty"
+          android:id="@+id/witnesses_text"
+          android:layout_width="match_parent"
+          android:layout_height="match_parent"
           android:textColor="@color/black"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:layout_marginTop="@dimen/margin_top"
-          android:layout_marginHorizontal="@dimen/margin_text_small"
-          android:textSize="@dimen/history_card_title" />
+          android:layout_margin="@dimen/witnessing_expand_text_margin"
+          android:visibility="gone"
+          app:layout_constraintTop_toBottomOf="@id/signatures_card" />
 
-      </LinearLayout>
+        <com.google.android.material.card.MaterialCardView
+          android:id="@+id/signatures_card"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_margin="@dimen/margin_top"
+          android:clickable="true"
+          app:cardCornerRadius="@dimen/roll_call_card_corner_radius"
+          app:layout_constraintTop_toBottomOf="@id/message_description_text"
+          tools:layout_editor_absoluteX="5dp">
+
+          <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingVertical="@dimen/padding_standard"
+            tools:layout_editor_absoluteX="0dp">
+
+            <ImageView
+              android:id="@+id/signatures_arrow"
+              android:layout_width="@dimen/expand_arrow_image_side"
+              android:layout_height="@dimen/expand_arrow_image_side"
+              android:layout_marginEnd="@dimen/expand_arrow_end_margin"
+              android:contentDescription="@string/event_right_arrow"
+              android:src="@drawable/ic_arrow_expand"
+              app:layout_constraintBottom_toBottomOf="parent"
+              app:layout_constraintEnd_toEndOf="parent"
+              app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+              style="@style/text_high_emphasis"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_marginStart="@dimen/message_card_margin"
+              android:text="@string/signatures_title"
+              app:layout_constraintBottom_toBottomOf="parent"
+              app:layout_constraintStart_toStartOf="parent"
+              app:layout_constraintTop_toTopOf="parent" />
+
+          </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+      </androidx.constraintlayout.widget.ConstraintLayout>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
   </com.google.android.material.card.MaterialCardView>
 

--- a/fe2-android/app/src/main/res/layout/witness_message_layout.xml
+++ b/fe2-android/app/src/main/res/layout/witness_message_layout.xml
@@ -4,6 +4,7 @@
   xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <com.google.android.material.card.MaterialCardView
+    android:id="@+id/witness_message_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     app:cardElevation="@dimen/card_view_elevation"

--- a/fe2-android/app/src/main/res/layout/witnesses_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/witnesses_fragment.xml
@@ -3,7 +3,6 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  android:background="@color/background_gray"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   tools:context=".ui.lao.witness.WitnessesFragment">
 

--- a/fe2-android/app/src/main/res/layout/witnesses_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/witnesses_fragment.xml
@@ -3,6 +3,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
+  android:background="@color/background_gray"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   tools:context=".ui.lao.witness.WitnessesFragment">
 

--- a/fe2-android/app/src/main/res/layout/witnesses_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/witnesses_fragment.xml
@@ -3,6 +3,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
+  android:id="@+id/fragment_witnesses"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   tools:context=".ui.lao.witness.WitnessesFragment">
 

--- a/fe2-android/app/src/main/res/layout/witnessing_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/witnessing_fragment.xml
@@ -4,35 +4,30 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
+  android:background="@color/background_gray"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   tools:context=".ui.lao.witness.WitnessingFragment">
 
-  <TextView
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:id="@+id/witness_title"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintTop_toTopOf="parent"
-    style="@style/title_style"
-    android:text="@string/witnessing" />
-
   <com.google.android.material.tabs.TabLayout
     android:id="@+id/witnessing_tab_layout"
+    android:layout_margin="@dimen/container_margin"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="@dimen/tab_layout_top_margin"
     android:layout_marginHorizontal="@dimen/container_margin"
-    app:layout_constraintTop_toBottomOf="@id/witness_title" />
+    android:background="@color/background_gray"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:layout_editor_absoluteX="8dp" />
 
   <androidx.viewpager2.widget.ViewPager2
     android:id="@+id/witnessing_view_pager"
     android:layout_width="match_parent"
     android:layout_height="0dp"
     android:layout_weight="1"
-    android:layout_margin="@dimen/container_margin"
+    android:layout_margin="@dimen/main_horizontal_margin"
+    app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintTop_toBottomOf="@id/witnessing_tab_layout"
-    app:layout_constraintBottom_toBottomOf="parent">
+    app:layout_constraintVertical_bias="0.0"
+    tools:layout_editor_absoluteX="8dp">
 
   </androidx.viewpager2.widget.ViewPager2>
 

--- a/fe2-android/app/src/main/res/values/dimens.xml
+++ b/fe2-android/app/src/main/res/values/dimens.xml
@@ -111,6 +111,9 @@
 
   <!--  Witnessing dimensions -->
   <dimen name="tab_layout_top_margin">20dp</dimen>
+  <dimen name="message_card_margin">10dp</dimen>
+  <dimen name="message_card_corner_radius">10dp</dimen>
+  <dimen name="witnessing_expand_text_margin">14dp</dimen>
 
   <!--  Event List Fragment dimensions -->
   <dimen name="add_event_texts_size">18sp</dimen>

--- a/fe2-android/app/src/main/res/values/dimens.xml
+++ b/fe2-android/app/src/main/res/values/dimens.xml
@@ -37,6 +37,7 @@
   <!-- Button -->
   <dimen name="standard_button_height">55dp</dimen>
   <dimen name="standard_button_width">105dp</dimen>
+  <dimen name="small_button_width">90dp</dimen>
   <dimen name="standard_button_text_size">16dp</dimen>
   <dimen name="big_button_text_size">22sp</dimen>
 

--- a/fe2-android/app/src/main/res/values/dimens.xml
+++ b/fe2-android/app/src/main/res/values/dimens.xml
@@ -114,7 +114,6 @@
   <dimen name="message_card_margin">10dp</dimen>
   <dimen name="message_card_corner_radius">10dp</dimen>
   <dimen name="witnessing_expand_text_margin">14dp</dimen>
-  <dimen name="message_title_text_size">16dp</dimen>
 
   <!--  Event List Fragment dimensions -->
   <dimen name="add_event_texts_size">18sp</dimen>

--- a/fe2-android/app/src/main/res/values/dimens.xml
+++ b/fe2-android/app/src/main/res/values/dimens.xml
@@ -111,10 +111,10 @@
   <dimen name="lone_bottom_button_top_margin">30dp</dimen>
 
   <!--  Witnessing dimensions -->
-  <dimen name="tab_layout_top_margin">20dp</dimen>
   <dimen name="message_card_margin">10dp</dimen>
   <dimen name="message_card_corner_radius">10dp</dimen>
   <dimen name="witnessing_expand_text_margin">14dp</dimen>
+  <dimen name="message_title_text_size">16dp</dimen>
 
   <!--  Event List Fragment dimensions -->
   <dimen name="add_event_texts_size">18sp</dimen>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -124,7 +124,6 @@
   <string name="messages">Messages</string>
   <string name="witnesses">Witnesses</string>
   <string name="witness_added">Witness %1$s successfully added to LAO</string>
-  <string name="Sign">Sign</string>
 
   <!-- Witness -->
   <string name="button_text">Cast Vote</string>
@@ -135,6 +134,9 @@
   <string name="not_a_witness">You\'re not a witness</string>
   <string name="not_a_witness_explanation">You need to be a witness in order to sign this message</string>
   <string name="confirm_to_sign">Are you sure you want to sign message with ID : %1$s</string>
+  <string name="message_description_title">Description</string>
+  <string name="signatures_title">Signatures</string>
+  <string name="Sign">Sign</string>
 
   <!--  Roll Call -->
   <string name="roll_call_setup_title">Roll Call Setup</string>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -131,8 +131,6 @@
   <string name="manual_witness_hint">Witness public key</string>
   <string name="add_witness_title">Add Witness</string>
   <string name="sign_message">Sign message</string>
-  <string name="not_a_witness">You\'re not a witness</string>
-  <string name="not_a_witness_explanation">You need to be a witness in order to sign this message</string>
   <string name="confirm_to_sign">Are you sure you want to sign message with ID : %1$s</string>
   <string name="message_description_title">Description</string>
   <string name="signatures_title">Signatures</string>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -124,6 +124,7 @@
   <string name="messages">Messages</string>
   <string name="witnesses">Witnesses</string>
   <string name="witness_added">Witness %1$s successfully added to LAO</string>
+  <string name="Sign">Sign</string>
 
   <!-- Witness -->
   <string name="button_text">Cast Vote</string>

--- a/fe2-android/app/src/main/res/values/styles.xml
+++ b/fe2-android/app/src/main/res/values/styles.xml
@@ -123,6 +123,12 @@
     <item name="android:textStyle">normal</item>
   </style>
 
+  <style name="text_medium_title">
+    <item name="android:textColor">@color/textOnBackground</item>
+    <item name="android:textStyle">bold</item>
+    <item name="android:textSize">@dimen/card_element_text_size</item>
+  </style>
+
   <!-- Toolbar styles -->
   <style name="toolbar_style" parent="Widget.MaterialComponents.Toolbar">
     <item name="android:textColorPrimary">@color/white</item>

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/MatcherUtils.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/MatcherUtils.java
@@ -2,10 +2,16 @@ package com.github.dedis.popstellar.testutils;
 
 import android.view.*;
 
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
 import androidx.test.espresso.matcher.BoundedMatcher;
 import androidx.viewpager2.widget.ViewPager2;
 
+import com.google.android.material.tabs.TabLayout;
+
 import org.hamcrest.*;
+
+import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
 
 public class MatcherUtils {
 
@@ -43,6 +49,29 @@ public class MatcherUtils {
       @Override
       protected boolean matchesSafely(ViewPager2 viewPager) {
         return viewPager.getCurrentItem() == position;
+      }
+    };
+  }
+
+  public static ViewAction selectTabAtPosition(final int tabIndex) {
+    return new ViewAction() {
+      @Override
+      public Matcher<View> getConstraints() {
+        return isAssignableFrom(TabLayout.class);
+      }
+
+      @Override
+      public String getDescription() {
+        return "select tab at index " + tabIndex;
+      }
+
+      @Override
+      public void perform(UiController uiController, View view) {
+        TabLayout tabLayout = (TabLayout) view;
+        TabLayout.Tab tab = tabLayout.getTabAt(tabIndex);
+        if (tab != null) {
+          tab.select();
+        }
       }
     };
   }

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/witness/WitnessMessageFragmentPageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/witness/WitnessMessageFragmentPageObject.java
@@ -3,8 +3,10 @@ package com.github.dedis.popstellar.testutils.pages.lao.witness;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
+import android.view.View;
 import androidx.test.espresso.ViewInteraction;
 import com.github.dedis.popstellar.R;
+import org.hamcrest.Matcher;
 
 public class WitnessMessageFragmentPageObject {
 
@@ -12,8 +14,28 @@ public class WitnessMessageFragmentPageObject {
     throw new IllegalStateException("Page object");
   }
 
+  public static Matcher<View> witnessMessageListMatcher() {
+    return withId(R.id.witness_message_list);
+  }
+
   public static ViewInteraction witnessMessageList() {
-    return onView(withId(R.id.witness_message_list));
+    return onView(witnessMessageListMatcher());
+  }
+
+  public static Matcher<View> messageDescriptionArrowMatcher() {
+    return withId(R.id.message_description_arrow);
+  }
+
+  public static Matcher<View> messageSignaturesArrowMatcher() {
+    return withId(R.id.signatures_arrow);
+  }
+  
+  public static ViewInteraction messageDescriptionText() {
+    return onView(withId(R.id.message_description_text));
+  }
+
+  public static ViewInteraction witnessSignaturesText() {
+    return onView(withId(R.id.witnesses_text));
   }
 
   public static ViewInteraction witnessMessageFragment() {

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/witness/WitnessMessageFragmentPageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/witness/WitnessMessageFragmentPageObject.java
@@ -15,5 +15,8 @@ public class WitnessMessageFragmentPageObject {
   public static ViewInteraction witnessMessageList() {
     return onView(withId(R.id.witness_message_list));
   }
-  
+
+  public static ViewInteraction witnessMessageFragment() {
+    return onView(withId(R.id.fragment_witness_message));
+  }
 }

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/witness/WitnessMessageFragmentPageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/witness/WitnessMessageFragmentPageObject.java
@@ -1,0 +1,19 @@
+package com.github.dedis.popstellar.testutils.pages.lao.witness;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+import androidx.test.espresso.ViewInteraction;
+import com.github.dedis.popstellar.R;
+
+public class WitnessMessageFragmentPageObject {
+
+  private WitnessMessageFragmentPageObject() {
+    throw new IllegalStateException("Page object");
+  }
+
+  public static ViewInteraction witnessMessageList() {
+    return onView(withId(R.id.witness_message_list));
+  }
+  
+}

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/witness/WitnessingFragmentPageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/witness/WitnessingFragmentPageObject.java
@@ -25,4 +25,16 @@ public class WitnessingFragmentPageObject {
   public static ViewInteraction getEventListFragment() {
     return onView(withId(R.id.fragment_event_list));
   }
+
+  public static ViewInteraction witnessMessageFragment() {
+    return onView(withId(R.id.fragment_witness_message));
+  }
+
+  public static ViewInteraction witnessesFragment() {
+    return onView(withId(R.id.fragment_witnesses));
+  }
+
+  public static ViewInteraction witnessingTabs() {
+    return onView(withId(R.id.witnessing_tab_layout));
+  }
 }

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragmentTest.java
@@ -3,46 +3,42 @@ package com.github.dedis.popstellar.ui.lao.witness;
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generateKeyPair;
 import static com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject.containerId;
 import static com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject.laoIdExtra;
-import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessMessageFragmentPageObject.witnessMessageFragment;
+import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessMessageFragmentPageObject.messageDescriptionArrowMatcher;
+import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessMessageFragmentPageObject.messageDescriptionText;
+import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessMessageFragmentPageObject.messageSignaturesArrowMatcher;
 import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessMessageFragmentPageObject.witnessMessageList;
+import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessMessageFragmentPageObject.witnessMessageListMatcher;
+import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessMessageFragmentPageObject.witnessSignaturesText;
 import static org.hamcrest.CoreMatchers.anything;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import android.app.Activity;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
-import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.test.espresso.matcher.ViewMatchers.Visibility;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import com.github.dedis.popstellar.R;
-import com.github.dedis.popstellar.model.network.method.message.data.lao.CreateLao;
 import com.github.dedis.popstellar.model.objects.Lao;
-import com.github.dedis.popstellar.model.objects.RollCall;
 import com.github.dedis.popstellar.model.objects.WitnessMessage;
-import com.github.dedis.popstellar.model.objects.event.EventState;
-import com.github.dedis.popstellar.model.objects.event.RollCallBuilder;
 import com.github.dedis.popstellar.model.objects.security.KeyPair;
 import com.github.dedis.popstellar.model.objects.security.MessageID;
 import com.github.dedis.popstellar.model.objects.security.PoPToken;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.repository.LAORepository;
-import com.github.dedis.popstellar.repository.RollCallRepository;
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 import com.github.dedis.popstellar.testutils.Base64DataUtils;
 import com.github.dedis.popstellar.testutils.BundleBuilder;
 import com.github.dedis.popstellar.testutils.MessageSenderHelper;
 import com.github.dedis.popstellar.testutils.fragment.ActivityFragmentScenarioRule;
-import com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
-import com.github.dedis.popstellar.ui.lao.event.rollcall.RollCallFragment;
-import com.github.dedis.popstellar.utility.Constants;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 import com.github.dedis.popstellar.utility.error.keys.KeyException;
 import com.github.dedis.popstellar.utility.security.KeyManager;
@@ -50,16 +46,10 @@ import dagger.hilt.android.testing.BindValue;
 import dagger.hilt.android.testing.HiltAndroidRule;
 import dagger.hilt.android.testing.HiltAndroidTest;
 import io.reactivex.subjects.BehaviorSubject;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.inject.Inject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
@@ -77,13 +67,26 @@ public class WitnessMessageFragmentTest {
   private static final PublicKey SENDER = SENDER_KEY.getPublicKey();
   private static final Lao LAO = new Lao(LAO_NAME, SENDER, Instant.now().getEpochSecond());
   private static final String LAO_ID = LAO.getId();
+
+  private static final MessageID MESSAGE_ID1 = Base64DataUtils.generateMessageID();
+  private static final WitnessMessage WITNESS_MESSAGE = new WitnessMessage(MESSAGE_ID1);
+  private static final String TITLE = "Message title";
+  private static final String DESCRIPTION = "roll call name: test roll call";
+  private static final String DESCRIPTION_TITLE = "Description";
+  private static final String SIGNATURES_TITLE = "Signatures";
+
+  private static final PublicKey WITNESS1 = Base64DataUtils.generatePublicKey();
+  private static final PublicKey WITNESS2 = Base64DataUtils.generatePublicKeyOtherThan(WITNESS1);
+
+  private static final String SIGNATURES_TEXT =
+      WITNESS2.getEncoded() + "\n" + WITNESS1.getEncoded();
+
   private static final BehaviorSubject<LaoView> laoSubject =
       BehaviorSubject.createDefault(new LaoView(LAO));
 
   private static final PoPToken POP_TOKEN = Base64DataUtils.generatePoPToken();
-  private static WitnessingViewModel witnessingViewModel;
-
-  @Inject RollCallRepository rollCallRepo;
+  private WitnessingViewModel witnessingViewModel;
+  private List<WitnessMessage> witnessMessages;
 
   @BindValue @Mock LAORepository laoRepo;
   @BindValue @Mock GlobalNetworkManager networkManager;
@@ -114,6 +117,12 @@ public class WitnessMessageFragmentTest {
           messageSenderHelper.setupMock();
 
           when(keyManager.getPoPToken(any(), any())).thenReturn(POP_TOKEN);
+
+          WITNESS_MESSAGE.setTitle(TITLE);
+          WITNESS_MESSAGE.setDescription(DESCRIPTION);
+          WITNESS_MESSAGE.addWitness(WITNESS1);
+          WITNESS_MESSAGE.addWitness(WITNESS2);
+          witnessMessages = Collections.singletonList(WITNESS_MESSAGE);
         }
       };
 
@@ -127,25 +136,73 @@ public class WitnessMessageFragmentTest {
           WitnessMessageFragment::new);
 
   @Test
-  public void testWitnessMessageListIsDisplayed() {
-    witnessMessageFragment().check(matches(isDisplayed()));
-    witnessMessageList().check(matches(isDisplayed()));
-  }
-
-  @Test
-  public void testWitnessMd() {
+  public void testWitnessMessageListDisplaysMessageTitle() {
     witnessingViewModel = new ViewModelProvider(getLaoActivity()).get(WitnessingViewModel.class);
-
-    WitnessMessage witnessMessage = new WitnessMessage(Base64DataUtils.generateMessageID());
-    List<WitnessMessage> witnessMessages = Collections.singletonList(witnessMessage);
-
     witnessingViewModel.setWitnessMessages(witnessMessages);
 
     witnessMessageList().check(matches(isDisplayed()));
     onData(anything())
-        .inAdapterView(withId(R.id.witness_message_list))
+        .inAdapterView(witnessMessageListMatcher())
         .atPosition(0)
+        .check(matches(hasDescendant(withText(TITLE))));
+  }
+
+  @Test
+  public void testWitnessMessageDescriptionDropdown() {
+    witnessingViewModel = new ViewModelProvider(getLaoActivity()).get(WitnessingViewModel.class);
+    witnessingViewModel.setWitnessMessages(witnessMessages);
+
+    // Check that the description title is displayed
+    onData(anything())
+        .inAdapterView(witnessMessageListMatcher())
+        .atPosition(0)
+        .check(matches(hasDescendant(withText(DESCRIPTION_TITLE))));
+
+    // Check that the message description is not displayed by default
+    messageDescriptionText().check(matches(withEffectiveVisibility(Visibility.GONE)));
+
+    // Click on the arrow to expand the text
+    onData(anything())
+        .inAdapterView(witnessMessageListMatcher())
+        .atPosition(0)
+        .onChildView(messageDescriptionArrowMatcher())
         .perform(click());
+
+    // Check that correct message description is displayed
+    messageDescriptionText().check(matches(withEffectiveVisibility(Visibility.VISIBLE)));
+    onData(anything())
+        .inAdapterView(witnessMessageListMatcher())
+        .atPosition(0)
+        .check(matches(hasDescendant(withText(DESCRIPTION))));
+  }
+
+  @Test
+  public void testWitnessMessageSignaturesDropdown() {
+    witnessingViewModel = new ViewModelProvider(getLaoActivity()).get(WitnessingViewModel.class);
+    witnessingViewModel.setWitnessMessages(witnessMessages);
+
+    // Check that the signatures title is displayed
+    onData(anything())
+        .inAdapterView(witnessMessageListMatcher())
+        .atPosition(0)
+        .check(matches(hasDescendant(withText(SIGNATURES_TITLE))));
+
+    // Check that the signatures are not displayed by default
+    witnessSignaturesText().check(matches(withEffectiveVisibility(Visibility.GONE)));
+
+    // Click on the arrow to expand the text
+    onData(anything())
+        .inAdapterView(witnessMessageListMatcher())
+        .atPosition(0)
+        .onChildView(messageSignaturesArrowMatcher())
+        .perform(click());
+
+    // Check that correct signatures are displayed
+    witnessSignaturesText().check(matches(withEffectiveVisibility(Visibility.VISIBLE)));
+    onData(anything())
+        .inAdapterView(witnessMessageListMatcher())
+        .atPosition(0)
+        .check(matches(hasDescendant(withText(SIGNATURES_TEXT))));
   }
 
   private LaoActivity getLaoActivity() {

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragmentTest.java
@@ -3,12 +3,10 @@ package com.github.dedis.popstellar.ui.lao.witness;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generateKeyPair;
+import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessMessageFragmentPageObject.witnessMessageFragment;
 import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessMessageFragmentPageObject.witnessMessageList;
-import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessingFragmentPageObject.getEventListFragment;
-import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessingFragmentPageObject.getRootView;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
-import androidx.test.espresso.action.ViewActions;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.CreateLao;
 import com.github.dedis.popstellar.model.objects.security.KeyPair;
@@ -65,6 +63,7 @@ public class WitnessMessageFragmentTest {
 
   @Test
   public void testWitnessMessageListIsDisplayed() {
+    witnessMessageFragment().check(matches(isDisplayed()));
     witnessMessageList().check(matches(isDisplayed()));
   }
 }

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragmentTest.java
@@ -1,28 +1,70 @@
 package com.github.dedis.popstellar.ui.lao.witness;
 
+import static androidx.test.espresso.Espresso.onData;
+import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generateKeyPair;
+import static com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject.containerId;
+import static com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject.laoIdExtra;
 import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessMessageFragmentPageObject.witnessMessageFragment;
 import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessMessageFragmentPageObject.witnessMessageList;
+import static org.hamcrest.CoreMatchers.anything;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
+import android.app.Activity;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.CreateLao;
+import com.github.dedis.popstellar.model.objects.Lao;
+import com.github.dedis.popstellar.model.objects.RollCall;
+import com.github.dedis.popstellar.model.objects.WitnessMessage;
+import com.github.dedis.popstellar.model.objects.event.EventState;
+import com.github.dedis.popstellar.model.objects.event.RollCallBuilder;
 import com.github.dedis.popstellar.model.objects.security.KeyPair;
+import com.github.dedis.popstellar.model.objects.security.MessageID;
+import com.github.dedis.popstellar.model.objects.security.PoPToken;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
+import com.github.dedis.popstellar.model.objects.view.LaoView;
+import com.github.dedis.popstellar.repository.LAORepository;
+import com.github.dedis.popstellar.repository.RollCallRepository;
+import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
+import com.github.dedis.popstellar.testutils.Base64DataUtils;
 import com.github.dedis.popstellar.testutils.BundleBuilder;
+import com.github.dedis.popstellar.testutils.MessageSenderHelper;
 import com.github.dedis.popstellar.testutils.fragment.ActivityFragmentScenarioRule;
 import com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
+import com.github.dedis.popstellar.ui.lao.event.rollcall.RollCallFragment;
 import com.github.dedis.popstellar.utility.Constants;
+import com.github.dedis.popstellar.utility.error.UnknownLaoException;
+import com.github.dedis.popstellar.utility.error.keys.KeyException;
+import com.github.dedis.popstellar.utility.security.KeyManager;
+import dagger.hilt.android.testing.BindValue;
 import dagger.hilt.android.testing.HiltAndroidRule;
 import dagger.hilt.android.testing.HiltAndroidTest;
+import io.reactivex.subjects.BehaviorSubject;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.inject.Inject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoTestRule;
 
@@ -30,10 +72,24 @@ import org.mockito.junit.MockitoTestRule;
 @RunWith(AndroidJUnit4.class)
 public class WitnessMessageFragmentTest {
 
+  private static final String LAO_NAME = "lao";
   private static final KeyPair SENDER_KEY = generateKeyPair();
   private static final PublicKey SENDER = SENDER_KEY.getPublicKey();
+  private static final Lao LAO = new Lao(LAO_NAME, SENDER, Instant.now().getEpochSecond());
+  private static final String LAO_ID = LAO.getId();
+  private static final BehaviorSubject<LaoView> laoSubject =
+      BehaviorSubject.createDefault(new LaoView(LAO));
 
-  private static final CreateLao CREATE_LAO = new CreateLao("lao", SENDER, new ArrayList<>());
+  private static final PoPToken POP_TOKEN = Base64DataUtils.generatePoPToken();
+  private static WitnessingViewModel witnessingViewModel;
+
+  @Inject RollCallRepository rollCallRepo;
+
+  @BindValue @Mock LAORepository laoRepo;
+  @BindValue @Mock GlobalNetworkManager networkManager;
+  @BindValue @Mock KeyManager keyManager;
+
+  MessageSenderHelper messageSenderHelper = new MessageSenderHelper();
 
   @Rule public InstantTaskExecutorRule rule = new InstantTaskExecutorRule();
 
@@ -47,8 +103,17 @@ public class WitnessMessageFragmentTest {
   public final ExternalResource setupRule =
       new ExternalResource() {
         @Override
-        protected void before() {
+        protected void before() throws UnknownLaoException, KeyException {
           hiltRule.inject();
+          when(laoRepo.getLaoObservable(anyString())).thenReturn(laoSubject);
+          when(laoRepo.getLaoView(any())).thenAnswer(invocation -> new LaoView(LAO));
+
+          when(keyManager.getMainPublicKey()).thenReturn(SENDER);
+
+          when(networkManager.getMessageSender()).thenReturn(messageSenderHelper.getMockedSender());
+          messageSenderHelper.setupMock();
+
+          when(keyManager.getPoPToken(any(), any())).thenReturn(POP_TOKEN);
         }
       };
 
@@ -56,8 +121,8 @@ public class WitnessMessageFragmentTest {
   public ActivityFragmentScenarioRule<LaoActivity, WitnessMessageFragment> activityScenarioRule =
       ActivityFragmentScenarioRule.launchIn(
           LaoActivity.class,
-          new BundleBuilder().putString(Constants.LAO_ID_EXTRA, CREATE_LAO.getId()).build(),
-          LaoActivityPageObject.containerId(),
+          new BundleBuilder().putString(laoIdExtra(), LAO_ID).build(),
+          containerId(),
           WitnessMessageFragment.class,
           WitnessMessageFragment::new);
 
@@ -65,5 +130,28 @@ public class WitnessMessageFragmentTest {
   public void testWitnessMessageListIsDisplayed() {
     witnessMessageFragment().check(matches(isDisplayed()));
     witnessMessageList().check(matches(isDisplayed()));
+  }
+
+  @Test
+  public void testWitnessMd() {
+    witnessingViewModel = new ViewModelProvider(getLaoActivity()).get(WitnessingViewModel.class);
+
+    WitnessMessage witnessMessage = new WitnessMessage(Base64DataUtils.generateMessageID());
+    List<WitnessMessage> witnessMessages = Collections.singletonList(witnessMessage);
+
+    witnessingViewModel.setWitnessMessages(witnessMessages);
+
+    witnessMessageList().check(matches(isDisplayed()));
+    onData(anything())
+        .inAdapterView(withId(R.id.witness_message_list))
+        .atPosition(0)
+        .perform(click());
+  }
+
+  private LaoActivity getLaoActivity() {
+    AtomicReference<LaoActivity> ref = new AtomicReference<>();
+    activityScenarioRule.getScenario().onActivity(activity -> ref.set(activity));
+
+    return ref.get();
   }
 }

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragmentTest.java
@@ -67,11 +67,4 @@ public class WitnessMessageFragmentTest {
   public void testWitnessMessageListIsDisplayed() {
     witnessMessageList().check(matches(isDisplayed()));
   }
-
-  @Test
-  public void testBackButtonBehaviour() {
-    getRootView().perform(ViewActions.pressBack());
-    // Check current fragment displayed is event list
-    getEventListFragment().check(matches(isDisplayed()));
-  }
 }

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageFragmentTest.java
@@ -1,0 +1,77 @@
+package com.github.dedis.popstellar.ui.lao.witness;
+
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static com.github.dedis.popstellar.testutils.Base64DataUtils.generateKeyPair;
+import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessMessageFragmentPageObject.witnessMessageList;
+import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessingFragmentPageObject.getEventListFragment;
+import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessingFragmentPageObject.getRootView;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.test.espresso.action.ViewActions;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.github.dedis.popstellar.model.network.method.message.data.lao.CreateLao;
+import com.github.dedis.popstellar.model.objects.security.KeyPair;
+import com.github.dedis.popstellar.model.objects.security.PublicKey;
+import com.github.dedis.popstellar.testutils.BundleBuilder;
+import com.github.dedis.popstellar.testutils.fragment.ActivityFragmentScenarioRule;
+import com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject;
+import com.github.dedis.popstellar.ui.lao.LaoActivity;
+import com.github.dedis.popstellar.utility.Constants;
+import dagger.hilt.android.testing.HiltAndroidRule;
+import dagger.hilt.android.testing.HiltAndroidTest;
+import java.util.ArrayList;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoTestRule;
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4.class)
+public class WitnessMessageFragmentTest {
+
+  private static final KeyPair SENDER_KEY = generateKeyPair();
+  private static final PublicKey SENDER = SENDER_KEY.getPublicKey();
+
+  private static final CreateLao CREATE_LAO = new CreateLao("lao", SENDER, new ArrayList<>());
+
+  @Rule public InstantTaskExecutorRule rule = new InstantTaskExecutorRule();
+
+  @Rule(order = 0)
+  public final MockitoTestRule mockitoRule = MockitoJUnit.testRule(this);
+
+  @Rule(order = 1)
+  public final HiltAndroidRule hiltRule = new HiltAndroidRule(this);
+
+  @Rule(order = 2)
+  public final ExternalResource setupRule =
+      new ExternalResource() {
+        @Override
+        protected void before() {
+          hiltRule.inject();
+        }
+      };
+
+  @Rule(order = 3)
+  public ActivityFragmentScenarioRule<LaoActivity, WitnessMessageFragment> activityScenarioRule =
+      ActivityFragmentScenarioRule.launchIn(
+          LaoActivity.class,
+          new BundleBuilder().putString(Constants.LAO_ID_EXTRA, CREATE_LAO.getId()).build(),
+          LaoActivityPageObject.containerId(),
+          WitnessMessageFragment.class,
+          WitnessMessageFragment::new);
+
+  @Test
+  public void testWitnessMessageListIsDisplayed() {
+    witnessMessageList().check(matches(isDisplayed()));
+  }
+
+  @Test
+  public void testBackButtonBehaviour() {
+    getRootView().perform(ViewActions.pressBack());
+    // Check current fragment displayed is event list
+    getEventListFragment().check(matches(isDisplayed()));
+  }
+}

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapterTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessMessageListViewAdapterTest.java
@@ -1,0 +1,118 @@
+package com.github.dedis.popstellar.ui.lao.witness;
+
+import static com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject.laoIdExtra;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import androidx.fragment.app.FragmentActivity;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.github.dedis.popstellar.SingleEvent;
+import com.github.dedis.popstellar.model.objects.*;
+import com.github.dedis.popstellar.model.objects.security.MessageID;
+import com.github.dedis.popstellar.testutils.*;
+import com.github.dedis.popstellar.ui.lao.LaoActivity;
+import dagger.hilt.android.testing.*;
+import java.security.GeneralSecurityException;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoTestRule;
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4.class)
+public class WitnessMessageListViewAdapterTest {
+
+  private static final Lao LAO =
+      new Lao("LAO", Base64DataUtils.generatePublicKey(), Instant.now().getEpochSecond());
+  private static final String LAO_ID = LAO.getId();
+  private static final MessageID MESSAGE_ID1 = Base64DataUtils.generateMessageID();
+  private static final MessageID MESSAGE_ID2 = Base64DataUtils.generateMessageID();
+  private static final WitnessMessage WITNESS_MESSAGE1 = new WitnessMessage(MESSAGE_ID1);
+  private static final WitnessMessage WITNESS_MESSAGE2 = new WitnessMessage(MESSAGE_ID2);
+
+  private static final List<WitnessMessage> WITNESS_MESSAGES1 =
+      Collections.singletonList(WITNESS_MESSAGE1);
+  private static final List<WitnessMessage> WITNESS_MESSAGES2 =
+      Collections.singletonList(WITNESS_MESSAGE2);
+
+  WitnessMessageListViewAdapter adapter;
+
+  @BindValue @Mock Wallet wallet;
+
+  @Rule(order = 0)
+  public final MockitoTestRule mockitoRule = MockitoJUnit.testRule(this);
+
+  @Rule(order = 1)
+  public final HiltAndroidRule hiltRule = new HiltAndroidRule(this);
+
+  @Rule(order = 2)
+  public final ExternalResource setupRule =
+      new ExternalResource() {
+        @Override
+        protected void before() throws GeneralSecurityException {
+          hiltRule.inject();
+
+          when(wallet.exportSeed())
+              .thenReturn(
+                  new String[] {
+                    "jar",
+                    "together",
+                    "minor",
+                    "alley",
+                    "glow",
+                    "hybrid",
+                    "village",
+                    "creek",
+                    "meadow",
+                    "atom",
+                    "travel",
+                    "bracket"
+                  });
+        }
+      };
+
+  @Rule(order = 3)
+  public ActivityScenarioRule<LaoActivity> activityScenarioRule =
+      new ActivityScenarioRule<>(
+          IntentUtils.createIntent(
+              LaoActivity.class, new BundleBuilder().putString(laoIdExtra(), LAO_ID).build()));
+
+  @Test
+  public void emptyAdapterTest() {
+    adapter = new WitnessMessageListViewAdapter(null, getFragmentActivity());
+
+    assertEquals(0, adapter.getCount());
+  }
+
+  @Test
+  public void oneElementAdapterTest() {
+    adapter = new WitnessMessageListViewAdapter(WITNESS_MESSAGES1, getFragmentActivity());
+
+    assertEquals(1, adapter.getCount());
+    assertEquals(WITNESS_MESSAGE1, adapter.getItem(0));
+    assertEquals(0, adapter.getItemId(0));
+  }
+
+  @Test
+  public void replaceListTest() {
+    adapter = new WitnessMessageListViewAdapter(WITNESS_MESSAGES1, getFragmentActivity());
+    adapter.replaceList(WITNESS_MESSAGES2);
+
+    assertEquals(1, adapter.getCount());
+    assertEquals(WITNESS_MESSAGE2, adapter.getItem(0));
+  }
+
+  private FragmentActivity getFragmentActivity() {
+    AtomicReference<FragmentActivity> ref = new AtomicReference<>();
+    activityScenarioRule.getScenario().onActivity(activity -> ref.set(activity));
+
+    return ref.get();
+  }
+}

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessingFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessingFragmentTest.java
@@ -1,9 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.witness;
 
-import android.view.View;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
-import androidx.test.espresso.UiController;
-import androidx.test.espresso.ViewAction;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -16,9 +13,6 @@ import com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.utility.Constants;
 
-import com.google.android.material.tabs.TabLayout;
-import java.time.Instant;
-import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
@@ -26,19 +20,17 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoTestRule;
 
+import java.time.Instant;
+
 import dagger.hilt.android.testing.HiltAndroidRule;
 import dagger.hilt.android.testing.HiltAndroidTest;
 
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generatePoPToken;
-import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessingFragmentPageObject.getEventListFragment;
-import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessingFragmentPageObject.getRootView;
-import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessingFragmentPageObject.witnessMessageFragment;
-import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessingFragmentPageObject.witnessesFragment;
-import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessingFragmentPageObject.witnessingTabs;
+import static com.github.dedis.popstellar.testutils.MatcherUtils.selectTabAtPosition;
+import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessingFragmentPageObject.*;
 
 @HiltAndroidTest
 @RunWith(AndroidJUnit4.class)
@@ -107,28 +99,4 @@ public class WitnessingFragmentTest {
     witnessMessageFragment().check(doesNotExist());
     witnessesFragment().check(matches(isDisplayed()));
   }
-
-  private static ViewAction selectTabAtPosition(final int tabIndex) {
-    return new ViewAction() {
-      @Override
-      public Matcher<View> getConstraints() {
-        return isAssignableFrom(TabLayout.class);
-      }
-
-      @Override
-      public String getDescription() {
-        return "select tab at index " + tabIndex;
-      }
-
-      @Override
-      public void perform(UiController uiController, View view) {
-        TabLayout tabLayout = (TabLayout) view;
-        TabLayout.Tab tab = tabLayout.getTabAt(tabIndex);
-        if (tab != null) {
-          tab.select();
-        }
-      }
-    };
-  }
-
 }

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessingFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/witness/WitnessingFragmentTest.java
@@ -1,6 +1,9 @@
 package com.github.dedis.popstellar.ui.lao.witness;
 
+import android.view.View;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -13,6 +16,9 @@ import com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.utility.Constants;
 
+import com.google.android.material.tabs.TabLayout;
+import java.time.Instant;
+import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
@@ -23,17 +29,22 @@ import org.mockito.junit.MockitoTestRule;
 import dagger.hilt.android.testing.HiltAndroidRule;
 import dagger.hilt.android.testing.HiltAndroidTest;
 
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generatePoPToken;
 import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessingFragmentPageObject.getEventListFragment;
 import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessingFragmentPageObject.getRootView;
+import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessingFragmentPageObject.witnessMessageFragment;
+import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessingFragmentPageObject.witnessesFragment;
+import static com.github.dedis.popstellar.testutils.pages.lao.witness.WitnessingFragmentPageObject.witnessingTabs;
 
 @HiltAndroidTest
 @RunWith(AndroidJUnit4.class)
 public class WitnessingFragmentTest {
 
-  private static final long CREATION_TIME = 1631280815;
+  private static final long CREATION_TIME = Instant.now().getEpochSecond();
   private static final String LAO_NAME = "laoName";
 
   private static final KeyPair SENDER_KEY_1 = generatePoPToken();
@@ -73,4 +84,51 @@ public class WitnessingFragmentTest {
     // Check current fragment displayed is event list
     getEventListFragment().check(matches(isDisplayed()));
   }
+
+  @Test
+  public void testTabMenu() {
+    witnessingTabs().check(matches(isDisplayed()));
+
+    // Check that by default the witnesses are displayed
+    witnessMessageFragment().check(doesNotExist());
+    witnessesFragment().check(matches(isDisplayed()));
+
+    // Select the messages tab
+    witnessingTabs().perform(selectTabAtPosition(1));
+
+    // Check that the witness messages are displayed and the witnesses are not displayed
+    witnessMessageFragment().check(matches(isDisplayed()));
+    witnessesFragment().check(doesNotExist());
+
+    // Select the witnesses tab
+    witnessingTabs().perform(selectTabAtPosition(0));
+
+    // Check that the witnesses are displayed and the witnesses messages are not displayed
+    witnessMessageFragment().check(doesNotExist());
+    witnessesFragment().check(matches(isDisplayed()));
+  }
+
+  private static ViewAction selectTabAtPosition(final int tabIndex) {
+    return new ViewAction() {
+      @Override
+      public Matcher<View> getConstraints() {
+        return isAssignableFrom(TabLayout.class);
+      }
+
+      @Override
+      public String getDescription() {
+        return "select tab at index " + tabIndex;
+      }
+
+      @Override
+      public void perform(UiController uiController, View view) {
+        TabLayout tabLayout = (TabLayout) view;
+        TabLayout.Tab tab = tabLayout.getTabAt(tabIndex);
+        if (tab != null) {
+          tab.select();
+        }
+      }
+    };
+  }
+
 }

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/objects/WitnessMessageTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/objects/WitnessMessageTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class WitnessMessageTest {
@@ -16,6 +17,13 @@ public class WitnessMessageTest {
   private static final MessageID MSG_ID = new MessageID("foo");
   private static final String DESCRIPTION = "description";
   private static final String TITLE = "title";
+  private static final MessageID MESSAGE_ID1 = Base64DataUtils.generateMessageID();
+  private static final MessageID MESSAGE_ID2 = MESSAGE_ID1;
+  private static final MessageID MESSAGE_ID3 = Base64DataUtils.generateMessageID();
+
+  private static final WitnessMessage MESSAGE1 = new WitnessMessage(MESSAGE_ID1);
+  private static final WitnessMessage MESSAGE2 = new WitnessMessage(MESSAGE_ID2);
+  private static final WitnessMessage MESSAGE3 = new WitnessMessage(MESSAGE_ID3);
 
   @Test
   public void addWitnessTest() {
@@ -35,5 +43,36 @@ public class WitnessMessageTest {
             "WitnessMessage{messageId='%s', witnesses=%s, title='%s', description='%s'}",
             MSG_ID, Collections.singletonList(PK), TITLE, DESCRIPTION);
     assertEquals(expected, witnessMessage.toString());
+  }
+
+  @Test
+  public void equalsTest() {
+    assertEquals(MESSAGE1, MESSAGE2);
+    assertNotEquals(MESSAGE1, MESSAGE3);
+
+    WitnessMessage message1 = new WitnessMessage(MESSAGE1);
+    message1.addWitness(PK);
+    message1.setDescription(DESCRIPTION);
+    message1.setTitle(TITLE);
+
+    WitnessMessage message2 = new WitnessMessage(message1);
+    assertEquals(message1, message2);
+
+    message2.addWitness(Base64DataUtils.generatePublicKey());
+    assertNotEquals(message1, message2);
+
+    message2 = new WitnessMessage(message1);
+    message2.setDescription("new description");
+    assertNotEquals(message1, message2);
+
+    message2 = new WitnessMessage(message1);
+    message2.setTitle("new title");
+    assertNotEquals(message1, message2);
+  }
+
+  @Test
+  public void hashCodeTest() {
+    assertEquals(MESSAGE1.hashCode(), MESSAGE2.hashCode());
+    assertNotEquals(MESSAGE2.hashCode(), MESSAGE3.hashCode());
   }
 }

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/objects/WitnessMessageTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/objects/WitnessMessageTest.java
@@ -18,11 +18,10 @@ public class WitnessMessageTest {
   private static final String DESCRIPTION = "description";
   private static final String TITLE = "title";
   private static final MessageID MESSAGE_ID1 = Base64DataUtils.generateMessageID();
-  private static final MessageID MESSAGE_ID2 = MESSAGE_ID1;
   private static final MessageID MESSAGE_ID3 = Base64DataUtils.generateMessageID();
 
   private static final WitnessMessage MESSAGE1 = new WitnessMessage(MESSAGE_ID1);
-  private static final WitnessMessage MESSAGE2 = new WitnessMessage(MESSAGE_ID2);
+  private static final WitnessMessage MESSAGE2 = MESSAGE1.copy();
   private static final WitnessMessage MESSAGE3 = new WitnessMessage(MESSAGE_ID3);
 
   @Test
@@ -68,6 +67,8 @@ public class WitnessMessageTest {
     message2 = new WitnessMessage(message1);
     message2.setTitle("new title");
     assertNotEquals(message1, message2);
+
+    assertNotEquals(message1, null);
   }
 
   @Test

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/MessageValidatorTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/MessageValidatorTest.java
@@ -34,7 +34,8 @@ public class MessageValidatorTest {
   public void testValidLaoId() {
     MessageValidator.MessageValidatorBuilder validator = MessageValidator.verify();
     String invalid1 = "invalidID";
-    String invalid2 = "A" + LAO_ID.substring(1);
+    String invalid2 =
+        Lao.generateLaoId(Base64DataUtils.generatePublicKeyOtherThan(ORGANIZER), 0, "name");
 
     validator.validLaoId(LAO_ID, ORGANIZER, CREATION, NAME);
     assertThrows(


### PR DESCRIPTION
This PR changes the Messages tab in the witnessing menu to diplay the messages that require witnessing. Most of the logic was already there, it was just not displayed correctly. The message types that require witnessing so far implemented were:
- SetupElection
- CreateRollCall
- OpenRollCall
- Close Roll Call
- UpdateLao
- CreateMeeting
- State Meeting

For attendees, the messages are displayed but the sign button is not shown.
On click of the sign button, a dialog pops up to ask if the user really wants to sign the message. On confirmation, a witness message is sent, but this is not fully implemented yet and a handler will be added later.

###   Witness and organizer UI
<img src="https://user-images.githubusercontent.com/71314469/236949152-17014e1a-07e6-4921-ada6-59baa918972b.png" 
     width="250" />

expanded:

<img src="https://user-images.githubusercontent.com/71314469/236949885-232f3893-d4cd-4e5a-bc57-05d377cf7dc7.png" 
     width="250" />

On click of the sign button:

<img src="https://user-images.githubusercontent.com/71314469/236950157-262863a8-46ce-4945-855e-51a79569f4aa.png" 
     width="250" />


###   Attendee UI
sign button not displayed:

<img src="https://user-images.githubusercontent.com/71314469/236949272-f761487d-5874-4872-b4ef-5cb523811167.png" 
     width="250" />

###   Attendee UI in light mode

<img src="https://github.com/dedis/popstellar/assets/71314469/b60a2971-ba6a-4534-b1c8-5c9500a36085.png" 
     width="250" />

<img src="https://github.com/dedis/popstellar/assets/71314469/0ee43370-e767-4387-8c68-cdb083d2a685.png" 
     width="250" />

