### PR TITLE
Fix the catchup on election results issue 

### DIFF
--- a/be1-go/channel/election/mod.go
+++ b/be1-go/channel/election/mod.go
@@ -642,8 +642,8 @@ func (c *Channel) broadcastElectionResult() error {
 		WitnessSignatures: []message.WitnessSignature{},
 	}
 
-	c.broadcastToAllClients(electionResultMsg)
 	c.inbox.StoreMessage(electionResultMsg)
+	c.broadcastToAllClients(electionResultMsg)
 
 	return nil
 }

--- a/be1-go/channel/election/mod.go
+++ b/be1-go/channel/election/mod.go
@@ -643,6 +643,7 @@ func (c *Channel) broadcastElectionResult() error {
 	}
 
 	c.broadcastToAllClients(electionResultMsg)
+	c.inbox.StoreMessage(electionResultMsg)
 
 	return nil
 }

--- a/be1-go/inbox/mod.go
+++ b/be1-go/inbox/mod.go
@@ -14,7 +14,7 @@ type messageInfo struct {
 	storedTime int64
 }
 
-// Inbox represents an in-memory data store to record incoming messages.
+// Inbox represents an in-memory data store to record messages.
 type Inbox struct {
 	mutex             sync.RWMutex
 	msgsMap           map[string]*messageInfo


### PR DESCRIPTION
After reading through the discussions in #1027 and #866, I think the solution of storing the election results in the election channel inbox is relevant now with respect to the current state of the system since the backends now create and send messages. 
The scala backend writes the results on its database (we don't have one on the go backend but the equivalent would be storing it in the inboxes).  
Also, the channel inboxes are only used for the catchup so their purpose should be to provide all the necessary information about the channel to the new subscribers. 
In this PR, I simply add storing the election results message in the inbox after broadcasting it to the clients and remove the "incoming messages" specification from the inbox documentation. 
