### PR TITLE
Removes the mock server button

### DIFF
--- a/fe1-web/src/features/home/screens/ConnectConfirm.tsx
+++ b/fe1-web/src/features/home/screens/ConnectConfirm.tsx
@@ -36,7 +36,7 @@ const ConnectConfirm = () => {
   const dispatch = useDispatch();
 
   const laoIdRouteParam = route.params?.laoId || '';
-  const url = route.params?.serverUrl || 'ws://localhost:9000/organizer/client';
+  const url = route.params?.serverUrl || 'wss://127.0.0.1:9000/client';
   const [serverUrl, setServerUrl] = useState(url);
   const [laoIdInput, setLaoIdInput] = useState(laoIdRouteParam);
 

--- a/fe1-web/src/features/home/screens/Launch.tsx
+++ b/fe1-web/src/features/home/screens/Launch.tsx
@@ -40,8 +40,9 @@ const Launch = () => {
   const dispatch = useDispatch();
 
   const [inputLaoName, setInputLaoName] = useState('');
-  const [inputAddress, setInputAddress] = useState('ws://127.0.0.1:9000/organizer/client');
-
+  const [inputAddress, setInputAddress] = useState('wss://127.0.0.1:9000/client');
+  // release : disable connect to test lao
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const connectToTestLao = HomeHooks.useConnectToTestLao();
   const requestCreateLao = HomeHooks.useRequestCreateLao();
 
@@ -102,9 +103,10 @@ const Launch = () => {
             {STRINGS.launch_button_launch}
           </PoPTextButton>
 
+          {/* release: Disable the MockServer
           <PoPTextButton onPress={connectToTestLao}>
             [TEST] Connect to LocalMockServer.ts (use &apos;npm run startServer&apos;)
-          </PoPTextButton>
+          </PoPTextButton>} */}
         </View>
       </View>
     </ScreenWrapper>

--- a/fe1-web/src/features/home/screens/__tests__/__snapshots__/ConnectConfirm.test.tsx.snap
+++ b/fe1-web/src/features/home/screens/__tests__/__snapshots__/ConnectConfirm.test.tsx.snap
@@ -413,7 +413,7 @@ exports[`ConnectNavigation renders correctly 1`] = `
                                       },
                                     ]
                                   }
-                                  value="ws://localhost:9000/organizer/client"
+                                  value="wss://127.0.0.1:9000/client"
                                 />
                               </View>
                               <Text

--- a/fe1-web/src/features/home/screens/__tests__/__snapshots__/Launch.test.tsx.snap
+++ b/fe1-web/src/features/home/screens/__tests__/__snapshots__/Launch.test.tsx.snap
@@ -490,7 +490,7 @@ exports[`Launch renders correctly 1`] = `
                                       ]
                                     }
                                     testID="launch_address_selector"
-                                    value="ws://127.0.0.1:9000/organizer/client"
+                                    value="wss://127.0.0.1:9000/client"
                                   />
                                 </View>
                               </View>
@@ -576,85 +576,6 @@ exports[`Launch renders correctly 1`] = `
                                           }
                                         >
                                           Launch
-                                        </Text>
-                                      </View>
-                                    </View>
-                                  </RNGestureHandlerButton>
-                                </View>
-                                <View
-                                  accessible={true}
-                                  collapsable={false}
-                                  focusable={true}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onResponderGrant={[Function]}
-                                  onResponderMove={[Function]}
-                                  onResponderRelease={[Function]}
-                                  onResponderTerminate={[Function]}
-                                  onResponderTerminationRequest={[Function]}
-                                  onStartShouldSetResponder={[Function]}
-                                  style={
-                                    {
-                                      "marginBottom": 16,
-                                    }
-                                  }
-                                >
-                                  <RNGestureHandlerButton
-                                    collapsable={false}
-                                    delayLongPress={600}
-                                    enabled={true}
-                                    exclusive={true}
-                                    handlerTag={4}
-                                    handlerType="NativeViewGestureHandler"
-                                    onGestureEvent={[Function]}
-                                    onGestureHandlerEvent={[Function]}
-                                    onGestureHandlerStateChange={[Function]}
-                                    onHandlerStateChange={[Function]}
-                                    rippleColor={0}
-                                    touchSoundDisabled={false}
-                                  >
-                                    <View
-                                      accessible={true}
-                                      collapsable={false}
-                                      style={
-                                        {
-                                          "opacity": 1,
-                                        }
-                                      }
-                                    >
-                                      <View
-                                        style={
-                                          [
-                                            {
-                                              "backgroundColor": "#3742fa",
-                                              "borderColor": "#3742fa",
-                                              "borderRadius": 8,
-                                              "borderWidth": 1,
-                                              "padding": 8,
-                                            },
-                                          ]
-                                        }
-                                      >
-                                        <Text
-                                          style={
-                                            [
-                                              {
-                                                "color": "#000",
-                                                "fontSize": 20,
-                                                "lineHeight": 26,
-                                                "textAlign": "left",
-                                              },
-                                              {
-                                                "textAlign": "center",
-                                              },
-                                              {
-                                                "color": "#fff",
-                                              },
-                                            ]
-                                          }
-                                        >
-                                          [TEST] Connect to LocalMockServer.ts (use 'npm run startServer')
                                         </Text>
                                       </View>
                                     </View>


### PR DESCRIPTION
This PR removes the mock server button and set the new default URL to their new states in both backends. This PR resolves #1590.
The new LAO creatio page : 
![image](https://github.com/dedis/popstellar/assets/42808302/5e4d2ac3-1f3c-458d-8d64-ec1583c455d9)
 