### PR TITLE
Fix overflow special character

### DIFF
--- a/fe1-web/src/features/social/components/ChirpCard.tsx
+++ b/fe1-web/src/features/social/components/ChirpCard.tsx
@@ -75,6 +75,9 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-end',
     marginLeft: 'auto',
   } as ViewStyle,
+  noOverflow: {
+    overflow: 'hidden',
+  } as ViewStyle,
 });
 
 const FOUR_SECONDS = 4000;
@@ -205,7 +208,7 @@ const ChirpCard = ({ chirp, isFirstItem, isLastItem }: IPropTypes) => {
         </View>
       </PoPTouchableOpacity>
       <ListItem.Content>
-        <ListItem.Subtitle>
+        <ListItem.Subtitle style={styles.noOverflow}>
           {chirp.isDeleted ? (
             <Text style={[Typography.base, Typography.inactive]}>{STRINGS.deleted_chirp}</Text>
           ) : (

--- a/fe1-web/src/features/social/components/__tests__/__snapshots__/ChirpCard.test.tsx.snap
+++ b/fe1-web/src/features/social/components/__tests__/__snapshots__/ChirpCard.test.tsx.snap
@@ -530,6 +530,7 @@ exports[`ChirpCard for deletion render correct for a deleted chirp 1`] = `
                                   "backgroundColor": "transparent",
                                   "color": "#242424",
                                   "fontSize": 15,
+                                  "overflow": "hidden",
                                 }
                               }
                               testID="listItemTitle"
@@ -1148,6 +1149,7 @@ exports[`ChirpCard for deletion renders correctly for non-sender 1`] = `
                                   "backgroundColor": "transparent",
                                   "color": "#242424",
                                   "fontSize": 15,
+                                  "overflow": "hidden",
                                 }
                               }
                               testID="listItemTitle"
@@ -2043,6 +2045,7 @@ exports[`ChirpCard for deletion renders correctly for sender 1`] = `
                                   "backgroundColor": "transparent",
                                   "color": "#242424",
                                   "fontSize": 15,
+                                  "overflow": "hidden",
                                 }
                               }
                               testID="listItemTitle"
@@ -3017,6 +3020,7 @@ exports[`ChirpCard for reaction renders correctly with reaction 1`] = `
                                   "backgroundColor": "transparent",
                                   "color": "#242424",
                                   "fontSize": 15,
+                                  "overflow": "hidden",
                                 }
                               }
                               testID="listItemTitle"
@@ -3912,6 +3916,7 @@ exports[`ChirpCard for reaction renders correctly without reaction 1`] = `
                                   "backgroundColor": "transparent",
                                   "color": "#242424",
                                   "fontSize": 15,
+                                  "overflow": "hidden",
                                 }
                               }
                               testID="listItemTitle"

--- a/fe1-web/src/features/social/screens/__tests__/__snapshots__/SocialTopChirps.test.tsx.snap
+++ b/fe1-web/src/features/social/screens/__tests__/__snapshots__/SocialTopChirps.test.tsx.snap
@@ -577,6 +577,7 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                           "backgroundColor": "transparent",
                                           "color": "#242424",
                                           "fontSize": 15,
+                                          "overflow": "hidden",
                                         }
                                       }
                                       testID="listItemTitle"
@@ -1138,6 +1139,7 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                           "backgroundColor": "transparent",
                                           "color": "#242424",
                                           "fontSize": 15,
+                                          "overflow": "hidden",
                                         }
                                       }
                                       testID="listItemTitle"
@@ -1705,6 +1707,7 @@ exports[`SocialTopChirps renders correctly 1`] = `
                                           "backgroundColor": "transparent",
                                           "color": "#242424",
                                           "fontSize": 15,
+                                          "overflow": "hidden",
                                         }
                                       }
                                       testID="listItemTitle"


### PR DESCRIPTION
This small PR fixes the issue with characters such as Zalgo characters overflowing, now the screen looks like this:

![image](https://github.com/dedis/popstellar/assets/82887324/47cde279-427c-4270-888c-904e262662a0)

Now these Zalgo characters are cropped, I tried using "big" characters that are used to check they are still correctly displayed and they are not cropped, so normally this shouldn't affect any "normal" text.