### PR TITLE
Refactoring Akka graph construction

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/PublishSubscribe.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/PublishSubscribe.scala
@@ -10,7 +10,7 @@ import ch.epfl.pop.decentralized.Monitor
 import ch.epfl.pop.model.network.MethodType._
 import ch.epfl.pop.model.network.{JsonRpcRequest, JsonRpcResponse}
 import ch.epfl.pop.pubsub.graph._
-import ch.epfl.pop.pubsub.graph.handlers.{GetMessagesByIdResponseHandler, ParamsWithChannelHandler, ParamsWithMapHandler, ParamsWithMessageHandler}
+import ch.epfl.pop.pubsub.graph.handlers.{GetMessagesByIdResponseHandler, ParamsHandler, ParamsWithMapHandler, ParamsWithMessageHandler}
 
 object PublishSubscribe {
 
@@ -126,9 +126,9 @@ object PublishSubscribe {
           ))
 
           val hasMessagePartition = builder.add(ParamsWithMessageHandler.graph(messageRegistry))
-          val subscribePartition = builder.add(ParamsWithChannelHandler.subscribeHandler(clientActorRef))
-          val unsubscribePartition = builder.add(ParamsWithChannelHandler.unsubscribeHandler(clientActorRef))
-          val catchupPartition = builder.add(ParamsWithChannelHandler.catchupHandler(clientActorRef))
+          val subscribePartition = builder.add(ParamsHandler.subscribeHandler(clientActorRef))
+          val unsubscribePartition = builder.add(ParamsHandler.unsubscribeHandler(clientActorRef))
+          val catchupPartition = builder.add(ParamsHandler.catchupHandler(clientActorRef))
           val heartbeatPartition = builder.add(ParamsWithMapHandler.heartbeatHandler(dbActorRef))
           val getMessagesByIdPartition = builder.add(ParamsWithMapHandler.getMessagesByIdHandler(dbActorRef))
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsHandler.scala
@@ -11,7 +11,7 @@ import ch.epfl.pop.pubsub.{AskPatternConstants, ClientActor, PubSubMediator}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, Future}
 
-object ParamsWithChannelHandler extends AskPatternConstants {
+object ParamsHandler extends AskPatternConstants {
 
   def subscribeHandler(clientActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map {
     case Right(jsonRpcMessage: JsonRpcRequest) =>

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -2,62 +2,22 @@ package ch.epfl.pop.pubsub.graph.handlers
 
 import akka.NotUsed
 import akka.pattern.AskableActorRef
-import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition}
-import ch.epfl.pop.model.network.method.{GetMessagesById, Heartbeat}
-import ch.epfl.pop.model.network.{JsonRpcRequest, JsonRpcResponse}
-import ch.epfl.pop.model.objects.{Channel, DbActorNAckException, Hash}
-import ch.epfl.pop.pubsub.graph.{ErrorCodes, GraphMessage, PipelineError}
-import ch.epfl.pop.pubsub.AskPatternConstants
-import ch.epfl.pop.storage.DbActor
-import ch.epfl.pop.model.network.MethodType
-import ch.epfl.pop.pubsub.graph.validators.RpcValidator
+import akka.stream.scaladsl.Flow
 import ch.epfl.pop.model.network.method.message.Message
-import scala.collection.mutable
-import akka.stream.FlowShape
-import ch.epfl.pop.model.network.ResultObject
+import ch.epfl.pop.model.network.method.{GetMessagesById, Heartbeat}
+import ch.epfl.pop.model.network.{JsonRpcRequest, JsonRpcResponse, MethodType, ResultObject}
+import ch.epfl.pop.model.objects.{Channel, DbActorNAckException, Hash}
+import ch.epfl.pop.pubsub.AskPatternConstants
+import ch.epfl.pop.pubsub.graph.validators.RpcValidator
+import ch.epfl.pop.pubsub.graph.{ErrorCodes, GraphMessage, PipelineError}
+import ch.epfl.pop.storage.DbActor
 
 import scala.collection.immutable.HashMap
+import scala.collection.mutable
 import scala.concurrent.Await
 import scala.util.{Failure, Success}
 
 object ParamsWithMapHandler extends AskPatternConstants {
-
-  def graph(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow.fromGraph(GraphDSL.create() {
-    implicit builder: GraphDSL.Builder[NotUsed] =>
-      {
-        import GraphDSL.Implicits._
-
-        /* partitioner port numbers */
-        val portPipelineError = 0
-        val portHeartBeatHandler = 1
-        val portGetMessagesByIdHandler = 2
-        val totalPorts = 3
-
-        /* building blocks */
-        val handlerPartitioner = builder.add(Partition[GraphMessage](
-          totalPorts,
-          {
-            case Right(jsonRpcMessage: JsonRpcRequest) => jsonRpcMessage.getParams match {
-                case _: Heartbeat       => portHeartBeatHandler
-                case _: GetMessagesById => portGetMessagesByIdHandler
-              }
-            case _ => portPipelineError // Pipeline error goes directly in handlerMerger
-          }
-        ))
-
-        val heartbeatHandler = builder.add(ParamsWithMapHandler.heartbeatHandler(dbActorRef))
-        val getMessagesByIdHandler = builder.add(ParamsWithMapHandler.getMessagesByIdHandler(dbActorRef))
-        val handlerMerger = builder.add(Merge[GraphMessage](totalPorts))
-
-        /* glue the components together */
-        handlerPartitioner.out(portPipelineError) ~> handlerMerger
-        handlerPartitioner.out(portHeartBeatHandler) ~> heartbeatHandler ~> handlerMerger
-        handlerPartitioner.out(portGetMessagesByIdHandler) ~> getMessagesByIdHandler ~> handlerMerger
-
-        /* close the shape */
-        FlowShape(handlerPartitioner.in, handlerMerger.out)
-      }
-  })
 
   def heartbeatHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map {
     case Right(jsonRpcMessage: JsonRpcRequest) =>

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandler.scala
@@ -59,7 +59,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
       }
   })
 
-  private def heartbeatHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map {
+  def heartbeatHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map {
     case Right(jsonRpcMessage: JsonRpcRequest) =>
       /** first step is to retrieve the received heartbeat from the jsonRpcRequest */
       val receivedHeartBeat: Map[Channel, Set[Hash]] = jsonRpcMessage.getParams.asInstanceOf[Heartbeat].channelsToMessageIds
@@ -105,7 +105,7 @@ object ParamsWithMapHandler extends AskPatternConstants {
     case graphMessage @ _ => graphMessage
   }.filter(!isGetMessagesByIdEmpty(_)) // Answer to heartbeats only if some messages are actually missing
 
-  private def getMessagesByIdHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map {
+  def getMessagesByIdHandler(dbActorRef: AskableActorRef): Flow[GraphMessage, GraphMessage, NotUsed] = Flow[GraphMessage].map {
     case Right(jsonRpcMessage: JsonRpcRequest) =>
       val receivedRequest: Map[Channel, Set[Hash]] = jsonRpcMessage.getParams.asInstanceOf[GetMessagesById].channelsToMessageIds
       val response: mutable.HashMap[Channel, Set[Message]] = mutable.HashMap()

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsHandlerSuite.scala
@@ -12,7 +12,7 @@ import util.examples.JsonRpcRequestExample
 import scala.concurrent.Await
 import scala.util.{Failure, Success}
 
-class ParamsWithChannelHandlerSuite extends FunSuite with Matchers with AskPatternConstants {
+class ParamsHandlerSuite extends FunSuite with Matchers with AskPatternConstants {
 
   implicit val system: ActorSystem = ActorSystem()
 
@@ -22,7 +22,7 @@ class ParamsWithChannelHandlerSuite extends FunSuite with Matchers with AskPatte
     val rpcExample = JsonRpcRequestExample.subscribeRpcRequest
     val expectedAsk = ClientActor.SubscribeTo(rpcExample.getParams.channel)
     val pipelineOutput = Source.single(Right(rpcExample))
-      .via(ParamsWithChannelHandler.subscribeHandler(mockClientRef.ref))
+      .via(ParamsHandler.subscribeHandler(mockClientRef.ref))
       .runWith(Sink.head)
 
     val channel = mockClientRef.expectMsg(expectedAsk).channel
@@ -40,7 +40,7 @@ class ParamsWithChannelHandlerSuite extends FunSuite with Matchers with AskPatte
     val rpcExample = JsonRpcRequestExample.subscribeRpcRequest
     val expectedAsk = ClientActor.SubscribeTo(rpcExample.getParams.channel)
     val pipelineOutput = Source.single(Right(rpcExample))
-      .via(ParamsWithChannelHandler.subscribeHandler(mockClientRef.ref))
+      .via(ParamsHandler.subscribeHandler(mockClientRef.ref))
       .runWith(Sink.head)
 
     val channel = mockClientRef.expectMsg(expectedAsk).channel
@@ -59,7 +59,7 @@ class ParamsWithChannelHandlerSuite extends FunSuite with Matchers with AskPatte
     val rpcExample = JsonRpcRequestExample.unSubscribeRpcRequest
     val expectedAsk = ClientActor.UnsubscribeFrom(rpcExample.getParams.channel)
     val pipelineOutput = Source.single(Right(rpcExample))
-      .via(ParamsWithChannelHandler.unsubscribeHandler(mockClientRef.ref))
+      .via(ParamsHandler.unsubscribeHandler(mockClientRef.ref))
       .runWith(Sink.head)
 
     val channel = mockClientRef.expectMsg(expectedAsk).channel
@@ -77,7 +77,7 @@ class ParamsWithChannelHandlerSuite extends FunSuite with Matchers with AskPatte
     val rpcExample = JsonRpcRequestExample.unSubscribeRpcRequest
     val expectedAsk = ClientActor.UnsubscribeFrom(rpcExample.getParams.channel)
     val pipelineOutput = Source.single(Right(rpcExample))
-      .via(ParamsWithChannelHandler.unsubscribeHandler(mockClientRef.ref))
+      .via(ParamsHandler.unsubscribeHandler(mockClientRef.ref))
       .runWith(Sink.head)
 
     val channel = mockClientRef.expectMsg(expectedAsk).channel

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/ParamsWithMapHandlerSuite.scala
@@ -1,36 +1,32 @@
 package ch.epfl.pop.pubsub.graph.handlers
 
-import akka.NotUsed
 import akka.actor.{ActorSystem, Props}
 import akka.pattern.AskableActorRef
-import akka.stream.SinkShape
-import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.stream.scaladsl.{Sink, Source}
 import akka.testkit.TestKit
 import ch.epfl.pop.decentralized.ToyDbActor
-import ch.epfl.pop.model.network.{JsonRpcRequest, JsonRpcResponse, MethodType, ResultObject}
-import ch.epfl.pop.model.network.method.{GetMessagesById, Heartbeat}
-import ch.epfl.pop.model.network.method.message.Message
-import ch.epfl.pop.model.objects.{Base64Data, Channel, Hash}
+import ch.epfl.pop.model.network.method.GetMessagesById
+import ch.epfl.pop.model.network.{JsonRpcRequest, JsonRpcResponse}
 import ch.epfl.pop.pubsub.AskPatternConstants
 import ch.epfl.pop.pubsub.graph.GraphMessage
-import ch.epfl.pop.pubsub.graph.validators.RpcValidator
-import org.scalatest.funsuite.{AnyFunSuite, AnyFunSuiteLike}
+import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, equal}
 import util.examples.JsonRpcRequestExample._
-import scala.collection.{immutable, mutable}
-import scala.concurrent.{Await, Future}
-import scala.util.{Failure, Success}
+
+import scala.concurrent.Await
+import scala.util.Success
 class ParamsWithMapHandlerSuite extends TestKit(ActorSystem("HbActorSuiteActorSystem")) with AnyFunSuiteLike with AskPatternConstants {
 
   final val toyDbActorRef: AskableActorRef = system.actorOf(Props(new ToyDbActor))
-  final val boxUnderTest: Flow[GraphMessage, GraphMessage, NotUsed] = ParamsWithMapHandler.graph(toyDbActorRef)
+  final val heartbeatHandler = ParamsWithMapHandler.heartbeatHandler(toyDbActorRef)
+  final val getMessagesByIdHandler = ParamsWithMapHandler.getMessagesByIdHandler(toyDbActorRef)
   final val rpc: String = "rpc"
   final val id: Option[Int] = Some(0)
 
   test("sending a heartbeat correctly returns the missing ids") {
     val input: List[GraphMessage] = List(Right(VALID_RECEIVED_HEARTBEAT_RPC))
     val source = Source(input)
-    val s = source.via(boxUnderTest).runWith(Sink.seq[GraphMessage])
+    val s = source.via(heartbeatHandler).runWith(Sink.seq[GraphMessage])
     Await.ready(s, duration).value match {
       case Some(Success(seq)) => seq.toList.head match {
           case Right(jsonRpcReq: JsonRpcRequest) => jsonRpcReq.getParams.asInstanceOf[GetMessagesById].channelsToMessageIds should equal(EXPECTED_MISSING_MESSAGE_IDS)
@@ -44,7 +40,7 @@ class ParamsWithMapHandlerSuite extends TestKit(ActorSystem("HbActorSuiteActorSy
   test("sending a getMessagesById correctly returns the missing messages") {
     val input: List[GraphMessage] = List(Right(VALID_RECEIVED_GET_MSG_BY_ID_RPC))
     val source = Source(input)
-    val s = source.via(boxUnderTest).runWith(Sink.seq[GraphMessage])
+    val s = source.via(getMessagesByIdHandler).runWith(Sink.seq[GraphMessage])
     Await.ready(s, duration).value match {
       case Some(Success(seq)) => seq.toList.head match {
           case Right(jsonRpcResp: JsonRpcResponse) => jsonRpcResp.result.get.resultMap.get should equal(EXPECTED_MISSING_MESSAGES)
@@ -58,7 +54,7 @@ class ParamsWithMapHandlerSuite extends TestKit(ActorSystem("HbActorSuiteActorSy
   test("receiving a heartbeat with unknown channel asks back for this channel") {
     val input: List[GraphMessage] = List(Right(VALID_RECEIVED_UNKNOWN_CHANNEL_HEARTBEAT_RPC))
     val source = Source(input)
-    val s = source.via(boxUnderTest).runWith(Sink.seq[GraphMessage])
+    val s = source.via(heartbeatHandler).runWith(Sink.seq[GraphMessage])
     Await.ready(s, duration).value match {
       case Some(Success(seq)) => seq.toList.head match {
           case Right(jsonRpcReq: JsonRpcRequest) => jsonRpcReq.getParams.asInstanceOf[GetMessagesById].channelsToMessageIds should equal(EXPECTED_UNKNOWN_CHANNEL_MISSING_MESSAGE_IDS)


### PR DESCRIPTION
The point of this pr is to prepare the arrival of the new `greet_server` json. The old partitioning did not allow for easy addition of new `JsonRpcRequest`. 
This refactoring helps in two ways: 
- By partitioning  using `MethodType` we can get rid of some boilerplate code in the other handlers
- By renaming `ParamsWithChannelHandler` to `ParamsHandler`, more general handlers can be added  without breaking consistency too much (`greet_server` should fit well in there, especially since it will also take a `clientActorRef` as parameter)