### PR TITLE
Fix pb with already deleted chirp

### DIFF
--- a/fe1-web/src/features/social/reducer/SocialReducer.ts
+++ b/fe1-web/src/features/social/reducer/SocialReducer.ts
@@ -253,6 +253,11 @@ const socialSlice = createSlice({
 
         const reaction = store.reactionsById[reactionId];
 
+        // reaction was already deleted
+        if (reaction === undefined) {
+          return;
+        }
+
         // delete id from mapping, works even if it does not exist
         delete store.reactionsById[reactionId];
 


### PR DESCRIPTION
This small PR fixes the small problem of error msg shown in terminal ("reaction is undefined"), this was simply due that after deleting the reaction if the user receives again the delete info message, it would look for this reaction but since it was deleted, it no longer exists. To fix I simply check that the reaction is not undefined, before continuing