### PR TITLE
Fix CI tests and general concurrency issues + avoid spam of lao connecting

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/MessageGeneral.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/MessageGeneral.java
@@ -120,6 +120,32 @@ public final class MessageGeneral {
     return true;
   }
 
+  public boolean isEmpty() {
+    return this.equals(EMPTY);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MessageGeneral that = (MessageGeneral) o;
+    return Objects.equals(sender, that.sender)
+        && Objects.equals(dataBuf, that.dataBuf)
+        && Objects.equals(data, that.data)
+        && Objects.equals(messageId, that.messageId)
+        && Objects.equals(signature, that.signature)
+        && Objects.equals(witnessSignatures, that.witnessSignatures);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sender, dataBuf, data, messageId, signature, witnessSignatures);
+  }
+
   @NonNull
   @Override
   public String toString() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/DigitalCashRepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/DigitalCashRepository.java
@@ -3,6 +3,7 @@ package com.github.dedis.popstellar.repository;
 import android.app.Activity;
 import android.app.Application;
 
+import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
 
 import com.github.dedis.popstellar.model.objects.OutputObject;
@@ -14,6 +15,8 @@ import com.github.dedis.popstellar.utility.ActivityUtils;
 import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -21,7 +24,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import io.reactivex.Observable;
-import io.reactivex.Observer;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
@@ -51,29 +53,65 @@ public class DigitalCashRepository {
         ActivityUtils.buildLifecycleCallback(consumerMap));
   }
 
+  /**
+   * Get the list of transactions that a given user has performed.
+   *
+   * @param laoId of the lao the transactions are part of
+   * @param user public key
+   * @return a list of transaction objects
+   */
   public List<TransactionObject> getTransactions(String laoId, PublicKey user) {
     return getLaoTransactions(laoId).getTransactions(user);
   }
 
+  /**
+   * This returns an observable on the list of transactions that a given user performs.
+   *
+   * @param laoId of the lao the transactions are part of
+   * @param user public key
+   * @return an observable that is notified whenever a new transaction is added/updated
+   */
   public Observable<List<TransactionObject>> getTransactionsObservable(
       String laoId, PublicKey user) {
     return getLaoTransactions(laoId).getTransactionsObservable(user);
   }
 
+  /**
+   * The function returns the user balance in miniLAOs based on the transactions he's involved into.
+   *
+   * @param laoId of the lao the transactions are part of
+   * @param user public key
+   * @return miniLAOs amount as long
+   */
   public long getUserBalance(String laoId, PublicKey user) {
     return getLaoTransactions(laoId).getUserBalance(user);
   }
 
+  /**
+   * This updates and persist a transaction in a digital cash state of a lao.
+   *
+   * @param laoId of the lao the transaction is part of
+   * @param transaction digital cash transaction to add
+   * @throws NoRollCallException if no roll call attendees is found
+   */
   public void updateTransactions(String laoId, TransactionObject transaction)
       throws NoRollCallException {
     Timber.tag(TAG).d("updating transactions on Lao %s and transaction %s", laoId, transaction);
     getLaoTransactions(laoId).updateTransactions(transaction, true);
   }
 
+  /**
+   * This function initializes the digital cash for a given lao. This happens after a rollcall is
+   * closed to reset the previous state and add the current attendees.
+   *
+   * @param laoId of the lao whose digital cash we are looking for
+   * @param attendees set of public keys of the attendees the the last closed roll call
+   */
   public void initializeDigitalCash(String laoId, List<PublicKey> attendees) {
     getLaoTransactions(laoId).initializeDigitalCash(attendees);
   }
 
+  @NonNull
   private synchronized LaoTransactions getLaoTransactions(String laoId) {
     // Create the lao transactions object if it is not present yet
     return transactionsByLao.computeIfAbsent(laoId, lao -> new LaoTransactions(laoId, this));
@@ -83,24 +121,33 @@ public class DigitalCashRepository {
 
     private final String laoId;
     private final DigitalCashRepository repository;
-    private boolean alreadyRetrieved = false;
 
-    private final Map<PublicKey, List<TransactionObject>> transactions = new HashMap<>();
-    private final Map<PublicKey, Subject<List<TransactionObject>>> transactionsSubject =
-        new HashMap<>();
-    private final Map<String, PublicKey> hashDictionary = new HashMap<>();
+    /**
+     * Thread-safe map that maps the users' public keys to a thread-safe list of transactions which
+     * they have been involved into (either senders or receivers)
+     */
+    private final ConcurrentHashMap<PublicKey, ConcurrentLinkedQueue<TransactionObject>>
+        transactions = new ConcurrentHashMap<>();
+
+    /** Thread-safe map that maps the users' public keys to the observable on their transactions */
+    private final ConcurrentHashMap<PublicKey, Subject<List<TransactionObject>>>
+        transactionsSubject = new ConcurrentHashMap<>();
+
+    /** Thread-safe dictionary to maps the hash to the user's public key */
+    private final ConcurrentHashMap<String, PublicKey> hashDictionary = new ConcurrentHashMap<>();
 
     public LaoTransactions(String laoId, DigitalCashRepository repository) {
       this.laoId = laoId;
       this.repository = repository;
+      loadLaoState();
     }
 
     /**
-     * This resets the digital cash state. This should be called each time a rc is closed
+     * This resets the digital cash state. This function is called each time a rc is closed.
      *
      * @param attendees the attendees of the closed roll call
      */
-    public synchronized void initializeDigitalCash(List<PublicKey> attendees) {
+    public void initializeDigitalCash(List<PublicKey> attendees) {
       Timber.tag(TAG).d("initializing digital cash with attendees %s", attendees);
 
       // Clear the transactions on the database for the given lao
@@ -117,8 +164,9 @@ public class DigitalCashRepository {
 
       // Clear the memory
       hashDictionary.clear();
-      transactionsSubject.values().forEach(Observer::onComplete);
+      transactions.clear();
       transactionsSubject.clear();
+      transactionsSubject.values().forEach(observer -> observer.toSerialized().onComplete());
 
       // Reset the hash dictionary
       List<HashEntity> hashEntities = new ArrayList<>();
@@ -127,12 +175,11 @@ public class DigitalCashRepository {
             String hash = publicKey.computeHash();
             hashDictionary.put(hash, publicKey);
             // Save the mapping in a list
-            HashEntity hashEntity = new HashEntity(hash, laoId, publicKey);
-            hashEntities.add(hashEntity);
+            hashEntities.add(new HashEntity(hash, laoId, publicKey));
           });
 
-      // Save all the entries at once to minimize I/O accesses but ensure to delete before adding
-      // the new entries
+      // Save all the entries at once to minimize I/O accesses
+      // Ensure to delete before adding the new entries
       repository.disposables.add(
           repository
               .hashDao
@@ -146,7 +193,7 @@ public class DigitalCashRepository {
                     repository.disposables.add(
                         repository
                             .hashDao
-                            .insert(hashEntities)
+                            .insertAll(hashEntities)
                             .subscribeOn(Schedulers.io())
                             .observeOn(AndroidSchedulers.mainThread())
                             .subscribe(
@@ -167,14 +214,43 @@ public class DigitalCashRepository {
                           .e(err, "Error in clearing the hash dictionary for lao %s", laoId)));
     }
 
-    public synchronized void updateTransactions(TransactionObject transaction, boolean toBeStored)
+    public void updateTransactions(TransactionObject transaction, boolean toBeStored)
         throws NoRollCallException {
       if (hashDictionary.isEmpty()) {
         throw new NoRollCallException("No roll call attendees could be found");
       }
 
+      for (PublicKey current : getReceiversTransaction(transaction)) {
+        ConcurrentLinkedQueue<TransactionObject> transactionList = transactions.get(current);
+
+        if (transactionList == null) {
+          transactionList = new ConcurrentLinkedQueue<>();
+          transactionList.add(transaction);
+
+          // An empty subject might have been created already
+          if (transactionsSubject.containsKey(current)) {
+            // Updating subject
+            Objects.requireNonNull(transactionsSubject.get(current))
+                .toSerialized()
+                .onNext(new ArrayList<>(transactionList));
+          } else {
+            // Creating new subject
+            transactionsSubject.put(
+                current, BehaviorSubject.createDefault(new ArrayList<>(transactionList)));
+          }
+
+          // Add it to the map
+          transactions.put(current, transactionList);
+        } else if (!transactionList.contains(transaction)) {
+          transactionList.add(transaction);
+          Objects.requireNonNull(transactionsSubject.get(current))
+              .toSerialized()
+              .onNext(new ArrayList<>(transactionList));
+        }
+      }
+
+      // Store the transaction in the db if the flag is true
       if (toBeStored) {
-        // Store it in the db if the flag is true
         TransactionEntity transactionEntity = new TransactionEntity(laoId, transaction);
         repository.disposables.add(
             repository
@@ -195,39 +271,15 @@ public class DigitalCashRepository {
                                 "Error in persisting the transaction %s",
                                 transaction.getTransactionId())));
       }
-
-      for (PublicKey current : getReceiversTransaction(transaction)) {
-        List<TransactionObject> transactionList = transactions.get(current);
-
-        if (transactionList == null) {
-          // Unfortunately without Java 9 one can't use List.of(...) :(
-          transactionList = new ArrayList<>();
-          transactionList.add(transaction);
-
-          // An empty subject might have been created already
-          if (transactionsSubject.containsKey(current)) {
-            // Updating subject
-            transactionsSubject.get(current).onNext(transactionList);
-          } else {
-            // Creating new subject
-            transactionsSubject.put(current, BehaviorSubject.createDefault(transactionList));
-          }
-        } else if (!transactionList.contains(transaction)) {
-          transactionList.add(transaction);
-          transactionsSubject.get(current).onNext(transactionList);
-        }
-        transactions.put(current, new ArrayList<>(transactionList));
-      }
     }
 
     public Observable<List<TransactionObject>> getTransactionsObservable(PublicKey user) {
-      loadLaoState();
       return transactionsSubject.computeIfAbsent(
           user, newUser -> BehaviorSubject.createDefault(new ArrayList<>()));
     }
 
     public List<TransactionObject> getTransactions(PublicKey user) {
-      List<TransactionObject> transactionList = transactions.get(user);
+      ConcurrentLinkedQueue<TransactionObject> transactionList = transactions.get(user);
       return transactionList == null ? null : new ArrayList<>(transactionList);
     }
 
@@ -248,7 +300,7 @@ public class DigitalCashRepository {
     }
 
     public long getUserBalance(PublicKey user) {
-      List<TransactionObject> transactionList = transactions.get(user);
+      ConcurrentLinkedQueue<TransactionObject> transactionList = transactions.get(user);
       return transactionList == null
           ? 0
           : transactionList.stream()
@@ -262,9 +314,6 @@ public class DigitalCashRepository {
      * accesses such LAO's digital cash section.
      */
     private void loadLaoState() {
-      if (alreadyRetrieved) {
-        return;
-      }
       repository.disposables.add(
           repository
               .hashDao
@@ -306,7 +355,6 @@ public class DigitalCashRepository {
                                         .e(err, "No transaction to load for lao %s", laoId)));
                   },
                   err -> Timber.tag(TAG).e(err, "No hash dictionary to load for lao %s", laoId)));
-      alreadyRetrieved = true;
     }
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/LAORepository.java
@@ -36,15 +36,14 @@ public class LAORepository {
 
   private final LAODao laoDao;
 
+  /** Thread-safe map used to store the laos by their unique identifiers */
   private final ConcurrentHashMap<String, Lao> laoById = new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<String, Subject<LaoView>> subjectById = new ConcurrentHashMap<>();
-  private final BehaviorSubject<List<String>> laosSubject = BehaviorSubject.create();
 
-  // ============ Lao Unrelated data ===============
-  // State for Messages
-  // Observable for view models that need access to all Nodes
-  private final Map<Channel, BehaviorSubject<List<ConsensusNode>>> channelToNodesSubject =
-      new HashMap<>();
+  /** Thread-safe map that maps a lao identifier to an observable over its lao view */
+  private final ConcurrentHashMap<String, Subject<LaoView>> subjectById = new ConcurrentHashMap<>();
+
+  /** Observable over the list of laos' identifiers */
+  private final BehaviorSubject<List<String>> laosSubject = BehaviorSubject.create();
 
   private final CompositeDisposable disposables = new CompositeDisposable();
 
@@ -83,7 +82,7 @@ public class LAORepository {
                             lao.getId(), BehaviorSubject.createDefault(new LaoView(lao)));
                       });
                   List<String> laoIds = laos.stream().map(Lao::getId).collect(Collectors.toList());
-                  laosSubject.onNext(laoIds);
+                  laosSubject.toSerialized().onNext(laoIds);
                   Timber.tag(TAG).d("Loaded all the LAOs from database: %s", laoIds);
                 },
                 err -> Timber.tag(TAG).e(err, "Error loading the LAOs from the database")));
@@ -142,7 +141,7 @@ public class LAORepository {
     return getLaoView(channel.extractLaoId());
   }
 
-  public synchronized void updateLao(Lao lao) {
+  public void updateLao(Lao lao) {
     Timber.tag(TAG).d("Updating Lao %s", lao);
     if (lao == null) {
       throw new IllegalArgumentException();
@@ -167,30 +166,32 @@ public class LAORepository {
       // Update observer if present
       Subject<LaoView> subject = subjectById.get(lao.getId());
       if (subject != null) {
-        subject.onNext(laoView);
+        subject.toSerialized().onNext(laoView);
       }
     } else {
       // Otherwise, create the entry
       laoById.put(lao.getId(), lao);
       // Update lao list
-      laosSubject.onNext(new ArrayList<>(laoById.keySet()));
+      laosSubject.toSerialized().onNext(new ArrayList<>(laoById.keySet()));
       subjectById.put(lao.getId(), BehaviorSubject.createDefault(laoView));
     }
   }
 
-  /**
-   * This function removes from the home all the laos displayed when the user wants to clear the
-   * data storage. The maps are automatically cleared by the intent flags.
-   */
+  /** This function clears the repository */
   public void clearRepository() {
-    Timber.tag(TAG).d("Clearing LAORepository");
+    Timber.tag(TAG).d("Clearing LAORepository...");
     laoById.clear();
     subjectById.clear();
-    laosSubject.onNext(new ArrayList<>());
+    laosSubject.toSerialized().onNext(new ArrayList<>());
   }
 
-  // ============ Lao Unrelated functions ===============
+  // ============ Lao Unrelated data ===============
+  // State for Messages
+  // Observable for view models that need access to all Nodes
+  private final Map<Channel, BehaviorSubject<List<ConsensusNode>>> channelToNodesSubject =
+      new HashMap<>();
 
+  // ============ Lao Unrelated functions ===============
   /**
    * Return an Observable to the list of nodes in a given channel.
    *

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/MessageRepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/MessageRepository.java
@@ -13,7 +13,9 @@ import com.github.dedis.popstellar.repository.database.message.MessageDao;
 import com.github.dedis.popstellar.repository.database.message.MessageEntity;
 import com.github.dedis.popstellar.utility.ActivityUtils;
 
-import java.util.*;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 import javax.inject.Inject;
@@ -30,15 +32,25 @@ public class MessageRepository {
   private static final String TAG = MessageRepository.class.getSimpleName();
 
   /** Size of the LRU cache */
-  private static final int CACHED_MESSAGES = 150;
+  private static final int CACHED_MESSAGES = 100;
 
   /**
-   * Ephemeral messages are all those messages which are not needed to be persisted. So far only the
-   * laos messages are persistent, but they will be extended in the future
+   * Ephemeral messages are all those messages which are not needed to be persisted on the disk, so
+   * they're only stored in memory. The messages persisted can be found in the Objects class, see
+   * {@link
+   * com.github.dedis.popstellar.model.network.method.message.data.Objects#hasToBePersisted())}
+   *
+   * <p>Other messages on the other hand are persisted, but only with their ids, as this is what is
+   * used to avoid reprocessing, as the relative object have already been processed and added to the
+   * other repositories. The messages for which we store the actual content can be found here {@link
+   * com.github.dedis.popstellar.model.network.method.message.data.Action#isStoreNeededByAction())}
    */
-  private final Map<MessageID, MessageGeneral> ephemeralMessages = new HashMap<>();
+  private final ConcurrentHashMap<MessageID, MessageGeneral> ephemeralMessages =
+      new ConcurrentHashMap<>();
 
+  /** Cache for efficient lookups and for avoiding I/O operations */
   private final LruCache<MessageID, MessageGeneral> messageCache = new LruCache<>(CACHED_MESSAGES);
+
   private final MessageDao messageDao;
 
   private final CompositeDisposable disposables = new CompositeDisposable();
@@ -50,6 +62,7 @@ public class MessageRepository {
     consumerMap.put(Lifecycle.Event.ON_STOP, activity -> disposables.clear());
     application.registerActivityLifecycleCallbacks(
         ActivityUtils.buildLifecycleCallback(consumerMap));
+    // Full the cache at starting time
     loadCache();
   }
 
@@ -67,13 +80,18 @@ public class MessageRepository {
                             messageCache.put(
                                 msg.getMessageId(),
                                 // Cache doesn't accept null as value, so an empty message is used
-                                // instead
                                 msg.getContent() == null
                                     ? MessageGeneral.emptyMessage()
                                     : msg.getContent())),
                 err -> Timber.tag(TAG).e(err, "Error loading message repository cache")));
   }
 
+  /**
+   * This function gets a message from the repository given its unique identifier.
+   *
+   * @param messageID identifier of the message to retrieve
+   * @return the message if present, null if absent
+   */
   public MessageGeneral getMessage(MessageID messageID) {
     // Check if it's an ephemeral message, so no need to look up in the db
     MessageGeneral ephemeralMessage = ephemeralMessages.get(messageID);
@@ -82,9 +100,11 @@ public class MessageRepository {
     }
 
     // Retrieve from cache if present
-    MessageGeneral cachedMessage = messageCache.get(messageID);
-    if (cachedMessage != null) {
-      return cachedMessage;
+    synchronized (messageCache) {
+      MessageGeneral cachedMessage = messageCache.get(messageID);
+      if (cachedMessage != null) {
+        return cachedMessage;
+      }
     }
 
     // Search in the db
@@ -92,7 +112,9 @@ public class MessageRepository {
     if (messageEntity != null) {
       MessageGeneral messageGeneral = messageEntity.getContent();
       // Put it into cache
-      messageCache.put(messageID, messageGeneral);
+      synchronized (messageCache) {
+        messageCache.put(messageID, messageGeneral);
+      }
       return messageGeneral;
     }
 
@@ -103,28 +125,32 @@ public class MessageRepository {
    * This function adds a message to the repository.
    *
    * @param message message to add to the repository
-   * @param isStoringNeeded boolean that specifies whether the content of the message is useful to
+   * @param isContentNeeded boolean that specifies whether the content of the message is useful to
    *     be stored (true) or if it's not needed and memory could be saved (false)
    * @param toPersist boolean that specifies whether the message has to be persisted and saved in
    *     the db (true) or only loaded in memory (false)
    */
-  public void addMessage(MessageGeneral message, boolean isStoringNeeded, boolean toPersist) {
+  public void addMessage(MessageGeneral message, boolean isContentNeeded, boolean toPersist) {
     MessageID messageID = message.getMessageId();
-    if (!isStoringNeeded) {
+    if (!isContentNeeded) {
       // No need to store the content of the message, just the id is needed
-      message = null;
+      // However the cache and the concurrent hash map don't accept null value
+      // Thus we use an empty messages that is light-weight (whose ref is also shared)
+      message = MessageGeneral.emptyMessage();
     }
 
     if (!toPersist) {
       ephemeralMessages.put(messageID, message);
     } else {
       // Add the message to the cache (cache cannot accept a null value)
-      messageCache.put(messageID, message == null ? MessageGeneral.emptyMessage() : message);
+      synchronized (messageCache) {
+        messageCache.put(messageID, message);
+      }
 
       // Add asynchronously the messages to the database
       disposables.add(
           messageDao
-              .insert(new MessageEntity(messageID, message))
+              .insert(new MessageEntity(messageID, message.isEmpty() ? null : message))
               .subscribeOn(Schedulers.io())
               .observeOn(AndroidSchedulers.mainThread())
               .subscribe(
@@ -133,6 +159,15 @@ public class MessageRepository {
     }
   }
 
+  /**
+   * This function searches if a given message is stored in the repository. This is used to avoid
+   * message reprocessing.
+   *
+   * @param messageID identifier of the message
+   * @param isPersisted boolean that specifies whether the message should be searched only in the
+   *     memory (if false), or also in the disk (if true)
+   * @return true if the message is present, false otherwise
+   */
   public boolean isMessagePresent(MessageID messageID, boolean isPersisted) {
     // Avoid I/O operation if it's an ephemeral message
     if (!isPersisted) {
@@ -140,9 +175,11 @@ public class MessageRepository {
     }
 
     // Check if it's already in cache
-    MessageGeneral messageGeneral = messageCache.get(messageID);
-    if (messageGeneral != null) {
-      return true;
+    synchronized (messageCache) {
+      MessageGeneral messageGeneral = messageCache.get(messageID);
+      if (messageGeneral != null) {
+        return true;
+      }
     }
 
     // Otherwise perform an I/O operation

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/RollCallRepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/RollCallRepository.java
@@ -16,6 +16,7 @@ import com.github.dedis.popstellar.utility.error.UnknownRollCallException;
 import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -58,7 +59,7 @@ public class RollCallRepository {
   }
 
   /**
-   * This either updates the roll call in the repository or adds it if absent
+   * This either updates the roll call in the repository or adds it if absent.
    *
    * @param rollCall the roll call to update/add
    */
@@ -71,11 +72,10 @@ public class RollCallRepository {
     }
     Timber.tag(TAG).d("Updating roll call on lao %s : %s", laoId, rollCall);
 
-    RollCallEntity rollCallEntity = new RollCallEntity(laoId, rollCall);
     // Persist the rollcall
     disposables.add(
         rollCallDao
-            .insert(rollCallEntity)
+            .insert(new RollCallEntity(laoId, rollCall))
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(
@@ -103,17 +103,35 @@ public class RollCallRepository {
     return getLaoRollCalls(laoId).getRollCallObservable(persistentId);
   }
 
+  /**
+   * This function retrieves a roll call from the repository given its persistent identifier.
+   *
+   * @param laoId the id of the Lao
+   * @param persistentId the persistent id of the roll call
+   * @return the roll call matching the identifier in the lao
+   * @throws UnknownRollCallException if no roll call with the provided id could be found
+   */
   public RollCall getRollCallWithPersistentId(String laoId, String persistentId)
       throws UnknownRollCallException {
     return getLaoRollCalls(laoId).getRollCallWithPersistentId(persistentId);
   }
 
+  /**
+   * This function retrieves a roll call from the repository given its ephemeral identifier.
+   *
+   * @param laoId the id of the Lao
+   * @param rollCallId the id of the roll call
+   * @return the roll call matching the identifier in the lao
+   * @throws UnknownRollCallException if no roll call with the provided id could be found
+   */
   public RollCall getRollCallWithId(String laoId, String rollCallId)
       throws UnknownRollCallException {
     return getLaoRollCalls(laoId).getRollCallWithId(rollCallId);
   }
 
   /**
+   * Returns an observable over the set of the roll calls in a given lao.
+   *
    * @param laoId the id of the Lao whose roll calls we want to observe
    * @return an observable set of ids who correspond to the set of roll calls published on the given
    *     lao
@@ -132,16 +150,18 @@ public class RollCallRepository {
     return getLaoRollCalls(laoId).getAllAttendees();
   }
 
+  /**
+   * Returns the last closed roll call on a temporal basis.
+   *
+   * @param laoId the id of the considered lao
+   * @return the roll call that has been the last one to be closed
+   * @throws NoRollCallException if no roll call in the lao is found
+   */
   public RollCall getLastClosedRollCall(String laoId) throws NoRollCallException {
     return getLaoRollCalls(laoId).rollCallByPersistentId.values().stream()
         .filter(RollCall::isClosed)
         .max(Comparator.comparing(RollCall::getEnd))
         .orElseThrow(() -> new NoRollCallException(laoId));
-  }
-
-  @NonNull
-  private synchronized LaoRollCalls getLaoRollCalls(String laoId) {
-    return rollCallsByLao.computeIfAbsent(laoId, lao -> new LaoRollCalls(this, laoId));
   }
 
   /**
@@ -155,27 +175,37 @@ public class RollCallRepository {
         .noneMatch(RollCall::isOpen);
   }
 
+  @NonNull
+  private synchronized LaoRollCalls getLaoRollCalls(String laoId) {
+    return rollCallsByLao.computeIfAbsent(laoId, lao -> new LaoRollCalls(this, laoId));
+  }
+
   private static final class LaoRollCalls {
     private final RollCallRepository repository;
     private final String laoId;
-    private boolean alreadyRetrieved = false;
 
-    private final Map<String, RollCall> rollCallByPersistentId = new HashMap<>();
+    /** Thread-safe mapping between a roll call persistent id and its object reference */
+    private final ConcurrentHashMap<String, RollCall> rollCallByPersistentId =
+        new ConcurrentHashMap<>();
 
-    // This maps a roll call id, which is state dependant,
-    // to its persistentId which is fixed at creation
-    private final Map<String, String> rollCallIdAlias = new HashMap<>();
+    /**
+     * Thread-safe mapping between the roll call ephemeral id (state dependant) and its persistent
+     * id, fixed at creation instead
+     */
+    private final ConcurrentHashMap<String, String> rollCallIdAlias = new ConcurrentHashMap<>();
 
-    // This allows to observe a specific roll call(s)
-    private final Map<String, Subject<RollCall>> rollCallSubjects = new HashMap<>();
+    /** Thread-safe map which maps a roll call persistent id to an observable over itself */
+    private final ConcurrentHashMap<String, Subject<RollCall>> rollCallSubjects =
+        new ConcurrentHashMap<>();
 
-    // This allows to observe the collection of roll calls as a whole
+    /** Observable over the whole set of roll calls */
     private final Subject<Set<RollCall>> rollCallsSubject =
         BehaviorSubject.createDefault(unmodifiableSet(emptySet()));
 
     public LaoRollCalls(RollCallRepository repository, String laoId) {
       this.repository = repository;
       this.laoId = laoId;
+      loadStorage();
     }
 
     /**
@@ -183,7 +213,7 @@ public class RollCallRepository {
      *
      * @param rollCall the roll call to update/add
      */
-    public synchronized void update(RollCall rollCall) {
+    public void update(RollCall rollCall) {
       // Updating repo data
       String persistentId = rollCall.getPersistentId();
       rollCallByPersistentId.put(persistentId, rollCall);
@@ -195,14 +225,16 @@ public class RollCallRepository {
       if (rollCallSubjects.containsKey(persistentId)) {
         // If it exist we update the subject
         Timber.tag(TAG).d("Updating existing roll call %s", rollCall.getName());
-        rollCallSubjects.get(persistentId).onNext(rollCall);
+        Objects.requireNonNull(rollCallSubjects.get(persistentId)).toSerialized().onNext(rollCall);
       } else {
         // If it does not, we create a new subject
         Timber.tag(TAG).d("New roll call, subject created for %s", rollCall.getName());
         rollCallSubjects.put(persistentId, BehaviorSubject.createDefault(rollCall));
       }
 
-      rollCallsSubject.onNext(unmodifiableSet(new HashSet<>(this.rollCallByPersistentId.values())));
+      rollCallsSubject
+          .toSerialized()
+          .onNext(unmodifiableSet(new HashSet<>(this.rollCallByPersistentId.values())));
     }
 
     public RollCall getRollCallWithPersistentId(String persistentId)
@@ -231,7 +263,6 @@ public class RollCallRepository {
     }
 
     public Observable<Set<RollCall>> getRollCallsSubject() {
-      loadStorage();
       return rollCallsSubject;
     }
 
@@ -248,13 +279,10 @@ public class RollCallRepository {
      * just needed one time only at creation.
      */
     private void loadStorage() {
-      if (alreadyRetrieved) {
-        return;
-      }
       repository.disposables.add(
           repository
               .rollCallDao
-              .getRollCallsByLaoId(laoId, rollCallByPersistentId.keySet())
+              .getRollCallsByLaoId(laoId)
               .subscribeOn(Schedulers.io())
               .observeOn(AndroidSchedulers.mainThread())
               .subscribe(
@@ -268,7 +296,6 @@ public class RollCallRepository {
                   err ->
                       Timber.tag(TAG)
                           .e(err, "No rollcall found in the storage for lao %s", laoId)));
-      alreadyRetrieved = true;
     }
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/RollCallRepository.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/RollCallRepository.java
@@ -117,7 +117,7 @@ public class RollCallRepository {
   }
 
   /**
-   * This function retrieves a roll call from the repository given its ephemeral identifier.
+   * This function retrieves a roll call from the repository given its state-dependent identifier.
    *
    * @param laoId the id of the Lao
    * @param rollCallId the id of the roll call

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/database/digitalcash/HashDao.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/database/digitalcash/HashDao.java
@@ -11,7 +11,7 @@ import io.reactivex.Single;
 public interface HashDao {
 
   @Insert(onConflict = OnConflictStrategy.REPLACE)
-  Completable insert(List<HashEntity> hashEntity);
+  Completable insertAll(List<HashEntity> hashEntity);
 
   @Query("SELECT * FROM hash_dictionary WHERE lao_id = :laoId")
   Single<List<HashEntity>> getDictionaryByLaoId(String laoId);

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/database/event/election/ElectionDao.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/database/event/election/ElectionDao.java
@@ -5,7 +5,6 @@ import androidx.room.*;
 import com.github.dedis.popstellar.model.objects.Election;
 
 import java.util.List;
-import java.util.Set;
 
 import io.reactivex.Completable;
 import io.reactivex.Single;
@@ -17,15 +16,11 @@ public interface ElectionDao {
   Completable insert(ElectionEntity electionEntity);
 
   /**
-   * This function is a query execution to search for elections that match a given lao but have
-   * their ids different from a specified set to exclude (this represents the elections already in
-   * memory and useless to retrieve).
+   * This function is a query execution to search for elections that are contained in a given lao.
    *
    * @param laoId identifier of the lao where to search the elections
-   * @param filteredIds ids of the election to exclude from the search
    * @return an emitter of a list of elections
    */
-  @Query(
-      "SELECT election FROM elections WHERE lao_id = :laoId AND election_id NOT IN (:filteredIds)")
-  Single<List<Election>> getElectionsByLaoId(String laoId, Set<String> filteredIds);
+  @Query("SELECT election FROM elections WHERE lao_id = :laoId")
+  Single<List<Election>> getElectionsByLaoId(String laoId);
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/database/event/meeting/MeetingDao.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/database/event/meeting/MeetingDao.java
@@ -5,7 +5,6 @@ import androidx.room.*;
 import com.github.dedis.popstellar.model.objects.Meeting;
 
 import java.util.List;
-import java.util.Set;
 
 import io.reactivex.Completable;
 import io.reactivex.Single;
@@ -17,14 +16,11 @@ public interface MeetingDao {
   Completable insert(MeetingEntity meetingEntity);
 
   /**
-   * This function is a query execution to search for meetings that match a given lao but have their
-   * ids different from a specified set to exclude (this represents the meetings already in memory
-   * and useless to retrieve).
+   * This function is a query execution to search for meetings that are contained in a given lao.
    *
    * @param laoId identifier of the lao where to search the meetings
-   * @param filteredIds ids of the meetings to exclude from the search
    * @return an emitter of a list of meetings
    */
-  @Query("SELECT meeting FROM meetings WHERE lao_id = :laoId AND meeting_id NOT IN (:filteredIds)")
-  Single<List<Meeting>> getMeetingsByLaoId(String laoId, Set<String> filteredIds);
+  @Query("SELECT meeting FROM meetings WHERE lao_id = :laoId")
+  Single<List<Meeting>> getMeetingsByLaoId(String laoId);
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/database/event/rollcall/RollCallDao.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/database/event/rollcall/RollCallDao.java
@@ -5,7 +5,6 @@ import androidx.room.*;
 import com.github.dedis.popstellar.model.objects.RollCall;
 
 import java.util.List;
-import java.util.Set;
 
 import io.reactivex.Completable;
 import io.reactivex.Single;
@@ -17,15 +16,11 @@ public interface RollCallDao {
   Completable insert(RollCallEntity rollCallEntity);
 
   /**
-   * This function is a query execution to search for rollcalls that match a given lao but have
-   * their ids different from a specified set to exclude (this represents the rollcalls already in
-   * memory and useless to retrieve).
+   * This function is a query execution to search for rollcalls in a given lao.
    *
    * @param laoId identifier of the lao where to search the rollcalls
-   * @param filteredIds ids of the rollcall to exclude from the search
    * @return an emitter of a list of rollcalls
    */
-  @Query(
-      "SELECT rollcall FROM rollcalls WHERE lao_id = :laoId AND rollcall_id NOT IN (:filteredIds)")
-  Single<List<RollCall>> getRollCallsByLaoId(String laoId, Set<String> filteredIds);
+  @Query("SELECT rollcall FROM rollcalls WHERE lao_id = :laoId")
+  Single<List<RollCall>> getRollCallsByLaoId(String laoId);
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/database/socialmedia/ChirpDao.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/database/socialmedia/ChirpDao.java
@@ -3,10 +3,8 @@ package com.github.dedis.popstellar.repository.database.socialmedia;
 import androidx.room.*;
 
 import com.github.dedis.popstellar.model.objects.Chirp;
-import com.github.dedis.popstellar.model.objects.security.MessageID;
 
 import java.util.List;
-import java.util.Set;
 
 import io.reactivex.Completable;
 import io.reactivex.Single;
@@ -17,6 +15,6 @@ public interface ChirpDao {
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   Completable insert(ChirpEntity chirpEntity);
 
-  @Query("SELECT chirp FROM chirps WHERE lao_id = :laoId AND chirp_id NOT IN (:filteredIds)")
-  Single<List<Chirp>> getChirpsByLaoId(String laoId, Set<MessageID> filteredIds);
+  @Query("SELECT chirp FROM chirps WHERE lao_id = :laoId")
+  Single<List<Chirp>> getChirpsByLaoId(String laoId);
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/database/socialmedia/ReactionDao.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/database/socialmedia/ReactionDao.java
@@ -6,7 +6,6 @@ import com.github.dedis.popstellar.model.objects.Reaction;
 import com.github.dedis.popstellar.model.objects.security.MessageID;
 
 import java.util.List;
-import java.util.Set;
 
 import io.reactivex.Completable;
 import io.reactivex.Single;
@@ -17,7 +16,6 @@ public interface ReactionDao {
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   Completable insert(ReactionEntity reactionEntity);
 
-  @Query(
-      "SELECT reaction FROM reactions WHERE chirp_id = :chirpId AND reaction_id NOT IN (:filteredIds)")
-  Single<List<Reaction>> getReactionsByChirpId(MessageID chirpId, Set<MessageID> filteredIds);
+  @Query("SELECT reaction FROM reactions WHERE chirp_id = :chirpId")
+  Single<List<Reaction>> getReactionsByChirpId(MessageID chirpId);
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeActivity.java
@@ -44,6 +44,10 @@ public class HomeActivity extends AppCompatActivity {
     setContentView(binding.getRoot());
 
     viewModel = obtainViewModel(this);
+
+    // When back to the home activity set connecting in view model to false
+    viewModel.disableConnectingFlag();
+
     handleTopAppBar();
 
     // Load all the json schemas in background when the app is started.

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/home/LaoCreateFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/home/LaoCreateFragmentTest.java
@@ -11,7 +11,6 @@ import com.github.dedis.popstellar.model.objects.security.KeyPair;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
 import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.repository.LAORepository;
-import com.github.dedis.popstellar.repository.database.AppDatabase;
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.testutils.Base64DataUtils;
@@ -27,10 +26,7 @@ import org.mockito.junit.MockitoTestRule;
 
 import java.util.Collections;
 
-import javax.inject.Inject;
-
 import dagger.hilt.android.testing.*;
-import io.reactivex.Completable;
 import io.reactivex.subjects.BehaviorSubject;
 
 import static androidx.test.espresso.action.ViewActions.click;
@@ -40,7 +36,6 @@ import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
 import static androidx.test.espresso.matcher.ViewMatchers.*;
 import static com.github.dedis.popstellar.testutils.pages.home.HomePageObject.*;
 import static com.github.dedis.popstellar.testutils.pages.home.LaoCreatePageObject.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -53,8 +48,6 @@ public class LaoCreateFragmentTest {
   private static final KeyPair KEY_PAIR = Base64DataUtils.generateKeyPair();
   private static final PublicKey PK = KEY_PAIR.getPublicKey();
   private static final Lao LAO = new Lao(LAO_NAME, PK, 10223421);
-
-  @Inject AppDatabase appDatabase;
 
   @BindValue @Mock LAORepository repository;
   @BindValue @Mock KeyManager keyManager;
@@ -75,18 +68,10 @@ public class LaoCreateFragmentTest {
         @Override
         protected void before() throws UnknownLaoException {
           hiltRule.inject();
-          when(repository.getLaoObservable(anyString()))
-              .thenReturn(BehaviorSubject.createDefault(new LaoView(LAO)));
+
           when(repository.getAllLaoIds())
               .thenReturn(BehaviorSubject.createDefault(Collections.singletonList(LAO.getId())));
           when(repository.getLaoView(anyString())).thenReturn(new LaoView(LAO));
-
-          when(keyManager.getMainPublicKey()).thenReturn(PK);
-          when(keyManager.getMainKeyPair()).thenReturn(KEY_PAIR);
-          when(networkManager.getMessageSender()).thenReturn(messageSender);
-          when(messageSender.subscribe(any())).then(args -> Completable.complete());
-          when(messageSender.publish(any(), any())).then(args -> Completable.complete());
-          when(messageSender.publish(any(), any(), any())).then(args -> Completable.complete());
         }
       };
 
@@ -99,11 +84,6 @@ public class LaoCreateFragmentTest {
     // Open the launch tab
     HomeActivityTest.initializeWallet(activityScenarioRule);
     createButton().perform(click());
-  }
-
-  @After
-  public void tearDown() {
-    appDatabase.close();
   }
 
   @Test

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/database/DigitalCashDatabaseTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/database/DigitalCashDatabaseTest.java
@@ -108,7 +108,7 @@ public class DigitalCashDatabaseTest {
 
   @Test
   public void insertHashTest() {
-    TestObserver<Void> testObserver = hashDao.insert(HASH_ENTITIES).test();
+    TestObserver<Void> testObserver = hashDao.insertAll(HASH_ENTITIES).test();
 
     testObserver.awaitTerminalEvent();
     testObserver.assertComplete();
@@ -116,7 +116,7 @@ public class DigitalCashDatabaseTest {
 
   @Test
   public void getHashTest() {
-    TestObserver<Void> testObserver = hashDao.insert(HASH_ENTITIES).test();
+    TestObserver<Void> testObserver = hashDao.insertAll(HASH_ENTITIES).test();
 
     testObserver.awaitTerminalEvent();
     testObserver.assertComplete();
@@ -136,7 +136,7 @@ public class DigitalCashDatabaseTest {
 
   @Test
   public void deleteHashByLaoTest() {
-    TestObserver<Void> testObserver = hashDao.insert(HASH_ENTITIES).test();
+    TestObserver<Void> testObserver = hashDao.insertAll(HASH_ENTITIES).test();
 
     testObserver.awaitTerminalEvent();
     testObserver.assertComplete();

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/database/ElectionDatabaseTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/database/ElectionDatabaseTest.java
@@ -14,7 +14,7 @@ import org.junit.*;
 import org.junit.runner.RunWith;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.List;
 
 import io.reactivex.observers.TestObserver;
 
@@ -32,11 +32,6 @@ public class ElectionDatabaseTest {
   private static final Election ELECTION =
       new Election.ElectionBuilder(LAO_ID, CREATION + 10, "Election1")
           .setElectionVersion(ElectionVersion.OPEN_BALLOT)
-          .build();
-
-  private static final Election ELECTION2 =
-      new Election.ElectionBuilder(LAO_ID, CREATION + 20, "Election2")
-          .setElectionVersion(ElectionVersion.SECRET_BALLOT)
           .build();
 
   private static final ElectionEntity ELECTION_ENTITY = new ElectionEntity(ELECTION);
@@ -68,47 +63,13 @@ public class ElectionDatabaseTest {
     testObserver.awaitTerminalEvent();
     testObserver.assertComplete();
 
-    Set<String> emptyFilter = new HashSet<>();
     TestObserver<List<Election>> testObserver2 =
         electionDao
-            .getElectionsByLaoId(LAO_ID, emptyFilter)
+            .getElectionsByLaoId(LAO_ID)
             .test()
             .assertValue(elections -> elections.size() == 1 && elections.get(0).equals(ELECTION));
 
     testObserver2.awaitTerminalEvent();
     testObserver2.assertComplete();
-  }
-
-  @Test
-  public void getFilteredIdsTest() {
-    TestObserver<Void> testObserver = electionDao.insert(ELECTION_ENTITY).test();
-
-    testObserver.awaitTerminalEvent();
-    testObserver.assertComplete();
-
-    Set<String> filter = new HashSet<>();
-    filter.add(ELECTION.getId());
-    TestObserver<List<Election>> testObserver2 =
-        electionDao.getElectionsByLaoId(LAO_ID, filter).test().assertValue(List::isEmpty);
-
-    testObserver2.awaitTerminalEvent();
-    testObserver2.assertComplete();
-
-    ElectionEntity newElectionEntity = new ElectionEntity(ELECTION2);
-    TestObserver<Void> testObserver3 = electionDao.insert(newElectionEntity).test();
-
-    testObserver3.awaitTerminalEvent();
-    testObserver3.assertComplete();
-
-    TestObserver<List<Election>> testObserver4 =
-        electionDao
-            .getElectionsByLaoId(LAO_ID, filter)
-            .test()
-            .assertValue(
-                electionEntities ->
-                    electionEntities.size() == 1 && electionEntities.get(0).equals(ELECTION2));
-
-    testObserver4.awaitTerminalEvent();
-    testObserver4.assertComplete();
   }
 }

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/database/MeetingDatabaseTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/database/MeetingDatabaseTest.java
@@ -13,7 +13,8 @@ import org.junit.*;
 import org.junit.runner.RunWith;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 import io.reactivex.observers.TestObserver;
 
@@ -33,17 +34,6 @@ public class MeetingDatabaseTest {
       new Meeting(
           MEETING_ID,
           "name",
-          CREATION,
-          CREATION + 10,
-          CREATION + 20,
-          "loc",
-          CREATION,
-          "modId",
-          new ArrayList<>());
-  private static final Meeting MEETING2 =
-      new Meeting(
-          MEETING_ID + "2",
-          "name2",
           CREATION,
           CREATION + 10,
           CREATION + 20,
@@ -81,45 +71,13 @@ public class MeetingDatabaseTest {
     testObserver.awaitTerminalEvent();
     testObserver.assertComplete();
 
-    Set<String> emptyFilter = new HashSet<>();
     TestObserver<List<Meeting>> testObserver2 =
         meetingDao
-            .getMeetingsByLaoId(LAO_ID, emptyFilter)
+            .getMeetingsByLaoId(LAO_ID)
             .test()
             .assertValue(meetings -> meetings.size() == 1 && meetings.get(0).equals(MEETING));
 
     testObserver2.awaitTerminalEvent();
     testObserver2.assertComplete();
-  }
-
-  @Test
-  public void getFilteredIdsTest() {
-    TestObserver<Void> testObserver = meetingDao.insert(MEETING_ENTITY).test();
-
-    testObserver.awaitTerminalEvent();
-    testObserver.assertComplete();
-
-    Set<String> filter = new HashSet<>();
-    filter.add(MEETING_ENTITY.getMeetingId());
-    TestObserver<List<Meeting>> testObserver2 =
-        meetingDao.getMeetingsByLaoId(LAO_ID, filter).test().assertValue(List::isEmpty);
-
-    testObserver2.awaitTerminalEvent();
-    testObserver2.assertComplete();
-
-    MeetingEntity newMeetingEntity = new MeetingEntity(LAO_ID, MEETING2);
-    TestObserver<Void> testObserver3 = meetingDao.insert(newMeetingEntity).test();
-
-    testObserver3.awaitTerminalEvent();
-    testObserver3.assertComplete();
-
-    TestObserver<List<Meeting>> testObserver4 =
-        meetingDao
-            .getMeetingsByLaoId(LAO_ID, filter)
-            .test()
-            .assertValue(meetings -> meetings.size() == 1 && meetings.get(0).equals(MEETING2));
-
-    testObserver4.awaitTerminalEvent();
-    testObserver4.assertComplete();
   }
 }

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/database/RollCallDatabaseTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/database/RollCallDatabaseTest.java
@@ -14,7 +14,8 @@ import org.junit.*;
 import org.junit.runner.RunWith;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
 
 import io.reactivex.observers.TestObserver;
 
@@ -41,18 +42,6 @@ public class RollCallDatabaseTest {
           new HashSet<>(),
           "loc",
           "");
-  private static final RollCall ROLL_CALL2 =
-      new RollCall(
-          LAO_ID + "2",
-          LAO_ID + "2",
-          "title2",
-          CREATION,
-          CREATION + 10,
-          CREATION + 20,
-          EventState.CREATED,
-          new HashSet<>(),
-          "loc2",
-          "description");
 
   private static final RollCallEntity ROLLCALL_ENTITY = new RollCallEntity(LAO_ID, ROLL_CALL);
 
@@ -83,45 +72,13 @@ public class RollCallDatabaseTest {
     testObserver.awaitTerminalEvent();
     testObserver.assertComplete();
 
-    Set<String> emptyFilter = new HashSet<>();
     TestObserver<List<RollCall>> testObserver2 =
         rollCallDao
-            .getRollCallsByLaoId(LAO_ID, emptyFilter)
+            .getRollCallsByLaoId(LAO_ID)
             .test()
             .assertValue(rollCalls -> rollCalls.size() == 1 && rollCalls.get(0).equals(ROLL_CALL));
 
     testObserver2.awaitTerminalEvent();
     testObserver2.assertComplete();
-  }
-
-  @Test
-  public void getFilteredIdsTest() {
-    TestObserver<Void> testObserver = rollCallDao.insert(ROLLCALL_ENTITY).test();
-
-    testObserver.awaitTerminalEvent();
-    testObserver.assertComplete();
-
-    Set<String> filter = new HashSet<>();
-    filter.add(ROLL_CALL.getPersistentId());
-    TestObserver<List<RollCall>> testObserver2 =
-        rollCallDao.getRollCallsByLaoId(LAO_ID, filter).test().assertValue(List::isEmpty);
-
-    testObserver2.awaitTerminalEvent();
-    testObserver2.assertComplete();
-
-    RollCallEntity newRollCallEntity = new RollCallEntity(LAO_ID, ROLL_CALL2);
-    TestObserver<Void> testObserver3 = rollCallDao.insert(newRollCallEntity).test();
-
-    testObserver3.awaitTerminalEvent();
-    testObserver3.assertComplete();
-
-    TestObserver<List<RollCall>> testObserver4 =
-        rollCallDao
-            .getRollCallsByLaoId(LAO_ID, filter)
-            .test()
-            .assertValue(rollCalls -> rollCalls.size() == 1 && rollCalls.get(0).equals(ROLL_CALL2));
-
-    testObserver4.awaitTerminalEvent();
-    testObserver4.assertComplete();
   }
 }

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/database/SocialMediaDatabaseTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/database/SocialMediaDatabaseTest.java
@@ -13,11 +13,12 @@ import org.junit.*;
 import org.junit.runner.RunWith;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.List;
 
 import io.reactivex.observers.TestObserver;
 
-import static com.github.dedis.popstellar.testutils.Base64DataUtils.*;
+import static com.github.dedis.popstellar.testutils.Base64DataUtils.generateMessageID;
+import static com.github.dedis.popstellar.testutils.Base64DataUtils.generatePublicKey;
 
 @RunWith(AndroidJUnit4.class)
 public class SocialMediaDatabaseTest {
@@ -39,14 +40,6 @@ public class SocialMediaDatabaseTest {
 
   private static final Reaction REACTION_1 =
       new Reaction(generateMessageID(), SENDER, EMOJI, CHIRP1_ID, Instant.now().getEpochSecond());
-
-  private static final Reaction REACTION_2 =
-      new Reaction(
-          generateMessageIDOtherThan(REACTION_1.getId()),
-          generatePublicKey(),
-          EMOJI,
-          CHIRP1_ID,
-          Instant.now().getEpochSecond());
 
   private static final ChirpEntity CHIRP_ENTITY = new ChirpEntity(LAO_ID, CHIRP_1);
   private static final ReactionEntity REACTION_ENTITY = new ReactionEntity(REACTION_1);
@@ -79,46 +72,14 @@ public class SocialMediaDatabaseTest {
     testObserver.awaitTerminalEvent();
     testObserver.assertComplete();
 
-    Set<MessageID> emptyFilter = new HashSet<>();
     TestObserver<List<Chirp>> testObserver2 =
         chirpDao
-            .getChirpsByLaoId(LAO_ID, emptyFilter)
+            .getChirpsByLaoId(LAO_ID)
             .test()
             .assertValue(chirps -> chirps.size() == 1 && chirps.get(0).equals(CHIRP_1));
 
     testObserver2.awaitTerminalEvent();
     testObserver2.assertComplete();
-  }
-
-  @Test
-  public void getChirpFilteredIdsTest() {
-    TestObserver<Void> testObserver = chirpDao.insert(CHIRP_ENTITY).test();
-
-    testObserver.awaitTerminalEvent();
-    testObserver.assertComplete();
-
-    Set<MessageID> filter = new HashSet<>();
-    filter.add(CHIRP1_ID);
-    TestObserver<List<Chirp>> testObserver2 =
-        chirpDao.getChirpsByLaoId(LAO_ID, filter).test().assertValue(List::isEmpty);
-
-    testObserver2.awaitTerminalEvent();
-    testObserver2.assertComplete();
-
-    ChirpEntity newChirpEntity = new ChirpEntity(LAO_ID, CHIRP_2);
-    TestObserver<Void> testObserver3 = chirpDao.insert(newChirpEntity).test();
-
-    testObserver3.awaitTerminalEvent();
-    testObserver3.assertComplete();
-
-    TestObserver<List<Chirp>> testObserver4 =
-        chirpDao
-            .getChirpsByLaoId(LAO_ID, filter)
-            .test()
-            .assertValue(chirps -> chirps.size() == 1 && chirps.get(0).equals(CHIRP_2));
-
-    testObserver4.awaitTerminalEvent();
-    testObserver4.assertComplete();
   }
 
   @Test
@@ -136,45 +97,13 @@ public class SocialMediaDatabaseTest {
     testObserver.awaitTerminalEvent();
     testObserver.assertComplete();
 
-    Set<MessageID> emptyFilter = new HashSet<>();
     TestObserver<List<Reaction>> testObserver2 =
         reactionDao
-            .getReactionsByChirpId(CHIRP1_ID, emptyFilter)
+            .getReactionsByChirpId(CHIRP1_ID)
             .test()
             .assertValue(reactions -> reactions.size() == 1 && reactions.get(0).equals(REACTION_1));
 
     testObserver2.awaitTerminalEvent();
     testObserver2.assertComplete();
-  }
-
-  @Test
-  public void getReactionFilteredIdsTest() {
-    TestObserver<Void> testObserver = reactionDao.insert(REACTION_ENTITY).test();
-
-    testObserver.awaitTerminalEvent();
-    testObserver.assertComplete();
-
-    Set<MessageID> filter = new HashSet<>();
-    filter.add(REACTION_1.getId());
-    TestObserver<List<Reaction>> testObserver2 =
-        reactionDao.getReactionsByChirpId(CHIRP1_ID, filter).test().assertValue(List::isEmpty);
-
-    testObserver2.awaitTerminalEvent();
-    testObserver2.assertComplete();
-
-    ReactionEntity newReactionEntity = new ReactionEntity(REACTION_2);
-    TestObserver<Void> testObserver3 = reactionDao.insert(newReactionEntity).test();
-
-    testObserver3.awaitTerminalEvent();
-    testObserver3.assertComplete();
-
-    TestObserver<List<Reaction>> testObserver4 =
-        reactionDao
-            .getReactionsByChirpId(CHIRP1_ID, filter)
-            .test()
-            .assertValue(reactions -> reactions.size() == 1 && reactions.get(0).equals(REACTION_2));
-
-    testObserver4.awaitTerminalEvent();
-    testObserver4.assertComplete();
   }
 }

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ChirpHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ChirpHandlerTest.java
@@ -1,11 +1,10 @@
 package com.github.dedis.popstellar.utility.handler;
 
-import android.content.Context;
+import android.app.Application;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.github.dedis.popstellar.di.AppDatabaseModuleHelper;
 import com.github.dedis.popstellar.model.network.method.message.data.socialmedia.AddChirp;
 import com.github.dedis.popstellar.model.network.method.message.data.socialmedia.DeleteChirp;
 import com.github.dedis.popstellar.model.objects.*;
@@ -13,20 +12,26 @@ import com.github.dedis.popstellar.model.objects.security.*;
 import com.github.dedis.popstellar.repository.LAORepository;
 import com.github.dedis.popstellar.repository.SocialMediaRepository;
 import com.github.dedis.popstellar.repository.database.AppDatabase;
+import com.github.dedis.popstellar.repository.database.lao.LAODao;
+import com.github.dedis.popstellar.repository.database.lao.LAOEntity;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.handler.data.ChirpHandler;
 import com.github.dedis.popstellar.utility.handler.data.HandlerContext;
 
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.ArrayList;
 
 import dagger.hilt.android.testing.HiltAndroidTest;
+import io.reactivex.Completable;
+import io.reactivex.Single;
 
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generateKeyPair;
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generateMessageID;
@@ -59,8 +64,9 @@ public class ChirpHandlerTest {
   private static final DeleteChirp DELETE_CHIRP = new DeleteChirp(CHIRP_ID, DELETION_TIME);
 
   private ChirpHandler handler;
-  private AppDatabase appDatabase;
 
+  @Mock AppDatabase appDatabase;
+  @Mock LAODao laoDao;
   @Mock MessageSender messageSender;
   @Mock SocialMediaRepository socialMediaRepo;
 
@@ -69,17 +75,15 @@ public class ChirpHandlerTest {
       throws GeneralSecurityException, DataHandlingException, IOException, UnknownLaoException {
     // Instantiate the dependencies here such that they are reset for each test
     MockitoAnnotations.openMocks(this);
-    Context context = ApplicationProvider.getApplicationContext();
-    appDatabase = AppDatabaseModuleHelper.getAppDatabase(context);
-    LAORepository laoRepo =
-        new LAORepository(appDatabase, ApplicationProvider.getApplicationContext());
+    Application application = ApplicationProvider.getApplicationContext();
+
+    when(appDatabase.laoDao()).thenReturn(laoDao);
+    when(laoDao.getAllLaos()).thenReturn(Single.just(new ArrayList<>()));
+    when(laoDao.insert(any(LAOEntity.class))).thenReturn(Completable.complete());
+
+    LAORepository laoRepo = new LAORepository(appDatabase, application);
     laoRepo.updateLao(LAO);
     handler = new ChirpHandler(laoRepo, socialMediaRepo);
-  }
-
-  @After
-  public void tearDown() {
-    appDatabase.close();
   }
 
   @Test

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/MeetingHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/MeetingHandlerTest.java
@@ -6,7 +6,8 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.github.dedis.popstellar.di.*;
+import com.github.dedis.popstellar.di.DataRegistryModuleHelper;
+import com.github.dedis.popstellar.di.JsonModule;
 import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
 import com.github.dedis.popstellar.model.network.method.message.data.DataRegistry;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.CreateLao;
@@ -15,6 +16,12 @@ import com.github.dedis.popstellar.model.objects.*;
 import com.github.dedis.popstellar.model.objects.security.*;
 import com.github.dedis.popstellar.repository.*;
 import com.github.dedis.popstellar.repository.database.AppDatabase;
+import com.github.dedis.popstellar.repository.database.event.meeting.MeetingDao;
+import com.github.dedis.popstellar.repository.database.event.meeting.MeetingEntity;
+import com.github.dedis.popstellar.repository.database.lao.LAODao;
+import com.github.dedis.popstellar.repository.database.lao.LAOEntity;
+import com.github.dedis.popstellar.repository.database.message.MessageDao;
+import com.github.dedis.popstellar.repository.database.message.MessageEntity;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.error.keys.KeyException;
@@ -34,14 +41,15 @@ import java.util.ArrayList;
 import java.util.Optional;
 
 import io.reactivex.Completable;
+import io.reactivex.Single;
 
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generateKeyPair;
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generatePoPToken;
 import static com.github.dedis.popstellar.utility.handler.data.MeetingHandler.createMeetingWitnessMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
 
 @RunWith(AndroidJUnit4.class)
 public class MeetingHandlerTest {
@@ -58,10 +66,13 @@ public class MeetingHandlerTest {
   private static MeetingRepository meetingRepo;
   private static MessageHandler messageHandler;
   private static Gson gson;
-  private AppDatabase appDatabase;
 
   private static Meeting meeting;
 
+  @Mock AppDatabase appDatabase;
+  @Mock LAODao laoDao;
+  @Mock MessageDao messageDao;
+  @Mock MeetingDao meetingDao;
   @Mock MessageSender messageSender;
   @Mock KeyManager keyManager;
 
@@ -72,7 +83,6 @@ public class MeetingHandlerTest {
       throws GeneralSecurityException, IOException, KeyException, UnknownRollCallException {
     MockitoAnnotations.openMocks(this);
     Application application = ApplicationProvider.getApplicationContext();
-    appDatabase = AppDatabaseModuleHelper.getAppDatabase(application);
 
     lenient().when(keyManager.getMainKeyPair()).thenReturn(SENDER_KEY);
     lenient().when(keyManager.getMainPublicKey()).thenReturn(SENDER);
@@ -80,12 +90,26 @@ public class MeetingHandlerTest {
 
     lenient().when(messageSender.subscribe(any())).then(args -> Completable.complete());
 
+    when(appDatabase.laoDao()).thenReturn(laoDao);
+    when(laoDao.getAllLaos()).thenReturn(Single.just(new ArrayList<>()));
+    when(laoDao.insert(any(LAOEntity.class))).thenReturn(Completable.complete());
+
+    when(appDatabase.messageDao()).thenReturn(messageDao);
+    when(messageDao.takeFirstNMessages(anyInt())).thenReturn(Single.just(new ArrayList<>()));
+    when(messageDao.insert(any(MessageEntity.class))).thenReturn(Completable.complete());
+    when(messageDao.getMessageById(any(MessageID.class))).thenReturn(null);
+
+    when(appDatabase.meetingDao()).thenReturn(meetingDao);
+    when(meetingDao.getMeetingsByLaoId(anyString())).thenReturn(Single.just(new ArrayList<>()));
+    when(meetingDao.insert(any(MeetingEntity.class))).thenReturn(Completable.complete());
+
     laoRepo = new LAORepository(appDatabase, application);
     meetingRepo = new MeetingRepository(appDatabase, application);
+    MessageRepository messageRepo = new MessageRepository(appDatabase, application);
 
     DataRegistry dataRegistry =
         DataRegistryModuleHelper.buildRegistry(laoRepo, keyManager, meetingRepo);
-    MessageRepository messageRepo = new MessageRepository(appDatabase, application);
+
     gson = JsonModule.provideGson(dataRegistry);
     messageHandler = new MessageHandler(messageRepo, dataRegistry);
 
@@ -106,12 +130,6 @@ public class MeetingHandlerTest {
     // Add the CreateLao message to the LAORepository
     MessageGeneral createLaoMessage = new MessageGeneral(SENDER_KEY, CREATE_LAO, gson);
     messageRepo.addMessage(createLaoMessage, true, true);
-  }
-
-  @After
-  public void tearDown() {
-    appDatabase.clearAllTables();
-    appDatabase.close();
   }
 
   @Test

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ReactionHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ReactionHandlerTest.java
@@ -1,11 +1,10 @@
 package com.github.dedis.popstellar.utility.handler;
 
-import android.content.Context;
+import android.app.Application;
 
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.github.dedis.popstellar.di.AppDatabaseModuleHelper;
 import com.github.dedis.popstellar.model.network.method.message.data.socialmedia.AddReaction;
 import com.github.dedis.popstellar.model.network.method.message.data.socialmedia.DeleteReaction;
 import com.github.dedis.popstellar.model.objects.*;
@@ -13,12 +12,15 @@ import com.github.dedis.popstellar.model.objects.security.*;
 import com.github.dedis.popstellar.repository.LAORepository;
 import com.github.dedis.popstellar.repository.SocialMediaRepository;
 import com.github.dedis.popstellar.repository.database.AppDatabase;
+import com.github.dedis.popstellar.repository.database.lao.LAODao;
+import com.github.dedis.popstellar.repository.database.lao.LAOEntity;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.handler.data.HandlerContext;
 import com.github.dedis.popstellar.utility.handler.data.ReactionHandler;
 
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -26,8 +28,11 @@ import org.mockito.MockitoAnnotations;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.Instant;
+import java.util.ArrayList;
 
 import dagger.hilt.android.testing.HiltAndroidTest;
+import io.reactivex.Completable;
+import io.reactivex.Single;
 
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.*;
 import static org.junit.Assert.assertThrows;
@@ -59,8 +64,9 @@ public class ReactionHandlerTest {
       new DeleteReaction(REACTION_ID, DELETION_TIME);
 
   private ReactionHandler handler;
-  private AppDatabase appDatabase;
 
+  @Mock AppDatabase appDatabase;
+  @Mock LAODao laoDao;
   @Mock MessageSender messageSender;
   @Mock SocialMediaRepository socialMediaRepo;
 
@@ -68,18 +74,15 @@ public class ReactionHandlerTest {
   public void setup()
       throws GeneralSecurityException, DataHandlingException, IOException, UnknownLaoException {
     MockitoAnnotations.openMocks(this);
-    Context context = ApplicationProvider.getApplicationContext();
-    appDatabase = AppDatabaseModuleHelper.getAppDatabase(context);
-    LAORepository laoRepo =
-        new LAORepository(appDatabase, ApplicationProvider.getApplicationContext());
+    Application application = ApplicationProvider.getApplicationContext();
+
+    when(appDatabase.laoDao()).thenReturn(laoDao);
+    when(laoDao.getAllLaos()).thenReturn(Single.just(new ArrayList<>()));
+    when(laoDao.insert(any(LAOEntity.class))).thenReturn(Completable.complete());
+
+    LAORepository laoRepo = new LAORepository(appDatabase, application);
     laoRepo.updateLao(LAO);
     handler = new ReactionHandler(laoRepo, socialMediaRepo);
-  }
-
-  @After
-  public void tearDown() {
-    appDatabase.clearAllTables();
-    appDatabase.close();
   }
 
   @Test

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/TransactionCoinHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/TransactionCoinHandlerTest.java
@@ -119,6 +119,7 @@ public class TransactionCoinHandlerTest {
     when(transactionDao.getTransactionsByLaoId(anyString()))
         .thenReturn(Single.just(new ArrayList<>()));
     when(transactionDao.insert(any(TransactionEntity.class))).thenReturn(Completable.complete());
+    when(transactionDao.deleteByLaoId(anyString())).thenReturn(Completable.complete());
 
     postTransactionCoin = new PostTransactionCoin(TRANSACTION);
 

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/TransactionCoinHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/TransactionCoinHandlerTest.java
@@ -5,7 +5,8 @@ import android.app.Application;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import com.github.dedis.popstellar.di.*;
+import com.github.dedis.popstellar.di.DataRegistryModuleHelper;
+import com.github.dedis.popstellar.di.JsonModule;
 import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
 import com.github.dedis.popstellar.model.network.method.message.data.DataRegistry;
 import com.github.dedis.popstellar.model.network.method.message.data.digitalcash.*;
@@ -17,13 +18,18 @@ import com.github.dedis.popstellar.model.objects.security.*;
 import com.github.dedis.popstellar.repository.DigitalCashRepository;
 import com.github.dedis.popstellar.repository.MessageRepository;
 import com.github.dedis.popstellar.repository.database.AppDatabase;
+import com.github.dedis.popstellar.repository.database.digitalcash.TransactionDao;
+import com.github.dedis.popstellar.repository.database.digitalcash.TransactionEntity;
+import com.github.dedis.popstellar.repository.database.message.MessageDao;
+import com.github.dedis.popstellar.repository.database.message.MessageEntity;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
 import com.github.dedis.popstellar.utility.security.KeyManager;
 import com.google.gson.Gson;
 
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -33,12 +39,14 @@ import java.security.GeneralSecurityException;
 import java.util.*;
 
 import io.reactivex.Completable;
+import io.reactivex.Single;
 
 import static com.github.dedis.popstellar.testutils.Base64DataUtils.generateKeyPair;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
 public class TransactionCoinHandlerTest {
@@ -82,10 +90,12 @@ public class TransactionCoinHandlerTest {
   private MessageHandler messageHandler;
   private Channel coinChannel;
   private Gson gson;
-  private AppDatabase appDatabase;
 
   private PostTransactionCoin postTransactionCoin;
 
+  @Mock AppDatabase appDatabase;
+  @Mock MessageDao messageDao;
+  @Mock TransactionDao transactionDao;
   @Mock MessageSender messageSender;
   @Mock KeyManager keyManager;
 
@@ -95,17 +105,28 @@ public class TransactionCoinHandlerTest {
           UnknownLaoException, NoRollCallException {
     MockitoAnnotations.openMocks(this);
     Application application = ApplicationProvider.getApplicationContext();
-    appDatabase = AppDatabaseModuleHelper.getAppDatabase(application);
 
     lenient().when(keyManager.getMainKeyPair()).thenReturn(SENDER_KEY);
     lenient().when(keyManager.getMainPublicKey()).thenReturn(SENDER);
     lenient().when(messageSender.subscribe(any())).then(args -> Completable.complete());
 
+    when(appDatabase.messageDao()).thenReturn(messageDao);
+    when(messageDao.takeFirstNMessages(anyInt())).thenReturn(Single.just(new ArrayList<>()));
+    when(messageDao.insert(any(MessageEntity.class))).thenReturn(Completable.complete());
+    when(messageDao.getMessageById(any(MessageID.class))).thenReturn(null);
+
+    when(appDatabase.transactionDao()).thenReturn(transactionDao);
+    when(transactionDao.getTransactionsByLaoId(anyString()))
+        .thenReturn(Single.just(new ArrayList<>()));
+    when(transactionDao.insert(any(TransactionEntity.class))).thenReturn(Completable.complete());
+
     postTransactionCoin = new PostTransactionCoin(TRANSACTION);
 
     digitalCashRepo = new DigitalCashRepository(appDatabase, application);
-    DataRegistry dataRegistry = DataRegistryModuleHelper.buildRegistry(digitalCashRepo, keyManager);
     MessageRepository messageRepo = new MessageRepository(appDatabase, application);
+
+    DataRegistry dataRegistry = DataRegistryModuleHelper.buildRegistry(digitalCashRepo, keyManager);
+
     gson = JsonModule.provideGson(dataRegistry);
     messageHandler = new MessageHandler(messageRepo, dataRegistry);
 
@@ -114,12 +135,6 @@ public class TransactionCoinHandlerTest {
 
     digitalCashRepo.initializeDigitalCash(lao.getId(), Collections.singletonList(SENDER));
     coinChannel = lao.getChannel().subChannel("coin").subChannel(SENDER.getEncoded());
-  }
-
-  @After
-  public void tearDown() {
-    appDatabase.clearAllTables();
-    appDatabase.close();
   }
 
   @Test

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/TransactionCoinHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/TransactionCoinHandlerTest.java
@@ -18,8 +18,7 @@ import com.github.dedis.popstellar.model.objects.security.*;
 import com.github.dedis.popstellar.repository.DigitalCashRepository;
 import com.github.dedis.popstellar.repository.MessageRepository;
 import com.github.dedis.popstellar.repository.database.AppDatabase;
-import com.github.dedis.popstellar.repository.database.digitalcash.TransactionDao;
-import com.github.dedis.popstellar.repository.database.digitalcash.TransactionEntity;
+import com.github.dedis.popstellar.repository.database.digitalcash.*;
 import com.github.dedis.popstellar.repository.database.message.MessageDao;
 import com.github.dedis.popstellar.repository.database.message.MessageEntity;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
@@ -96,6 +95,7 @@ public class TransactionCoinHandlerTest {
   @Mock AppDatabase appDatabase;
   @Mock MessageDao messageDao;
   @Mock TransactionDao transactionDao;
+  @Mock HashDao hashDao;
   @Mock MessageSender messageSender;
   @Mock KeyManager keyManager;
 
@@ -120,6 +120,11 @@ public class TransactionCoinHandlerTest {
         .thenReturn(Single.just(new ArrayList<>()));
     when(transactionDao.insert(any(TransactionEntity.class))).thenReturn(Completable.complete());
     when(transactionDao.deleteByLaoId(anyString())).thenReturn(Completable.complete());
+
+    when(appDatabase.hashDao()).thenReturn(hashDao);
+    when(hashDao.getDictionaryByLaoId(anyString())).thenReturn(Single.just(new ArrayList<>()));
+    when(hashDao.insertAll(any())).thenReturn(Completable.complete());
+    when(hashDao.deleteByLaoId(anyString())).thenReturn(Completable.complete());
 
     postTransactionCoin = new PostTransactionCoin(TRANSACTION);
 


### PR DESCRIPTION
This PR is a bug-fixing PR.

- It resolves #1608 by replacing synchronization of methods with a more elegant and efficient usage of concurrent thread-safe data structures.

>**Note**: with these changes now tests are executing in less time (around 2min 30sec against the previous 6min), so the application seems way faster and responsive.

- It improves the documentation of the repositories.

- It resolves #1609 by preventing the connecting activity to be spammed several times upon connection of a lao.