### PR TITLE
Add config file watch service

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/decentralized/ConnectionMediator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/decentralized/ConnectionMediator.scala
@@ -21,6 +21,9 @@ final case class ConnectionMediator(
   // List of servers connected
   private var serverSet: Set[ActorRef] = Set()
 
+  // Ping Monitor to inform it of our ActorRef
+  monitorRef ! ConnectionMediator.Ping()
+
   override def receive: Receive = {
 
     // Connect to some servers
@@ -77,4 +80,5 @@ object ConnectionMediator {
   final case class ConnectTo(urlList: List[String]) extends Event
   final case class NewServerConnected(serverRef: ActorRef) extends Event
   final case class ServerLeft(serverRef: ActorRef) extends Event
+  final case class Ping() extends Event
 }

--- a/be2-scala/src/main/scala/ch/epfl/pop/decentralized/Monitor.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/decentralized/Monitor.scala
@@ -115,8 +115,8 @@ private class FileMonitor(mediatorRef: ActorRef) extends Runnable {
           if (serverPeersListPath.endsWith(event.context().toString)) {
             mediatorRef ! ConnectionMediator.ConnectTo(readServerPeers())
           }
-          watchKey.reset()
         }
+        watchKey.reset()
       }
     } catch {
       case _: InterruptedException =>

--- a/be2-scala/src/main/scala/ch/epfl/pop/decentralized/Monitor.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/decentralized/Monitor.scala
@@ -35,7 +35,6 @@ final case class Monitor(
   override def receive: Receive = LoggingReceive {
 
     case Monitor.AtLeastOneServerConnected =>
-      connectionMediatorRef = sender()
       if (!someServerConnected) {
         timers.startTimerWithFixedDelay(periodicHbKey, TriggerHeartbeat, heartbeatRate)
         someServerConnected = true
@@ -60,6 +59,11 @@ final case class Monitor(
             timers.startSingleTimer(singleHbKey, TriggerHeartbeat, messageDelay)
           }
       }
+
+    case ConnectionMediator.Ping() =>
+      log.info("Received ConnectionMediator ping")
+      connectionMediatorRef = sender()
+      new Thread(new FileMonitor(connectionMediatorRef)).start()
 
     case _ => /* DO NOTHING */
   }

--- a/be2-scala/src/test/scala/ch/epfl/pop/decentralized/ConnectionMediatorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/decentralized/ConnectionMediatorSuite.scala
@@ -26,6 +26,8 @@ class ConnectionMediatorSuite extends TestKit(ActorSystem("ConnectionMediatorSui
       ConnectionMediator.props(mockMonitor.ref, ActorRef.noSender, ActorRef.noSender, MessageRegistry())
     )
 
+    mockMonitor.expectMsg(timeout, ConnectionMediator.Ping())
+
     // Register server
     connectionMediatorRef ! ConnectionMediator.NewServerConnected(server.ref)
 
@@ -47,6 +49,8 @@ class ConnectionMediatorSuite extends TestKit(ActorSystem("ConnectionMediatorSui
     val connectionMediatorRef = system.actorOf(
       ConnectionMediator.props(mockMonitor.ref, ActorRef.noSender, ActorRef.noSender, MessageRegistry())
     )
+
+    mockMonitor.expectMsg(timeout, ConnectionMediator.Ping())
 
     // Register servers
     connectionMediatorRef ! ConnectionMediator.NewServerConnected(server1.ref)


### PR DESCRIPTION
This pr adds the ability for the system to react on the fly to changes in the config files added in #1519. 

Limitations: Without greet_server implementation we are still susceptible to having double connections (A to B and B to A, over two websockets). 