### PR TITLE
Fix empty lines in ballot disappearing

### DIFF
--- a/fe1-web/src/features/evoting/screens/CreateElection.tsx
+++ b/fe1-web/src/features/evoting/screens/CreateElection.tsx
@@ -414,7 +414,7 @@ const CreateElection = () => {
                   id === idx
                     ? {
                         ...item,
-                        ballot_options: ballot_options.filter((option) => option !== ''),
+                        ballot_options: ballot_options,
                       }
                     : item,
                 ),


### PR DESCRIPTION
This simple PR fixes the fact that the ballot option would disappear if the line is empty, which could surprise the user, now it can have the empty line and there would be a message to say the user can't submit (message was already there)

![image](https://github.com/dedis/popstellar/assets/82887324/ea296234-5f7c-4ce4-a18b-8fbdeece5614)
