### PR TITLE
Extended multi connection to multiple greet laos

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/LAONetworkManager.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/repository/remote/LAONetworkManager.java
@@ -193,13 +193,16 @@ public class LAONetworkManager implements MessageSender {
 
   @Override
   public void extendConnection(List<PeerAddress> peerAddressList) {
-    // If succeeded in extending the connections then return true
-    if (multiConnection.connectToPeers(peerAddressList)) {
-      // Start the incoming message processing for the other connections
-      processIncomingMessages();
-      // Start the routine aimed at resubscribing to channels when the connection is lost
-      resubscribeToChannelOnReconnection();
+    // If the connections to other peers are not created then do nothing
+    if (!multiConnection.connectToPeers(peerAddressList)) {
+      return;
     }
+    // First dispose the previous connections
+    disposables.clear();
+    // Start the incoming message processing for all the new connections
+    processIncomingMessages();
+    // Start the routine aimed at resubscribing to channels when the connection is lost
+    resubscribeToChannelOnReconnection();
   }
 
   private void handleBroadcast(Broadcast broadcast) {

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/remote/LAONetworkManagerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/remote/LAONetworkManagerTest.java
@@ -77,6 +77,7 @@ public class LAONetworkManagerTest {
     hiltRule.inject();
     when(connection.observeMessage()).thenReturn(messages);
     when(connection.observeConnectionEvents()).thenReturn(events);
+    when(connection.connectToPeers(any())).thenReturn(true);
 
     // Default behavior : success
     Answer<?> answer =

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/remote/LAONetworkManagerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/remote/LAONetworkManagerTest.java
@@ -13,6 +13,7 @@ import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
 import com.github.dedis.popstellar.model.network.method.message.data.Data;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.CreateLao;
 import com.github.dedis.popstellar.model.objects.Channel;
+import com.github.dedis.popstellar.model.objects.PeerAddress;
 import com.github.dedis.popstellar.model.objects.security.KeyPair;
 import com.github.dedis.popstellar.testutils.Base64DataUtils;
 import com.github.dedis.popstellar.utility.error.*;
@@ -397,5 +398,54 @@ public class LAONetworkManagerTest {
     testObserver.dispose();
     disposable.dispose();
     networkManager.dispose();
+  }
+
+  @Test
+  public void testExtendConnection() {
+    TestSchedulerProvider schedulerProvider = new TestSchedulerProvider();
+    TestScheduler testScheduler = schedulerProvider.getTestScheduler();
+
+    LAONetworkManager networkManager =
+        new LAONetworkManager(
+            handler,
+            connection,
+            JsonModule.provideGson(DataRegistryModuleHelper.buildRegistry()),
+            schedulerProvider,
+            new HashSet<>());
+
+    // Extend the connections with a new peer
+    List<PeerAddress> peers = new ArrayList<>();
+    peers.add(new PeerAddress("url"));
+    networkManager.extendConnection(peers);
+
+    // Ensure that publish sends the right messages with 2 connections
+
+    networkManager.subscribe(CHANNEL).subscribe(); // First subscribe
+    testScheduler.advanceTimeBy(REPROCESSING_DELAY, TimeUnit.SECONDS);
+
+    verify(connection).sendMessage(any(Subscribe.class));
+    verify(connection).sendMessage(any(Catchup.class));
+
+    // Setup mock answer
+    Answer<?> answer =
+        args -> {
+          Subscribe subscribe = args.getArgument(0); // Retrieve subscribe object
+          assertEquals(CHANNEL, subscribe.getChannel()); // Make sure the channel is correct
+          messages.onNext(new Result(subscribe.getRequestId())); // Return a positive result
+          return null;
+        };
+    doAnswer(answer).when(connection).sendMessage(any(Subscribe.class));
+
+    // Push Connection open event
+    events.onNext(new WebSocket.Event.OnConnectionOpened<>(mock(WebSocket.class)));
+    testScheduler.advanceTimeBy(REPROCESSING_DELAY, TimeUnit.SECONDS);
+
+    networkManager.dispose();
+
+    verify(connection, times(2)).sendMessage(any(Subscribe.class));
+    verify(connection, times(2)).sendMessage(any(Catchup.class));
+    verify(connection, atLeastOnce()).observeMessage();
+    verify(connection).observeConnectionEvents();
+    verify(connection).close();
   }
 }

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/remote/LAONetworkManagerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/remote/LAONetworkManagerTest.java
@@ -446,7 +446,7 @@ public class LAONetworkManagerTest {
     verify(connection, times(2)).sendMessage(any(Subscribe.class));
     verify(connection, times(2)).sendMessage(any(Catchup.class));
     verify(connection, atLeastOnce()).observeMessage();
-    verify(connection).observeConnectionEvents();
+    verify(connection, times(2)).observeConnectionEvents();
     verify(connection).close();
   }
 }


### PR DESCRIPTION
This PR extends the current multiconnection to also connect to servers which join later.

As the backends have implemented a dynamic server configuration, they are going to send a new GreetLao when a new peer joins. So far, the current multiconnection was only connecting to the peers in the very first greet lao, maintaining static the servers set. By this change now we process each greetlao and we connect to all the peers we have not been connected yet, allowing to connect to new servers joining the network.