### PR TITLE
Add circular handling of GetMessagesById answer

### DIFF
--- a/be1-go/hub/standard_hub/message_handling.go
+++ b/be1-go/hub/standard_hub/message_handling.go
@@ -559,8 +559,8 @@ func (h *Hub) handleReceivedMessage(socket socket.Socket, messageData message.Me
 	}
 	_, stored := h.hubInbox.GetMessage(publish.Params.Message.MessageID)
 	if stored {
+		h.log.Info().Msgf("Already stored message %s", publish.Params.Message.MessageID)
 		h.Unlock()
-		log.Info().Msgf("Already stored message %s", publish.Params.Message.MessageID)
 		return nil
 	}
 	h.Unlock()

--- a/be1-go/hub/standard_hub/message_handling.go
+++ b/be1-go/hub/standard_hub/message_handling.go
@@ -560,7 +560,8 @@ func (h *Hub) handleReceivedMessage(socket socket.Socket, messageData message.Me
 	_, stored := h.hubInbox.GetMessage(publish.Params.Message.MessageID)
 	if stored {
 		h.Unlock()
-		return xerrors.Errorf("already stored this message")
+		log.Info().Msgf("Already stored message %s", publish.Params.Message.MessageID)
+		return nil
 	}
 	h.Unlock()
 
@@ -583,10 +584,9 @@ func (h *Hub) handleReceivedMessage(socket socket.Socket, messageData message.Me
 	}
 
 	h.Lock()
-	defer h.Unlock()
 	h.hubInbox.StoreMessage(publish.Params.Message)
 	h.addMessageId(publish.Params.Channel, publish.Params.Message.MessageID)
-
+	h.Unlock()
 	return nil
 }
 

--- a/be1-go/hub/standard_hub/message_handling.go
+++ b/be1-go/hub/standard_hub/message_handling.go
@@ -3,6 +3,7 @@ package standard_hub
 import (
 	"encoding/base64"
 	"encoding/json"
+	"github.com/rs/zerolog/log"
 	"popstellar/crypto"
 	jsonrpc "popstellar/message"
 	"popstellar/message/answer"
@@ -531,6 +532,7 @@ func (h *Hub) handleReceivedMessage(socket socket.Socket, messageData message.Me
 	signature := messageData.Signature
 	messageID := messageData.MessageID
 	data := messageData.Data
+	log.Info().Msgf("Received message on %s", targetChannel)
 
 	expectedMessageID := messagedata.Hash(data, signature)
 	if expectedMessageID != messageID {
@@ -581,9 +583,9 @@ func (h *Hub) handleReceivedMessage(socket socket.Socket, messageData message.Me
 	}
 
 	h.Lock()
+	defer h.Unlock()
 	h.hubInbox.StoreMessage(publish.Params.Message)
 	h.addMessageId(publish.Params.Channel, publish.Params.Message.MessageID)
-	h.Unlock()
 
 	return nil
 }

--- a/be1-go/hub/standard_hub/mod.go
+++ b/be1-go/hub/standard_hub/mod.go
@@ -425,7 +425,7 @@ func (h *Hub) handleMessageFromServer(incomingMessage *socket.IncomingMessage) e
 		return err
 	}
 
-	var id int
+	id := -1
 	var msgsByChannel map[string][]message.Message
 	var handlerErr error
 
@@ -461,7 +461,9 @@ func (h *Hub) handleMessageFromServer(incomingMessage *socket.IncomingMessage) e
 		return nil
 	}
 
-	socket.SendResult(id, nil, nil)
+	if id != -1 {
+		socket.SendResult(id, nil, nil)
+	}
 
 	return nil
 }

--- a/be1-go/hub/standard_hub/mod_test.go
+++ b/be1-go/hub/standard_hub/mod_test.go
@@ -1318,8 +1318,8 @@ func Test_Create_LAO_GetMessagesById_Wrong_MessageID(t *testing.T) {
 		Message: answerBuf,
 	})
 
-	//expectedMessageID := messagedata.Hash(dataBase64, signatureBase64)
-	require.EqualError(t, sock.err, fmt.Sprint("failed to handle answer message: failed to process messages after 5 attempts"))
+	expectedMessageID := messagedata.Hash(dataBase64, signatureBase64)
+	require.EqualError(t, sock.err, fmt.Sprintf("failed to handle answer message: failed to process messages: message_id is wrong: expected %q found %q", expectedMessageID, fakeMessageID))
 }
 
 // Check that if the server receives a subscribe message, it will call the

--- a/be1-go/hub/standard_hub/mod_test.go
+++ b/be1-go/hub/standard_hub/mod_test.go
@@ -1881,12 +1881,6 @@ func Test_Handle_GreetServer_Already_Greeted(t *testing.T) {
 	require.Nil(t, sock.msg)
 }
 
-// Test that receiving a GetMessagesById message with the wrong order is properly handled
-// by sending a create roll call
-func Test_Handle_GetMessagesById_Answer_Wrong_Order(t *testing.T) {
-
-}
-
 // -----------------------------------------------------------------------------
 // Utility functions
 

--- a/be1-go/hub/standard_hub/mod_test.go
+++ b/be1-go/hub/standard_hub/mod_test.go
@@ -1318,8 +1318,8 @@ func Test_Create_LAO_GetMessagesById_Wrong_MessageID(t *testing.T) {
 		Message: answerBuf,
 	})
 
-	expectedMessageID := messagedata.Hash(dataBase64, signatureBase64)
-	require.EqualError(t, sock.err, fmt.Sprintf("failed to handle answer message: message_id is wrong: expected %q found %q", expectedMessageID, fakeMessageID))
+	//expectedMessageID := messagedata.Hash(dataBase64, signatureBase64)
+	require.EqualError(t, sock.err, fmt.Sprint("failed to handle answer message: failed to process messages after 5 attempts"))
 }
 
 // Check that if the server receives a subscribe message, it will call the
@@ -1879,6 +1879,12 @@ func Test_Handle_GreetServer_Already_Greeted(t *testing.T) {
 
 	//socket should not receive anything back after handling of server greet
 	require.Nil(t, sock.msg)
+}
+
+// Test that receiving a GetMessagesById message with the wrong order is properly handled
+// by sending a create roll call
+func Test_Handle_GetMessagesById_Answer_Wrong_Order(t *testing.T) {
+
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
We noticed that the go servers fail to catch up properly through a GetMessagesById if they connect some time after the creation of the LAO. Since the message processing is linear and only goes through the list once, it fails if, for example, the message for an election creation is processed before the lao creation.
To fix that, I implemented a simple circular way of handling the answer. The server now goes through the list enough times until it succeeds or reaches maxium number of retries (=10). 

When testing with 3 servers, we noticed that there are a lot of errors logged. That is because a server can send a GetMessagesById with the same message ids to multiple servers. When it receives the result, it processes the messages correctly the first time. It then receives the result a second time from another server and logs errors because the message was already received. I think that in the context of decentralized communication, it makes more sense to log that as an info rather than an error since it is virtually unavoidable and doesn't cause any harm as far as I know. 

The PR also removes sending empty results to messages that aren't json rpc requests (messages that don't have an id field).