### PR TITLE
Fix build info over left menu

### DIFF
--- a/fe1-web/src/App.tsx
+++ b/fe1-web/src/App.tsx
@@ -10,7 +10,6 @@ import Toast, { ToastProvider } from 'react-native-toast-notifications';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 
-import { BuildInfo } from 'core/components';
 import FeatureContext from 'core/contexts/FeatureContext';
 import { configureKeyPair } from 'core/keypair';
 import AppNavigation, { navigationRef } from 'core/navigation/AppNavigation';
@@ -50,7 +49,6 @@ function App() {
                 {Platform.OS === 'ios' && (
                   <StatusBar barStyle="dark-content" backgroundColor="white" />
                 )}
-                <BuildInfo />
                 <ToastProvider
                   normalColor={Color.primary}
                   successColor={Color.success}

--- a/fe1-web/src/core/components/BuildInfo.tsx
+++ b/fe1-web/src/core/components/BuildInfo.tsx
@@ -7,10 +7,9 @@ import { Spacing, Typography } from 'core/styles';
 const styles = StyleSheet.create({
   container: {
     position: 'absolute',
-    top: Spacing.x3,
+    bottom: Spacing.x075,
     left: Spacing.x05,
     right: Spacing.x05,
-    zIndex: 100,
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'center',

--- a/fe1-web/src/core/components/__tests__/__snapshots__/BuildInfo.test.tsx.snap
+++ b/fe1-web/src/core/components/__tests__/__snapshots__/BuildInfo.test.tsx.snap
@@ -4,14 +4,13 @@ exports[`BuildInfo renders correctly 1`] = `
 <View
   style={
     {
+      "bottom": 12,
       "display": "flex",
       "flexDirection": "row",
       "justifyContent": "center",
       "left": 8,
       "position": "absolute",
       "right": 8,
-      "top": 48,
-      "zIndex": 100,
     }
   }
 >

--- a/fe1-web/src/core/navigation/ScreenOptions.ts
+++ b/fe1-web/src/core/navigation/ScreenOptions.ts
@@ -21,6 +21,10 @@ export const stackScreenOptionsWithoutHeader: StackNavigationOptions = {
 
 export const stackScreenOptionsWithHeader: StackNavigationOptions = {
   headerBackground: buildInfo,
+  headerBackgroundContainerStyle: {
+    backgroundColor: Color.contrast,
+    borderColor: Color.separator,
+  },
   headerLeftContainerStyle: {
     flexBasis: 'auto',
     paddingLeft: Spacing.contentSpacing,
@@ -34,10 +38,6 @@ export const stackScreenOptionsWithHeader: StackNavigationOptions = {
   },
   headerTitleStyle: Typography.topNavigationHeading,
   headerTitleAlign: 'center',
-  headerStyle: {
-    backgroundColor: Color.contrast,
-    borderColor: Color.separator,
-  },
   headerLeft: BackButton,
   headerRight: ButtonPadding,
   // Since we explicitly use scroll views for screens, we should disable scrolling for

--- a/fe1-web/src/core/navigation/ScreenOptions.ts
+++ b/fe1-web/src/core/navigation/ScreenOptions.ts
@@ -7,6 +7,8 @@ import ButtonPadding from 'core/components/ButtonPadding';
 import DrawerMenuButton from 'core/components/DrawerMenuButton';
 import { Color, Spacing, Typography } from 'core/styles';
 
+import buildInfo from '../components/BuildInfo';
+
 export const stackScreenOptionsWithoutHeader: StackNavigationOptions = {
   headerShown: false,
   headerLeft: BackButton,
@@ -18,6 +20,7 @@ export const stackScreenOptionsWithoutHeader: StackNavigationOptions = {
 };
 
 export const stackScreenOptionsWithHeader: StackNavigationOptions = {
+  headerBackground: buildInfo,
   headerLeftContainerStyle: {
     flexBasis: 'auto',
     paddingLeft: Spacing.contentSpacing,

--- a/fe1-web/src/core/navigation/ScreenOptions.ts
+++ b/fe1-web/src/core/navigation/ScreenOptions.ts
@@ -3,11 +3,10 @@ import { StackNavigationOptions } from '@react-navigation/stack';
 import { ViewStyle } from 'react-native';
 
 import BackButton from 'core/components/BackButton';
+import buildInfo from 'core/components/BuildInfo';
 import ButtonPadding from 'core/components/ButtonPadding';
 import DrawerMenuButton from 'core/components/DrawerMenuButton';
 import { Color, Spacing, Typography } from 'core/styles';
-
-import buildInfo from '../components/BuildInfo';
 
 export const stackScreenOptionsWithoutHeader: StackNavigationOptions = {
   headerShown: false,

--- a/fe1-web/src/core/styles/spacing.ts
+++ b/fe1-web/src/core/styles/spacing.ts
@@ -2,6 +2,7 @@ const spacingUnit = 16;
 
 export const x025 = 0.25 * spacingUnit;
 export const x05 = 0.5 * spacingUnit;
+export const x075 = 0.75 * spacingUnit;
 export const x1 = spacingUnit;
 export const x2 = 2 * spacingUnit;
 export const x3 = 3 * spacingUnit;

--- a/fe1-web/src/features/home/navigation/__tests__/__snapshots__/ConnectNavigation.test.tsx.snap
+++ b/fe1-web/src/features/home/navigation/__tests__/__snapshots__/ConnectNavigation.test.tsx.snap
@@ -376,6 +376,8 @@ exports[`ConnectNavigation renders correctly 1`] = `
                                   pointerEvents="box-none"
                                   style={
                                     {
+                                      "backgroundColor": "#fff",
+                                      "borderColor": "rgb(216, 216, 216)",
                                       "bottom": 0,
                                       "left": 0,
                                       "opacity": 1,
@@ -389,14 +391,13 @@ exports[`ConnectNavigation renders correctly 1`] = `
                                   <View
                                     style={
                                       {
+                                        "bottom": 12,
                                         "display": "flex",
                                         "flexDirection": "row",
                                         "justifyContent": "center",
                                         "left": 8,
                                         "position": "absolute",
                                         "right": 8,
-                                        "top": 48,
-                                        "zIndex": 100,
                                       }
                                     }
                                   >

--- a/fe1-web/src/features/home/navigation/__tests__/__snapshots__/ConnectNavigation.test.tsx.snap
+++ b/fe1-web/src/features/home/navigation/__tests__/__snapshots__/ConnectNavigation.test.tsx.snap
@@ -387,23 +387,53 @@ exports[`ConnectNavigation renders correctly 1`] = `
                                   }
                                 >
                                   <View
-                                    collapsable={false}
                                     style={
                                       {
-                                        "backgroundColor": "#fff",
-                                        "borderBottomColor": "rgb(216, 216, 216)",
-                                        "borderColor": "rgb(216, 216, 216)",
-                                        "flex": 1,
-                                        "shadowColor": "rgb(216, 216, 216)",
-                                        "shadowOffset": {
-                                          "height": 0.5,
-                                          "width": 0,
-                                        },
-                                        "shadowOpacity": 0.85,
-                                        "shadowRadius": 0,
+                                        "display": "flex",
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "left": 8,
+                                        "position": "absolute",
+                                        "right": 8,
+                                        "top": 48,
+                                        "zIndex": 100,
                                       }
                                     }
-                                  />
+                                  >
+                                    <Text
+                                      style={
+                                        [
+                                          {
+                                            "fontSize": 8,
+                                            "lineHeight": 1,
+                                          },
+                                          {
+                                            "color": "#8E8E8E",
+                                          },
+                                          {
+                                            "fontFamily": "Courier New",
+                                          },
+                                          {
+                                            "textTransform": "uppercase",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        onPress={[Function]}
+                                      />
+                                      <Text>
+                                         | 
+                                      </Text>
+                                      <Text
+                                        onPress={[Function]}
+                                      />
+                                      <Text>
+                                         | 
+                                      </Text>
+                                      <Text />
+                                    </Text>
+                                  </View>
                                 </View>
                                 <View
                                   collapsable={false}

--- a/fe1-web/src/features/home/navigation/__tests__/__snapshots__/HomeNavigation.test.tsx.snap
+++ b/fe1-web/src/features/home/navigation/__tests__/__snapshots__/HomeNavigation.test.tsx.snap
@@ -376,6 +376,8 @@ exports[`HomeNavigation renders correctly 1`] = `
                                   pointerEvents="box-none"
                                   style={
                                     {
+                                      "backgroundColor": "#fff",
+                                      "borderColor": "rgb(216, 216, 216)",
                                       "bottom": 0,
                                       "left": 0,
                                       "opacity": 1,
@@ -389,14 +391,13 @@ exports[`HomeNavigation renders correctly 1`] = `
                                   <View
                                     style={
                                       {
+                                        "bottom": 12,
                                         "display": "flex",
                                         "flexDirection": "row",
                                         "justifyContent": "center",
                                         "left": 8,
                                         "position": "absolute",
                                         "right": 8,
-                                        "top": 48,
-                                        "zIndex": 100,
                                       }
                                     }
                                   >

--- a/fe1-web/src/features/home/navigation/__tests__/__snapshots__/HomeNavigation.test.tsx.snap
+++ b/fe1-web/src/features/home/navigation/__tests__/__snapshots__/HomeNavigation.test.tsx.snap
@@ -387,23 +387,53 @@ exports[`HomeNavigation renders correctly 1`] = `
                                   }
                                 >
                                   <View
-                                    collapsable={false}
                                     style={
                                       {
-                                        "backgroundColor": "#fff",
-                                        "borderBottomColor": "rgb(216, 216, 216)",
-                                        "borderColor": "rgb(216, 216, 216)",
-                                        "flex": 1,
-                                        "shadowColor": "rgb(216, 216, 216)",
-                                        "shadowOffset": {
-                                          "height": 0.5,
-                                          "width": 0,
-                                        },
-                                        "shadowOpacity": 0.85,
-                                        "shadowRadius": 0,
+                                        "display": "flex",
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "left": 8,
+                                        "position": "absolute",
+                                        "right": 8,
+                                        "top": 48,
+                                        "zIndex": 100,
                                       }
                                     }
-                                  />
+                                  >
+                                    <Text
+                                      style={
+                                        [
+                                          {
+                                            "fontSize": 8,
+                                            "lineHeight": 1,
+                                          },
+                                          {
+                                            "color": "#8E8E8E",
+                                          },
+                                          {
+                                            "fontFamily": "Courier New",
+                                          },
+                                          {
+                                            "textTransform": "uppercase",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        onPress={[Function]}
+                                      />
+                                      <Text>
+                                         | 
+                                      </Text>
+                                      <Text
+                                        onPress={[Function]}
+                                      />
+                                      <Text>
+                                         | 
+                                      </Text>
+                                      <Text />
+                                    </Text>
+                                  </View>
                                 </View>
                                 <View
                                   collapsable={false}

--- a/fe1-web/src/features/lao/navigation/LaoNavigation.tsx
+++ b/fe1-web/src/features/lao/navigation/LaoNavigation.tsx
@@ -9,6 +9,7 @@ import {
 import React, { useMemo } from 'react';
 import { StyleSheet, Text, View, ViewStyle } from 'react-native';
 
+import { BuildInfo } from 'core/components';
 import ButtonPadding from 'core/components/ButtonPadding';
 import { makeIcon } from 'core/components/PoPIcon';
 import { AppScreen } from 'core/navigation/AppNavigation';
@@ -173,6 +174,11 @@ const LaoNavigation: React.FC<unknown> = () => {
                   headerLeft: headerLeft || drawerNavigationOptions.headerLeft,
                   headerRight: headerRight || drawerNavigationOptions.headerRight,
                   drawerIcon: Icon,
+                  headerBackground: BuildInfo,
+                  headerBackgroundContainerStyle: {
+                    backgroundColor: Color.contrast,
+                    borderColor: Color.separator,
+                  },
                   headerShown,
                   tabBarTestID: testID,
                   tabBarStyle:

--- a/fe1-web/src/features/lao/navigation/__tests__/__snapshots__/EventsNavigation.test.tsx.snap
+++ b/fe1-web/src/features/lao/navigation/__tests__/__snapshots__/EventsNavigation.test.tsx.snap
@@ -376,6 +376,8 @@ exports[`OrganizerNavigation renders correctly 1`] = `
                                   pointerEvents="box-none"
                                   style={
                                     {
+                                      "backgroundColor": "#fff",
+                                      "borderColor": "rgb(216, 216, 216)",
                                       "bottom": 0,
                                       "left": 0,
                                       "opacity": 1,
@@ -389,14 +391,13 @@ exports[`OrganizerNavigation renders correctly 1`] = `
                                   <View
                                     style={
                                       {
+                                        "bottom": 12,
                                         "display": "flex",
                                         "flexDirection": "row",
                                         "justifyContent": "center",
                                         "left": 8,
                                         "position": "absolute",
                                         "right": 8,
-                                        "top": 48,
-                                        "zIndex": 100,
                                       }
                                     }
                                   >

--- a/fe1-web/src/features/lao/navigation/__tests__/__snapshots__/EventsNavigation.test.tsx.snap
+++ b/fe1-web/src/features/lao/navigation/__tests__/__snapshots__/EventsNavigation.test.tsx.snap
@@ -387,23 +387,53 @@ exports[`OrganizerNavigation renders correctly 1`] = `
                                   }
                                 >
                                   <View
-                                    collapsable={false}
                                     style={
                                       {
-                                        "backgroundColor": "#fff",
-                                        "borderBottomColor": "rgb(216, 216, 216)",
-                                        "borderColor": "rgb(216, 216, 216)",
-                                        "flex": 1,
-                                        "shadowColor": "rgb(216, 216, 216)",
-                                        "shadowOffset": {
-                                          "height": 0.5,
-                                          "width": 0,
-                                        },
-                                        "shadowOpacity": 0.85,
-                                        "shadowRadius": 0,
+                                        "display": "flex",
+                                        "flexDirection": "row",
+                                        "justifyContent": "center",
+                                        "left": 8,
+                                        "position": "absolute",
+                                        "right": 8,
+                                        "top": 48,
+                                        "zIndex": 100,
                                       }
                                     }
-                                  />
+                                  >
+                                    <Text
+                                      style={
+                                        [
+                                          {
+                                            "fontSize": 8,
+                                            "lineHeight": 1,
+                                          },
+                                          {
+                                            "color": "#8E8E8E",
+                                          },
+                                          {
+                                            "fontFamily": "Courier New",
+                                          },
+                                          {
+                                            "textTransform": "uppercase",
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        onPress={[Function]}
+                                      />
+                                      <Text>
+                                         | 
+                                      </Text>
+                                      <Text
+                                        onPress={[Function]}
+                                      />
+                                      <Text>
+                                         | 
+                                      </Text>
+                                      <Text />
+                                    </Text>
+                                  </View>
                                 </View>
                                 <View
                                   collapsable={false}

--- a/fe1-web/src/features/lao/navigation/__tests__/__snapshots__/LaoNavigation.test.tsx.snap
+++ b/fe1-web/src/features/lao/navigation/__tests__/__snapshots__/LaoNavigation.test.tsx.snap
@@ -501,6 +501,8 @@ exports[`LaoNavigation renders correctly 1`] = `
                                                     pointerEvents="box-none"
                                                     style={
                                                       {
+                                                        "backgroundColor": "#fff",
+                                                        "borderColor": "rgb(216, 216, 216)",
                                                         "bottom": 0,
                                                         "left": 0,
                                                         "opacity": 1,
@@ -514,14 +516,13 @@ exports[`LaoNavigation renders correctly 1`] = `
                                                     <View
                                                       style={
                                                         {
+                                                          "bottom": 12,
                                                           "display": "flex",
                                                           "flexDirection": "row",
                                                           "justifyContent": "center",
                                                           "left": 8,
                                                           "position": "absolute",
                                                           "right": 8,
-                                                          "top": 48,
-                                                          "zIndex": 100,
                                                         }
                                                       }
                                                     >

--- a/fe1-web/src/features/lao/navigation/__tests__/__snapshots__/LaoNavigation.test.tsx.snap
+++ b/fe1-web/src/features/lao/navigation/__tests__/__snapshots__/LaoNavigation.test.tsx.snap
@@ -512,23 +512,53 @@ exports[`LaoNavigation renders correctly 1`] = `
                                                     }
                                                   >
                                                     <View
-                                                      collapsable={false}
                                                       style={
                                                         {
-                                                          "backgroundColor": "#fff",
-                                                          "borderBottomColor": "rgb(216, 216, 216)",
-                                                          "borderColor": "rgb(216, 216, 216)",
-                                                          "flex": 1,
-                                                          "shadowColor": "rgb(216, 216, 216)",
-                                                          "shadowOffset": {
-                                                            "height": 0.5,
-                                                            "width": 0,
-                                                          },
-                                                          "shadowOpacity": 0.85,
-                                                          "shadowRadius": 0,
+                                                          "display": "flex",
+                                                          "flexDirection": "row",
+                                                          "justifyContent": "center",
+                                                          "left": 8,
+                                                          "position": "absolute",
+                                                          "right": 8,
+                                                          "top": 48,
+                                                          "zIndex": 100,
                                                         }
                                                       }
-                                                    />
+                                                    >
+                                                      <Text
+                                                        style={
+                                                          [
+                                                            {
+                                                              "fontSize": 8,
+                                                              "lineHeight": 1,
+                                                            },
+                                                            {
+                                                              "color": "#8E8E8E",
+                                                            },
+                                                            {
+                                                              "fontFamily": "Courier New",
+                                                            },
+                                                            {
+                                                              "textTransform": "uppercase",
+                                                            },
+                                                          ]
+                                                        }
+                                                      >
+                                                        <Text
+                                                          onPress={[Function]}
+                                                        />
+                                                        <Text>
+                                                           | 
+                                                        </Text>
+                                                        <Text
+                                                          onPress={[Function]}
+                                                        />
+                                                        <Text>
+                                                           | 
+                                                        </Text>
+                                                        <Text />
+                                                      </Text>
+                                                    </View>
                                                   </View>
                                                   <View
                                                     collapsable={false}

--- a/fe1-web/src/features/social/navigation/SocialMediaNavigation.tsx
+++ b/fe1-web/src/features/social/navigation/SocialMediaNavigation.tsx
@@ -3,6 +3,7 @@ import { CompositeScreenProps, useNavigation } from '@react-navigation/core';
 import { StackScreenProps } from '@react-navigation/stack';
 import React, { useMemo, useState } from 'react';
 
+import { BuildInfo } from 'core/components';
 import DrawerMenuButton from 'core/components/DrawerMenuButton';
 import { makeIcon } from 'core/components/PoPIcon';
 import { AppParamList } from 'core/navigation/typing/AppParamList';
@@ -75,8 +76,11 @@ const SocialMediaNavigation = () => {
     <SocialMediaContext.Provider value={contextValue}>
       <Tab.Navigator
         screenOptions={{
-          tabBarActiveTintColor: Color.accent,
-          tabBarInactiveTintColor: Color.inactive,
+          headerBackground: BuildInfo,
+          headerBackgroundContainerStyle: {
+            backgroundColor: Color.contrast,
+            borderColor: Color.separator,
+          },
           headerLeft: DrawerMenuButton,
           headerLeftContainerStyle: {
             paddingLeft: Spacing.contentSpacing,


### PR DESCRIPTION
Fix #1592

This PR puts the Build infos in the header background, so that they do not overlap anymore with the left menu.
Without menu:
![image](https://github.com/dedis/popstellar/assets/42808302/e232d84f-9c61-45bb-baa9-54a649197df5)

With menu: 
![image](https://github.com/dedis/popstellar/assets/42808302/ffc60695-aed6-4c88-a17a-eb958c03319b)
