### PR TITLE
Display attendee pop token when trying to join roll call

### DIFF
--- a/fe1-web/src/features/rollCall/components/RollCallOpen.tsx
+++ b/fe1-web/src/features/rollCall/components/RollCallOpen.tsx
@@ -182,7 +182,13 @@ const RollCallOpen = ({
               value={ScannablePopToken.encodePopToken({ pop_token: popToken })}
               overlayText={STRINGS.roll_call_qrcode_text}
             />
-            <Text style={[Typography.paragraph, Typography.centered, textStyle.topSpace]}>
+            <Text
+              style={[
+                Typography.paragraph,
+                Typography.centered,
+                Typography.code,
+                textStyle.topSpace,
+              ]}>
               {popToken}
             </Text>
           </View>

--- a/fe1-web/src/features/rollCall/components/RollCallOpen.tsx
+++ b/fe1-web/src/features/rollCall/components/RollCallOpen.tsx
@@ -2,7 +2,7 @@ import { CompositeScreenProps, useNavigation } from '@react-navigation/core';
 import { StackScreenProps } from '@react-navigation/stack';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Text } from 'react-native';
+import { StyleSheet, Text, View, ViewStyle } from 'react-native';
 import { useToast } from 'react-native-toast-notifications';
 import ReactTimeago from 'react-timeago';
 
@@ -14,7 +14,7 @@ import { LaoEventsParamList } from 'core/navigation/typing/LaoEventsParamList';
 import { LaoParamList } from 'core/navigation/typing/LaoParamList';
 import { Hash, PublicKey, Timestamp } from 'core/objects';
 import { ScannablePopToken } from 'core/objects/ScannablePopToken';
-import { Typography } from 'core/styles';
+import { Spacing, Typography } from 'core/styles';
 import { FOUR_SECONDS } from 'resources/const';
 import STRINGS from 'resources/strings';
 
@@ -30,6 +30,12 @@ type NavigationProps = CompositeScreenProps<
     StackScreenProps<AppParamList, typeof STRINGS.navigation_app_lao>
   >
 >;
+
+const textStyle = StyleSheet.create({
+  topSpace: {
+    marginTop: Spacing.x2,
+  } as ViewStyle,
+});
 
 const RollCallOpen = ({
   rollCall,
@@ -171,10 +177,15 @@ const RollCallOpen = ({
       {!isOrganizer && (
         <>
           <Text style={Typography.paragraph}>{STRINGS.roll_call_open_attendee}</Text>
-          <QRCode
-            value={ScannablePopToken.encodePopToken({ pop_token: popToken })}
-            overlayText={STRINGS.roll_call_qrcode_text}
-          />
+          <View>
+            <QRCode
+              value={ScannablePopToken.encodePopToken({ pop_token: popToken })}
+              overlayText={STRINGS.roll_call_qrcode_text}
+            />
+            <Text style={[Typography.paragraph, Typography.centered, textStyle.topSpace]}>
+              {popToken}
+            </Text>
+          </View>
         </>
       )}
 

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
@@ -505,6 +505,9 @@ exports[`EventRollCall render correctly no duplicate attendees opened roll calls
                                       "textAlign": "center",
                                     },
                                     {
+                                      "fontFamily": "Courier New",
+                                    },
+                                    {
                                       "marginTop": 32,
                                     },
                                   ]
@@ -1491,6 +1494,9 @@ exports[`EventRollCall render correctly no duplicate attendees re-opened roll ca
                                     },
                                     {
                                       "textAlign": "center",
+                                    },
+                                    {
+                                      "fontFamily": "Courier New",
                                     },
                                     {
                                       "marginTop": 32,
@@ -3794,6 +3800,9 @@ exports[`EventRollCall render correctly non organizers opened roll calls 1`] = `
                                       "textAlign": "center",
                                     },
                                     {
+                                      "fontFamily": "Courier New",
+                                    },
+                                    {
                                       "marginTop": 32,
                                     },
                                   ]
@@ -4780,6 +4789,9 @@ exports[`EventRollCall render correctly non organizers re-opened roll calls 1`] 
                                     },
                                     {
                                       "textAlign": "center",
+                                    },
+                                    {
+                                      "fontFamily": "Courier New",
                                     },
                                     {
                                       "marginTop": 32,

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
@@ -421,74 +421,95 @@ exports[`EventRollCall render correctly no duplicate attendees opened roll calls
                             >
                               The Roll Call is currently open and you as an attendee should let the organizer scan your PoP token encoded in the QR Code below.
                             </Text>
-                            <View
-                              style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                }
-                              }
-                            >
+                            <View>
                               <View
                                 style={
                                   {
-                                    "position": "relative",
+                                    "flexDirection": "row",
+                                    "justifyContent": "center",
                                   }
                                 }
                               >
-                                <qrcode
-                                  level="H"
-                                  size={256}
-                                  style={
-                                    {
-                                      "height": "auto",
-                                      "maxWidth": "300px",
-                                      "width": "100%",
-                                    }
-                                  }
-                                  value="{"pop_token":""}"
-                                  viewBox="0 0 256 256"
-                                />
                                 <View
                                   style={
                                     {
-                                      "alignItems": "center",
-                                      "backgroundColor": "#3742fa",
-                                      "borderRadius": 100,
-                                      "bottom": "27.9%",
-                                      "display": "flex",
-                                      "justifyContent": "center",
-                                      "left": "27.9%",
-                                      "overflow": "hidden",
-                                      "padding": "4",
-                                      "position": "absolute",
-                                      "right": "27.9%",
-                                      "top": "27.9%",
+                                      "position": "relative",
                                     }
                                   }
                                 >
-                                  <Text
+                                  <qrcode
+                                    level="H"
+                                    size={256}
                                     style={
-                                      [
-                                        {
-                                          "color": "#000",
-                                          "fontSize": 20,
-                                          "lineHeight": 26,
-                                          "textAlign": "left",
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        {
-                                          "color": "#fff",
-                                        },
-                                      ]
+                                      {
+                                        "height": "auto",
+                                        "maxWidth": "300px",
+                                        "width": "100%",
+                                      }
+                                    }
+                                    value="{"pop_token":""}"
+                                    viewBox="0 0 256 256"
+                                  />
+                                  <View
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3742fa",
+                                        "borderRadius": 100,
+                                        "bottom": "27.9%",
+                                        "display": "flex",
+                                        "justifyContent": "center",
+                                        "left": "27.9%",
+                                        "overflow": "hidden",
+                                        "padding": "4",
+                                        "position": "absolute",
+                                        "right": "27.9%",
+                                        "top": "27.9%",
+                                      }
                                     }
                                   >
-                                    Scan to add attendee
-                                  </Text>
+                                    <Text
+                                      style={
+                                        [
+                                          {
+                                            "color": "#000",
+                                            "fontSize": 20,
+                                            "lineHeight": 26,
+                                            "textAlign": "left",
+                                          },
+                                          {
+                                            "textAlign": "center",
+                                          },
+                                          {
+                                            "color": "#fff",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      Scan to add attendee
+                                    </Text>
+                                  </View>
                                 </View>
                               </View>
+                              <Text
+                                style={
+                                  [
+                                    {
+                                      "color": "#000",
+                                      "fontSize": 20,
+                                      "lineHeight": 26,
+                                      "marginBottom": 16,
+                                      "textAlign": "left",
+                                    },
+                                    {
+                                      "textAlign": "center",
+                                    },
+                                    {
+                                      "marginTop": 32,
+                                    },
+                                  ]
+                                }
+                              />
                             </View>
                             <View
                               style={
@@ -1388,74 +1409,95 @@ exports[`EventRollCall render correctly no duplicate attendees re-opened roll ca
                             >
                               The Roll Call is currently open and you as an attendee should let the organizer scan your PoP token encoded in the QR Code below.
                             </Text>
-                            <View
-                              style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                }
-                              }
-                            >
+                            <View>
                               <View
                                 style={
                                   {
-                                    "position": "relative",
+                                    "flexDirection": "row",
+                                    "justifyContent": "center",
                                   }
                                 }
                               >
-                                <qrcode
-                                  level="H"
-                                  size={256}
-                                  style={
-                                    {
-                                      "height": "auto",
-                                      "maxWidth": "300px",
-                                      "width": "100%",
-                                    }
-                                  }
-                                  value="{"pop_token":""}"
-                                  viewBox="0 0 256 256"
-                                />
                                 <View
                                   style={
                                     {
-                                      "alignItems": "center",
-                                      "backgroundColor": "#3742fa",
-                                      "borderRadius": 100,
-                                      "bottom": "27.9%",
-                                      "display": "flex",
-                                      "justifyContent": "center",
-                                      "left": "27.9%",
-                                      "overflow": "hidden",
-                                      "padding": "4",
-                                      "position": "absolute",
-                                      "right": "27.9%",
-                                      "top": "27.9%",
+                                      "position": "relative",
                                     }
                                   }
                                 >
-                                  <Text
+                                  <qrcode
+                                    level="H"
+                                    size={256}
                                     style={
-                                      [
-                                        {
-                                          "color": "#000",
-                                          "fontSize": 20,
-                                          "lineHeight": 26,
-                                          "textAlign": "left",
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        {
-                                          "color": "#fff",
-                                        },
-                                      ]
+                                      {
+                                        "height": "auto",
+                                        "maxWidth": "300px",
+                                        "width": "100%",
+                                      }
+                                    }
+                                    value="{"pop_token":""}"
+                                    viewBox="0 0 256 256"
+                                  />
+                                  <View
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3742fa",
+                                        "borderRadius": 100,
+                                        "bottom": "27.9%",
+                                        "display": "flex",
+                                        "justifyContent": "center",
+                                        "left": "27.9%",
+                                        "overflow": "hidden",
+                                        "padding": "4",
+                                        "position": "absolute",
+                                        "right": "27.9%",
+                                        "top": "27.9%",
+                                      }
                                     }
                                   >
-                                    Scan to add attendee
-                                  </Text>
+                                    <Text
+                                      style={
+                                        [
+                                          {
+                                            "color": "#000",
+                                            "fontSize": 20,
+                                            "lineHeight": 26,
+                                            "textAlign": "left",
+                                          },
+                                          {
+                                            "textAlign": "center",
+                                          },
+                                          {
+                                            "color": "#fff",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      Scan to add attendee
+                                    </Text>
+                                  </View>
                                 </View>
                               </View>
+                              <Text
+                                style={
+                                  [
+                                    {
+                                      "color": "#000",
+                                      "fontSize": 20,
+                                      "lineHeight": 26,
+                                      "marginBottom": 16,
+                                      "textAlign": "left",
+                                    },
+                                    {
+                                      "textAlign": "center",
+                                    },
+                                    {
+                                      "marginTop": 32,
+                                    },
+                                  ]
+                                }
+                              />
                             </View>
                             <View
                               style={
@@ -3668,74 +3710,95 @@ exports[`EventRollCall render correctly non organizers opened roll calls 1`] = `
                             >
                               The Roll Call is currently open and you as an attendee should let the organizer scan your PoP token encoded in the QR Code below.
                             </Text>
-                            <View
-                              style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                }
-                              }
-                            >
+                            <View>
                               <View
                                 style={
                                   {
-                                    "position": "relative",
+                                    "flexDirection": "row",
+                                    "justifyContent": "center",
                                   }
                                 }
                               >
-                                <qrcode
-                                  level="H"
-                                  size={256}
-                                  style={
-                                    {
-                                      "height": "auto",
-                                      "maxWidth": "300px",
-                                      "width": "100%",
-                                    }
-                                  }
-                                  value="{"pop_token":""}"
-                                  viewBox="0 0 256 256"
-                                />
                                 <View
                                   style={
                                     {
-                                      "alignItems": "center",
-                                      "backgroundColor": "#3742fa",
-                                      "borderRadius": 100,
-                                      "bottom": "27.9%",
-                                      "display": "flex",
-                                      "justifyContent": "center",
-                                      "left": "27.9%",
-                                      "overflow": "hidden",
-                                      "padding": "4",
-                                      "position": "absolute",
-                                      "right": "27.9%",
-                                      "top": "27.9%",
+                                      "position": "relative",
                                     }
                                   }
                                 >
-                                  <Text
+                                  <qrcode
+                                    level="H"
+                                    size={256}
                                     style={
-                                      [
-                                        {
-                                          "color": "#000",
-                                          "fontSize": 20,
-                                          "lineHeight": 26,
-                                          "textAlign": "left",
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        {
-                                          "color": "#fff",
-                                        },
-                                      ]
+                                      {
+                                        "height": "auto",
+                                        "maxWidth": "300px",
+                                        "width": "100%",
+                                      }
+                                    }
+                                    value="{"pop_token":""}"
+                                    viewBox="0 0 256 256"
+                                  />
+                                  <View
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3742fa",
+                                        "borderRadius": 100,
+                                        "bottom": "27.9%",
+                                        "display": "flex",
+                                        "justifyContent": "center",
+                                        "left": "27.9%",
+                                        "overflow": "hidden",
+                                        "padding": "4",
+                                        "position": "absolute",
+                                        "right": "27.9%",
+                                        "top": "27.9%",
+                                      }
                                     }
                                   >
-                                    Scan to add attendee
-                                  </Text>
+                                    <Text
+                                      style={
+                                        [
+                                          {
+                                            "color": "#000",
+                                            "fontSize": 20,
+                                            "lineHeight": 26,
+                                            "textAlign": "left",
+                                          },
+                                          {
+                                            "textAlign": "center",
+                                          },
+                                          {
+                                            "color": "#fff",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      Scan to add attendee
+                                    </Text>
+                                  </View>
                                 </View>
                               </View>
+                              <Text
+                                style={
+                                  [
+                                    {
+                                      "color": "#000",
+                                      "fontSize": 20,
+                                      "lineHeight": 26,
+                                      "marginBottom": 16,
+                                      "textAlign": "left",
+                                    },
+                                    {
+                                      "textAlign": "center",
+                                    },
+                                    {
+                                      "marginTop": 32,
+                                    },
+                                  ]
+                                }
+                              />
                             </View>
                             <View
                               style={
@@ -4635,74 +4698,95 @@ exports[`EventRollCall render correctly non organizers re-opened roll calls 1`] 
                             >
                               The Roll Call is currently open and you as an attendee should let the organizer scan your PoP token encoded in the QR Code below.
                             </Text>
-                            <View
-                              style={
-                                {
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                }
-                              }
-                            >
+                            <View>
                               <View
                                 style={
                                   {
-                                    "position": "relative",
+                                    "flexDirection": "row",
+                                    "justifyContent": "center",
                                   }
                                 }
                               >
-                                <qrcode
-                                  level="H"
-                                  size={256}
-                                  style={
-                                    {
-                                      "height": "auto",
-                                      "maxWidth": "300px",
-                                      "width": "100%",
-                                    }
-                                  }
-                                  value="{"pop_token":""}"
-                                  viewBox="0 0 256 256"
-                                />
                                 <View
                                   style={
                                     {
-                                      "alignItems": "center",
-                                      "backgroundColor": "#3742fa",
-                                      "borderRadius": 100,
-                                      "bottom": "27.9%",
-                                      "display": "flex",
-                                      "justifyContent": "center",
-                                      "left": "27.9%",
-                                      "overflow": "hidden",
-                                      "padding": "4",
-                                      "position": "absolute",
-                                      "right": "27.9%",
-                                      "top": "27.9%",
+                                      "position": "relative",
                                     }
                                   }
                                 >
-                                  <Text
+                                  <qrcode
+                                    level="H"
+                                    size={256}
                                     style={
-                                      [
-                                        {
-                                          "color": "#000",
-                                          "fontSize": 20,
-                                          "lineHeight": 26,
-                                          "textAlign": "left",
-                                        },
-                                        {
-                                          "textAlign": "center",
-                                        },
-                                        {
-                                          "color": "#fff",
-                                        },
-                                      ]
+                                      {
+                                        "height": "auto",
+                                        "maxWidth": "300px",
+                                        "width": "100%",
+                                      }
+                                    }
+                                    value="{"pop_token":""}"
+                                    viewBox="0 0 256 256"
+                                  />
+                                  <View
+                                    style={
+                                      {
+                                        "alignItems": "center",
+                                        "backgroundColor": "#3742fa",
+                                        "borderRadius": 100,
+                                        "bottom": "27.9%",
+                                        "display": "flex",
+                                        "justifyContent": "center",
+                                        "left": "27.9%",
+                                        "overflow": "hidden",
+                                        "padding": "4",
+                                        "position": "absolute",
+                                        "right": "27.9%",
+                                        "top": "27.9%",
+                                      }
                                     }
                                   >
-                                    Scan to add attendee
-                                  </Text>
+                                    <Text
+                                      style={
+                                        [
+                                          {
+                                            "color": "#000",
+                                            "fontSize": 20,
+                                            "lineHeight": 26,
+                                            "textAlign": "left",
+                                          },
+                                          {
+                                            "textAlign": "center",
+                                          },
+                                          {
+                                            "color": "#fff",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      Scan to add attendee
+                                    </Text>
+                                  </View>
                                 </View>
                               </View>
+                              <Text
+                                style={
+                                  [
+                                    {
+                                      "color": "#000",
+                                      "fontSize": 20,
+                                      "lineHeight": 26,
+                                      "marginBottom": 16,
+                                      "textAlign": "left",
+                                    },
+                                    {
+                                      "textAlign": "center",
+                                    },
+                                    {
+                                      "marginTop": 32,
+                                    },
+                                  ]
+                                }
+                              />
                             </View>
                             <View
                               style={


### PR DESCRIPTION
This PR makes that now the pop token is also displayed in clear text in case the organizer can't use his camera. I added some space between the qr code and the text in case the attendee doesn't want the organizer to see the text he can simply zoom on the qr code et let the text be outside of the screen. 

![image](https://github.com/dedis/popstellar/assets/82887324/17af0360-aaec-49ba-9772-1c8e87baba79)
