### PR TITLE
Setup environment for server-server tests

### DIFF
--- a/tests/karate/src/test/java/be/BackEndTest.java
+++ b/tests/karate/src/test/java/be/BackEndTest.java
@@ -11,29 +11,56 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class BackEndTest {
 
   /**
-   * This test will execute all back-end tests with the Go back-end
+   * This test will execute the tests for back-ends connected to a frontend with the Go back-end
    * It will not generate a clean report, but it can be used in development
    *
    * @return the Karate builder
    */
   @Karate.Test
-  Karate testGo() {
+  Karate testGoWithFrontend() {
     return Karate.run()
       .relativeTo(getClass())
-      .karateEnv("go");
+      .karateEnv("go_client");
+  }
+
+
+  /**
+   * This test will execute the tests for back-ends connected to another backend with the Go back-end
+   * It will not generate a clean report, but it can be used in development
+   *
+   * @return the Karate builder
+   */
+  @Karate.Test
+  Karate testGoWithServer() {
+    return Karate.run()
+      .relativeTo(getClass())
+      .karateEnv("go_server");
   }
 
   /**
-   * This test will execute all back-end tests with the Scala back-end
+   * This test will execute the tests for back-ends connected to a frontend with the Scala back-end
    * It will not generate a clean report, but it can be used in development
    *
    * @return the Karate builder
    */
   @Karate.Test
-  Karate testScala() {
+  Karate testScalaWithFrontend() {
     return Karate.run()
       .relativeTo(getClass())
-      .karateEnv("scala");
+      .karateEnv("scala_client");
+  }
+
+  /**
+   * This test will execute the tests for back-ends connected to another backend with the Scala back-end
+   * It will not generate a clean report, but it can be used in development
+   *
+   * @return the Karate builder
+   */
+  @Karate.Test
+  Karate testScalaWithServer() {
+    return Karate.run()
+      .relativeTo(getClass())
+      .karateEnv("scala_server");
   }
 
   /**

--- a/tests/karate/src/test/java/be/LAO/create.feature
+++ b/tests/karate/src/test/java/be/LAO/create.feature
@@ -1,4 +1,4 @@
-@env=go,scala
+@env=go_client,scala_client
 Feature: Create a pop LAO
 
   Background:

--- a/tests/karate/src/test/java/be/LAO/update.feature
+++ b/tests/karate/src/test/java/be/LAO/update.feature
@@ -1,4 +1,4 @@
-@env=go,scala
+@env=go_client,scala_client
 Feature: Update a LAO
 
   Background:

--- a/tests/karate/src/test/java/be/digitalCash/transaction.feature
+++ b/tests/karate/src/test/java/be/digitalCash/transaction.feature
@@ -1,4 +1,4 @@
-@env=go,scala
+@env=go_client,scala_client
 Feature: Simple Transactions for digital cash
   Background:
       # This feature will be called to test some simple transactions

--- a/tests/karate/src/test/java/be/election/castVote.feature
+++ b/tests/karate/src/test/java/be/election/castVote.feature
@@ -1,4 +1,4 @@
-@env=go,scala
+@env=go_client,scala_client
 Feature: Cast a vote
   Background:
         # This feature will be called to test Cast Vote

--- a/tests/karate/src/test/java/be/election/electionEnd.feature
+++ b/tests/karate/src/test/java/be/election/electionEnd.feature
@@ -1,4 +1,4 @@
-@env=go,scala
+@env=go_client,scala_client
 Feature: Terminate an election
   Background:
         # This feature will be called to test End Election

--- a/tests/karate/src/test/java/be/election/electionOpen.feature
+++ b/tests/karate/src/test/java/be/election/electionOpen.feature
@@ -1,4 +1,4 @@
-@env=go,scala
+@env=go_client,scala_client
 Feature: Open an Election
   Background:
         # This feature will be called to test Election Open

--- a/tests/karate/src/test/java/be/election/electionSetup.feature
+++ b/tests/karate/src/test/java/be/election/electionSetup.feature
@@ -1,4 +1,4 @@
-@env=go,scala
+@env=go_client,scala_client
 Feature: Setup an Election
   Background:
         # This feature will be called to test Election Setup

--- a/tests/karate/src/test/java/be/heartbeat/heartbeat.feature
+++ b/tests/karate/src/test/java/be/heartbeat/heartbeat.feature
@@ -1,4 +1,4 @@
-@env=go,scala
+@env=go_server,scala_server
 Feature: Send heartbeats to other servers
 
   Background:

--- a/tests/karate/src/test/java/be/rollCall/closeRollCall.feature
+++ b/tests/karate/src/test/java/be/rollCall/closeRollCall.feature
@@ -1,4 +1,4 @@
-@env=go,scala
+@env=go_client,scala_client
 Feature: Close a Roll Call
   Background:
         # This feature will be called to test Roll Call close
@@ -51,7 +51,7 @@ Feature: Close a Roll Call
         }
       """
     * frontend.changeSenderToBeNonAttendee()
-    When frontend.publish((validCloseRollCall, laoChannel)
+    When frontend.publish(validCloseRollCall, laoChannel)
     And json answer = frontend.getBackendResponse(validCloseRollCall)
     Then match answer contains INVALID_MESSAGE_FIELD
     And match frontend.receiveNoMoreResponses() == true

--- a/tests/karate/src/test/java/be/rollCall/createRollCall.feature
+++ b/tests/karate/src/test/java/be/rollCall/createRollCall.feature
@@ -1,4 +1,4 @@
-@env=go,scala
+@env=go_client,scala_client
 Feature: Create a Roll Call
   Background:
       # This feature will be called to test a Roll Call Creation

--- a/tests/karate/src/test/java/be/rollCall/openRollCall.feature
+++ b/tests/karate/src/test/java/be/rollCall/openRollCall.feature
@@ -1,4 +1,4 @@
-@env=go,scala
+@env=go_client,scala_client
 Feature: Roll Call Open
   Background:
         # This feature will be called to test Roll call open

--- a/tests/karate/src/test/java/be/utils/server.feature
+++ b/tests/karate/src/test/java/be/utils/server.feature
@@ -22,9 +22,9 @@ Feature: This feature starts a server and stops it after every scenario.
     * def getServer =
             """
                 function() {
-                    if(env == 'go')
+                    if(env == 'go_client' || env == 'go_server')
                         return new GoServer();
-                    else if(env == 'scala')
+                    else if(env == 'scala_client' || env == 'scala_server')
                         return new ScalaServer();
                     else
                         karate.fail("Unknown environment for server");

--- a/tests/karate/src/test/java/common/net/MultiMsgWebSocketClient.java
+++ b/tests/karate/src/test/java/common/net/MultiMsgWebSocketClient.java
@@ -143,6 +143,10 @@ public class MultiMsgWebSocketClient extends WebSocketClient {
     return messages;
   }
 
+  /**
+   * Method to check that no more responses are send by the server, ignores heartbeat messages.
+   * @return true if no more responses or only a heartbeat was received.
+   */
   public boolean receiveNoMoreResponses(){
     String result = getBuffer().takeTimeout(5000);
     return result == null;

--- a/tests/karate/src/test/java/karate-config.js
+++ b/tests/karate/src/test/java/karate-config.js
@@ -2,7 +2,7 @@ function fn() {
   var env = karate.env; // get system property 'karate.env'
   karate.log('karate.env system property was:', env);
   if (!env) {
-    env = 'go'
+    env = 'go_client'
   }
   karate.log('karate.env system property is set to', env);
   var config = {
@@ -14,13 +14,25 @@ function fn() {
     timeout: 5000, //Timeout for websocket response
     args: [],
   }
-  if (env === 'go') {
+  if (env === 'go_client') {
     // customize
     config.host = '127.0.0.1';
     config.port = 9000;
     config.path = 'client';
     config.wsURL = `ws://${config.host}:${config.port}/${config.path}`;
-  } else if (env === 'scala') {
+  } else if (env === 'go_server') {
+    // customize
+    config.host = '127.0.0.1';
+    config.port = 9001;
+    config.path = 'server';
+    config.wsURL = `ws://${config.host}:${config.port}/${config.path}`;
+  } else if (env === 'scala_client') {
+    // customize
+    config.host = '127.0.0.1';
+    config.port = 8000;
+    config.path = 'client';
+    config.wsURL = `ws://${config.host}:${config.port}/${config.path}`;
+  } else if (env === 'scala_server') {
     // customize
     config.host = '127.0.0.1';
     config.port = 8000;


### PR DESCRIPTION
Set up the environment so that heartbeat tests are only run when connected as a server and all other tests when connected as a frontend.