### PR TITLE
Scala deployment CI fix

### DIFF
--- a/be2-scala/build.sbt
+++ b/be2-scala/build.sbt
@@ -78,6 +78,7 @@ copyProtocolTask := {
 // Add the copyProtocolTask to compile and test scopes
 (Compile/ compile) := ((Compile/ compile) dependsOn copyProtocolTask).value
 (Test/ test) := ((Test/ test) dependsOn copyProtocolTask).value
+assembly := (assembly dependsOn copyProtocolTask).value
 
 // Setup resource directory for jar assembly
 (Compile/ packageBin/ resourceDirectory) := file(".") / "./src/main/resources"


### PR DESCRIPTION
The CI failed to build be2 jar files because the protocol folder wasn't properly copied in the resources folder in the project. This pr should be fixing that.