### PR TITLE
Integration of PoPCHA in cli/mod.go

### DIFF
--- a/be1-go/cli/mod_test.go
+++ b/be1-go/cli/mod_test.go
@@ -26,6 +26,9 @@ const (
 	// invalidConfigEqualClientServerPortsPath is the path to a config file with the same client and server ports
 	invalidConfigEqualClientServerPortsPath = "test_config_files/invalid_config_equal_client_server_ports.json"
 
+	// invalidConfigEqualClientAuthPortsPath is the path to a config file with the same client and auth ports
+	invalidConfigEqualClientAuthPortsPath = "test_config_files/invalid_config_equal_ports.json"
+
 	// validConfigWatcherPath is the path to a valid config file that used for testing the config watcher
 	validConfigWatcherPath = "test_config_files/valid_config_watcher.json"
 )
@@ -70,8 +73,10 @@ func TestLoadConfigFile(t *testing.T) {
 	require.Equal(t, "", ServerConfig.PublicKey)
 	require.Equal(t, "localhost", ServerConfig.PublicAddress)
 	require.Equal(t, "localhost", ServerConfig.PrivateAddress)
+	require.Equal(t, "localhost", ServerConfig.AuthAddress)
 	require.Equal(t, 9000, ServerConfig.ClientPort)
 	require.Equal(t, 9001, ServerConfig.ServerPort)
+	require.Equal(t, 9100, ServerConfig.AuthPort)
 	require.Equal(t, []string{}, ServerConfig.OtherServers)
 }
 
@@ -84,6 +89,12 @@ func TestLoadInvalidConfigFilename(t *testing.T) {
 // TestLoadConfigFileWithInvalidPorts tests that loading a config file with the same client and server ports fails
 func TestLoadConfigFileWithInvalidPorts(t *testing.T) {
 	_, err := startWithConfigFile(invalidConfigEqualClientServerPortsPath)
+	require.Error(t, err)
+}
+
+// TestLoadConfigFileWithInvalidPorts tests that loading a config file with the same client and PoPCHA ports fails
+func TestLoadConfigFileWithInvalidAuthPort(t *testing.T) {
+	_, err := startWithConfigFile(invalidConfigEqualClientAuthPortsPath)
 	require.Error(t, err)
 }
 

--- a/be1-go/cli/pop.go
+++ b/be1-go/cli/pop.go
@@ -59,6 +59,12 @@ func run(ctx context.Context, args []string) {
 		Usage:   "address where the server should listen to",
 		Value:   "localhost",
 	}
+	authServerAddressFlag := &cli.StringFlag{
+		Name:    "auth-server-address",
+		Aliases: []string{"asa"},
+		Usage:   "address of the PoPCHA Server",
+		Value:   "localhost",
+	}
 	clientPortFlag := &cli.IntFlag{
 		Name:    "client-port",
 		Aliases: []string{"cp"},
@@ -70,6 +76,12 @@ func run(ctx context.Context, args []string) {
 		Aliases: []string{"sp"},
 		Usage:   "port to listen websocket connections from remote servers on",
 		Value:   9001,
+	}
+	authServerPortFlag := &cli.IntFlag{
+		Name:    "auth-port",
+		Aliases: []string{"asp"},
+		Usage:   "listening port of the PoPCHA HTTP server",
+		Value:   9100,
 	}
 	otherServersFlag := &cli.StringSliceFlag{
 		Name:    "other-servers",
@@ -101,8 +113,10 @@ func run(ctx context.Context, args []string) {
 							clientAddressFlag,
 							serverPublicAddressFlag,
 							serverListenAddressFlag,
+							authServerAddressFlag,
 							clientPortFlag,
 							serverPortFlag,
+							authServerPortFlag,
 							otherServersFlag,
 							configFileFlag,
 						},

--- a/be1-go/cli/pop_test.go
+++ b/be1-go/cli/pop_test.go
@@ -19,7 +19,7 @@ func TestConnectMultipleServers(t *testing.T) {
 	go func() {
 		defer wait.Done()
 
-		args := []string{os.Args[0], "server", "--pk", "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=", "serve", "--server-port", "9011", "--client-port", "8010"}
+		args := []string{os.Args[0], "server", "--pk", "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=", "serve", "--server-port", "9011", "--client-port", "8010", "--auth-port", "9103"}
 		t.Logf("running server 1: %v", args)
 
 		run(ctx, args)
@@ -33,7 +33,8 @@ func TestConnectMultipleServers(t *testing.T) {
 	go func() {
 		defer wait.Done()
 
-		args := []string{os.Args[0], "server", "--pk", "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=", "serve", "--client-port", "8020", "--server-port", "9003", "--other-servers", "localhost:9011"}
+		args := []string{os.Args[0], "server", "--pk", "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=", "serve",
+			"--client-port", "8020", "--server-port", "9003", "--other-servers", "localhost:9011", "--auth-port", "9101"}
 		t.Logf("running server 2: %v", args)
 
 		run(ctx, args)
@@ -47,7 +48,7 @@ func TestConnectMultipleServers(t *testing.T) {
 	go func() {
 		defer wait.Done()
 
-		args := []string{os.Args[0], "server", "--pk", "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=", "serve", "--server-port", "9004", "--client-port", "8021", "--other-servers", "localhost:9011", "localhost:9003"}
+		args := []string{os.Args[0], "server", "--pk", "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=", "serve", "--server-port", "9004", "--client-port", "8021", "--other-servers", "localhost:9011", "localhost:9003", "--auth-port", "9102"}
 		t.Logf("running server 3: %v", args)
 
 		run(ctx, args)
@@ -70,7 +71,7 @@ func TestConnectMultipleServersWithoutPK(t *testing.T) {
 	go func() {
 		defer wait.Done()
 
-		args := []string{os.Args[0], "server", "serve", "--server-port", "9011", "--client-port", "8010"}
+		args := []string{os.Args[0], "server", "serve", "--server-port", "9011", "--client-port", "8010", "--auth-port", "9101"}
 		t.Logf("running server 1: %v", args)
 
 		run(ctx, args)
@@ -84,7 +85,7 @@ func TestConnectMultipleServersWithoutPK(t *testing.T) {
 	go func() {
 		defer wait.Done()
 
-		args := []string{os.Args[0], "server", "serve", "--server-port", "9003", "--client-port", "8020", "--other-servers", "localhost:9011"}
+		args := []string{os.Args[0], "server", "serve", "--server-port", "9003", "--client-port", "8020", "--other-servers", "localhost:9011", "--auth-port", "9102"}
 		t.Logf("running server 2: %v", args)
 
 		run(ctx, args)
@@ -98,7 +99,7 @@ func TestConnectMultipleServersWithoutPK(t *testing.T) {
 	go func() {
 		defer wait.Done()
 
-		args := []string{os.Args[0], "server", "serve", "--server-port", "9004", "--client-port", "8021", "--other-servers", "localhost:9011", "localhost:9003"}
+		args := []string{os.Args[0], "server", "serve", "--server-port", "9004", "--client-port", "8021", "--other-servers", "localhost:9011", "localhost:9003", "--auth-port", "9103"}
 		t.Logf("running server 3: %v", args)
 
 		run(ctx, args)

--- a/be1-go/cli/test_config_files/invalid_config_equal_client_server_ports.json
+++ b/be1-go/cli/test_config_files/invalid_config_equal_client_server_ports.json
@@ -4,7 +4,9 @@
     "client-address"                       : "ws://127.0.0.1:9000/client",
     "server-public-address"                : "localhost",
     "server-listen-address"                : "localhost",
+    "auth-server-address"                  : "localhost",
     "client-port"                          : 9000,
     "server-port"                          : 9000,
+    "auth-port"                            : 9101,
     "other-servers": []
 }

--- a/be1-go/cli/test_config_files/invalid_config_equal_ports.json
+++ b/be1-go/cli/test_config_files/invalid_config_equal_ports.json
@@ -1,0 +1,12 @@
+{
+    "public-key"                           : "",
+    "server-address"                       : "ws://127.0.0.1:9000/server",
+    "client-address"                       : "ws://127.0.0.1:9000/client",
+    "server-public-address"                : "localhost",
+    "server-listen-address"                : "localhost",
+    "auth-server-address"                  : "localhost",
+    "client-port"                          : 9000,
+    "server-port"                          : 9001,
+    "auth-port"                            : 9000,
+    "other-servers": []
+}

--- a/be1-go/cli/test_config_files/valid_config.json
+++ b/be1-go/cli/test_config_files/valid_config.json
@@ -4,7 +4,9 @@
     "client-address"                       : "ws://127.0.0.1:9000/client",
     "server-public-address"                : "localhost",
     "server-listen-address"                : "localhost",
+    "auth-server-address"                  : "localhost",
     "client-port"                          : 9000,
     "server-port"                          : 9001,
+    "auth-port"                            : 9100,
     "other-servers": []
 }

--- a/be1-go/cli/test_config_files/valid_config_watcher.json
+++ b/be1-go/cli/test_config_files/valid_config_watcher.json
@@ -1,1 +1,1 @@
-{"public-key":"","client-address":"ws://localhost:9000/client","server-address":"ws://localhost:9001/server","server-public-address":"localhost","server-listen-address":"localhost","client-port":9000,"server-port":9001,"other-servers":[]}
+{"public-key":"","client-address":"ws://localhost:9000/client","server-address":"ws://localhost:9001/server","server-public-address":"localhost","server-listen-address":"localhost","auth-server-address":"localhost","client-port":9000,"server-port":9001,"auth-port":9100,"other-servers":[]}

--- a/be1-go/configServer1.json
+++ b/be1-go/configServer1.json
@@ -4,7 +4,9 @@
     "client-address"                       : "ws://127.0.0.1:9000/client",
     "server-public-address"                : "localhost",
     "server-listen-address"                : "localhost",
+    "auth-server-address"                  : "localhost",
     "client-port"                          : 9000,
     "server-port"                          : 9001,
+    "auth-port"                            : 9100,
     "other-servers": []
 }

--- a/be1-go/configServer2.json
+++ b/be1-go/configServer2.json
@@ -4,8 +4,10 @@
     "client-address"                       : "ws://127.0.0.1:9002/client",
     "server-public-address"                : "localhost",
     "server-listen-address"                : "localhost",
+    "auth-server-address"                  : "localhost",
     "client-port"                          : 9002,
     "server-port"                          : 9003,
+    "auth-port"                            : 9101,
     "other-servers": [
         "localhost:9001"
     ]

--- a/be1-go/network/shutdown.go
+++ b/be1-go/network/shutdown.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"popstellar/popcha"
 	"syscall"
 )
 
 // WaitAndShutdownServers blocks until the user passes a SIGINT or SIGTERM and
-// then shuts down the http servers.
-func WaitAndShutdownServers(ctx context.Context, servers ...*Server) error {
+// then shuts down the http servers. The popchaSrv argument is optional, and handles the case where
+// we use the authorization server.
+func WaitAndShutdownServers(ctx context.Context, popchaSrv *popcha.AuthorizationServer, servers ...*Server) error {
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
 
@@ -26,5 +28,9 @@ func WaitAndShutdownServers(ctx context.Context, servers ...*Server) error {
 		}
 	}
 
+	// making sure that passing the popchaSrv is optional
+	if popchaSrv != nil {
+		return popchaSrv.Shutdown()
+	}
 	return nil
 }


### PR DESCRIPTION
* adding PoPCHA address and port in the config files
* adding test to ensure distinct ports for server, client and popcha ports
* modifying shutdown.go to integrate the authorization server