### PR TITLE
Remove the cash, and notifications from the fe1 home screen

### DIFF
--- a/fe1-web/src/features/index.ts
+++ b/fe1-web/src/features/index.ts
@@ -22,7 +22,6 @@ export function configureFeatures() {
   // configure features
   const eventConfiguration = events.configure();
   const walletConfiguration = wallet.configure();
-  const digitalCashConfiguration = digitalCash.configure();
 
   const notificationConfiguration = notification.configure();
   const laoConfiguration = lao.configure({ registry: messageRegistry });
@@ -167,12 +166,7 @@ export function configureFeatures() {
     /* connect */
     encodeLaoConnectionForQRCode: homeComposition.functions.encodeLaoConnectionForQRCode,
     /* navigation */
-    laoNavigationScreens: [
-      ...socialConfiguration.laoScreens,
-      ...notificationConfiguration.laoScreens,
-      ...walletComposition.laoScreens,
-      ...digitalCashConfiguration.laoScreens,
-    ],
+    laoNavigationScreens: [...socialConfiguration.laoScreens, ...walletComposition.laoScreens],
     eventsNavigationScreens: [
       ...eventConfiguration.laoEventScreens,
       ...meetingConfiguration.laoEventScreens,


### PR DESCRIPTION
This very tiny PR will remove the digital cash and notification features from the home screen. 
The notification is currently only used by witnessing, therefor it is not useful and part of release.
![image](https://github.com/dedis/popstellar/assets/42808302/88e17bde-a9f4-4fc8-8874-08000546888b)
