### PR TITLE
Fine-tune Decentralized communications

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/GetMessagesByIdResponseHandler.scala
@@ -19,7 +19,7 @@ import scala.concurrent.Await
 // When receiving the missing messages, the server's job is to write them on the database.
 object GetMessagesByIdResponseHandler extends AskPatternConstants {
 
-  private val MAX_RETRY_PER_MESSAGE = 5
+  private val MAX_RETRY_PER_MESSAGE = 10
   private val SUCCESS = 0
 
   /** Validate and replay on the system each message received in the get_messages_by_id result


### PR DESCRIPTION
Two things in this pr: 

`GetMessagesByIdResponseHanlder`:
The validation has changed so that instead of retrying a certain amount of time per channel, each message has its own counter. 

`ConnectionMediator`: 
Prevent it to connect to the same urls upon change in the config. The behavior is not perfect as for now there is no link between clientActorRef and their urls. `GreetServer` will be helpful in that regard.