### PR TITLE
Disallow multiple whitespace in chirps

### DIFF
--- a/fe1-web/src/features/social/components/NewChirp.tsx
+++ b/fe1-web/src/features/social/components/NewChirp.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { useContext, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { StyleSheet, Text, TextStyle, View, ViewStyle } from 'react-native';
 import { useToast } from 'react-native-toast-notifications';
 
+import { ConfirmModal } from 'core/components';
 import { Spacing, Typography } from 'core/styles';
 import { FOUR_SECONDS } from 'resources/const';
 import STRINGS from 'resources/strings';
@@ -27,6 +28,8 @@ const NewChirp = () => {
   const toast = useToast();
   const laoId = SocialHooks.useCurrentLaoId();
   const isConnected = SocialHooks.useConnectedToLao();
+  const [showPublishConfirmation, setShowPublishConfirmation] = useState(false);
+  const trimmedInputChirp = useMemo(() => inputChirp.replace(/\s+/g, ' ').trim(), [inputChirp]);
 
   if (laoId === undefined) {
     throw new Error('Impossible to render Social Home, current lao id is undefined');
@@ -40,7 +43,7 @@ const NewChirp = () => {
       return;
     }
 
-    requestAddChirp(currentUserPopTokenPublicKey, inputChirp, laoId)
+    requestAddChirp(currentUserPopTokenPublicKey, trimmedInputChirp, laoId)
       .then(() => {
         setInputChirp('');
       })
@@ -60,7 +63,13 @@ const NewChirp = () => {
         testID="new_chirp"
         value={inputChirp}
         onChangeText={setInputChirp}
-        onPress={publishChirp}
+        onPress={() => {
+          if (trimmedInputChirp === inputChirp) {
+            publishChirp();
+          } else {
+            setShowPublishConfirmation(true);
+          }
+        }}
         disabled={publishDisabled}
         currentUserPublicKey={currentUserPopTokenPublicKey}
       />
@@ -69,6 +78,16 @@ const NewChirp = () => {
           {STRINGS.social_media_create_chirp_no_pop_token}
         </Text>
       )}
+      <ConfirmModal
+        onConfirmPress={publishChirp}
+        visibility={showPublishConfirmation}
+        description={STRINGS.social_media_ask_publish_trimmed_chirp.replace(
+          '{}',
+          trimmedInputChirp,
+        )}
+        title={STRINGS.social_media_confirm_publish_chirp}
+        setVisibility={setShowPublishConfirmation}
+      />
     </View>
   );
 };

--- a/fe1-web/src/features/social/components/__tests__/__snapshots__/NewChirp.test.tsx.snap
+++ b/fe1-web/src/features/social/components/__tests__/__snapshots__/NewChirp.test.tsx.snap
@@ -187,5 +187,11 @@ exports[`NewChirp renders correctly 1`] = `
       </View>
     </View>
   </View>
+  <Modal
+    hardwareAccelerated={false}
+    onRequestClose={[Function]}
+    transparent={true}
+    visible={false}
+  />
 </View>
 `;

--- a/fe1-web/src/features/social/screens/__tests__/__snapshots__/SocialHome.test.tsx.snap
+++ b/fe1-web/src/features/social/screens/__tests__/__snapshots__/SocialHome.test.tsx.snap
@@ -235,6 +235,12 @@ exports[`SocialHome renders correctly 1`] = `
             </View>
           </View>
         </View>
+        <Modal
+          hardwareAccelerated={false}
+          onRequestClose={[Function]}
+          transparent={true}
+          visible={false}
+        />
       </View>
     </View>
   </RCTScrollView>

--- a/fe1-web/src/resources/strings.ts
+++ b/fe1-web/src/resources/strings.ts
@@ -147,6 +147,9 @@ namespace STRINGS {
   export const button_publish = 'Publish';
   export const your_chirp = 'Your chirp';
   export const deleted_chirp = 'This chirp was deleted';
+  export const social_media_ask_publish_trimmed_chirp =
+    'Your chirp has been trimmed to : \n\n {}\n\nDo you still want to publish this chirp ?';
+  export const social_media_confirm_publish_chirp = 'Confirm publication';
   export const social_media_ask_confirm_delete_chirp =
     'Are you sure you want to delete this chirp?';
   export const social_media_confirm_delete_chirp = 'Confirm deletion';


### PR DESCRIPTION
Resolves #1627 

The user won't be able to send chirps that include line breaks anymore. The user can only send chirps where any substring of whitespace will be replaced by a single space. 

While the user writes the chirp, he won't get any live feedback (to not have an error message poping up and disappearing any time you type multiple spaces).
Instead, the user will have a confirmation window (only if the chirp is not valid) with an insight f its trimmed chirp.

While typing: 
![image](https://github.com/dedis/popstellar/assets/42808302/df98ed99-a768-472c-acd1-db06ffc96cca)
The confirmation window:
![image](https://github.com/dedis/popstellar/assets/42808302/381b301f-36ad-4f4d-8660-e713c1092fd1)
