### PR TITLE
Ask confirmation leaving rollcall with newly scanned tokens

### DIFF
--- a/fe1-web/src/core/components/BackButton.tsx
+++ b/fe1-web/src/core/components/BackButton.tsx
@@ -12,12 +12,12 @@ import PoPTouchableOpacity from './PoPTouchableOpacity';
 
 type NavigationProps = StackNavigationProp<AppParamList>;
 
-const BackButton = ({ padding }: IPropTypes) => {
+const BackButton = ({ padding, testID }: IPropTypes) => {
   const navigation = useNavigation<NavigationProps>();
 
   return (
     <>
-      <PoPTouchableOpacity onPress={navigation.goBack}>
+      <PoPTouchableOpacity onPress={navigation.goBack} testID={testID}>
         <PoPIcon name="arrowBack" color={Color.inactive} size={Icon.size} />
       </PoPTouchableOpacity>
       <ButtonPadding paddingAmount={padding || 0} nextToIcon />
@@ -27,12 +27,14 @@ const BackButton = ({ padding }: IPropTypes) => {
 
 const propTypes = {
   padding: PropTypes.number,
+  testID: PropTypes.string,
 };
 
 BackButton.propTypes = propTypes;
 
 BackButton.defaultProps = {
   padding: 0,
+  testID: undefined,
 };
 
 type IPropTypes = PropTypes.InferProps<typeof propTypes>;

--- a/fe1-web/src/features/rollCall/screens/ViewSingleRollCall.tsx
+++ b/fe1-web/src/features/rollCall/screens/ViewSingleRollCall.tsx
@@ -21,7 +21,7 @@ import RollCallCreated from '../components/RollCallCreated';
 import RollCallOpen from '../components/RollCallOpen';
 import { RollCallHooks } from '../hooks';
 import { RollCallFeature } from '../interface';
-import { RollCallStatus } from '../objects';
+import { RollCall, RollCallStatus } from '../objects';
 import { makeRollCallSelector } from '../reducer';
 
 type NavigationProps = CompositeScreenProps<
@@ -114,15 +114,19 @@ const ReturnButton = ({ padding }: IPropTypes) => {
 
   if (
     rollCall === undefined ||
-    rollCall.attendees === undefined ||
-    attendeePopTokensStrings === undefined
+    attendeePopTokensStrings === undefined ||
+    // only the organizer -> no new scanned attendees
+    attendeePopTokensStrings.length <= 1
   ) {
     return backButton({ padding });
   }
 
-  // no new scanned attendees
-  if (attendeePopTokensStrings?.length <= rollCall.attendees.length) {
-    return backButton({ padding });
+  // attendees are undefined but poptokens are not -> new scanned attendees
+  if (rollCall.attendees !== undefined) {
+    // attendeesPopTokens longer than rollCall.attendees -> new scanned attendees
+    if (attendeePopTokensStrings?.length <= rollCall.attendees.length) {
+      return backButton({ padding });
+    }
   }
 
   // new scanned attendees -> leaving will not save the new attendees
@@ -135,8 +139,8 @@ const ReturnButton = ({ padding }: IPropTypes) => {
       <ConfirmModal
         onConfirmPress={navigation.goBack}
         visibility={showConfirmModal}
-        description="Description"
-        title="Title"
+        description={STRINGS.roll_call_leave_description}
+        title={STRINGS.roll_call_leave_confirmation_title}
         setVisibility={setShowConfirmModal}
       />
     </>

--- a/fe1-web/src/features/rollCall/screens/ViewSingleRollCall.tsx
+++ b/fe1-web/src/features/rollCall/screens/ViewSingleRollCall.tsx
@@ -1,5 +1,5 @@
 import { CompositeScreenProps, useNavigation, useRoute } from '@react-navigation/core';
-import { StackScreenProps } from '@react-navigation/stack';
+import { StackNavigationProp, StackScreenProps } from '@react-navigation/stack';
 import PropTypes from 'prop-types';
 import React, { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -21,7 +21,7 @@ import RollCallCreated from '../components/RollCallCreated';
 import RollCallOpen from '../components/RollCallOpen';
 import { RollCallHooks } from '../hooks';
 import { RollCallFeature } from '../interface';
-import { RollCall, RollCallStatus } from '../objects';
+import { RollCallStatus } from '../objects';
 import { makeRollCallSelector } from '../reducer';
 
 type NavigationProps = CompositeScreenProps<
@@ -30,6 +30,11 @@ type NavigationProps = CompositeScreenProps<
     StackScreenProps<LaoParamList, typeof STRINGS.navigation_lao_events>,
     StackScreenProps<AppParamList, typeof STRINGS.navigation_app_lao>
   >
+>;
+
+type SingleRollCallProps = StackNavigationProp<
+  LaoEventsParamList,
+  typeof STRINGS.events_view_single_roll_call
 >;
 
 /**
@@ -103,7 +108,7 @@ const ViewSingleRollCall = () => {
  */
 const ReturnButton = ({ padding }: IPropTypes) => {
   const navigationRoute = useRoute<NavigationProps['route']>();
-  const navigation = useNavigation<NavigationProps>();
+  const navigation = useNavigation<SingleRollCallProps>();
   const { attendeePopTokens: attendeePopTokensStrings, eventId: rollCallId } =
     navigationRoute.params;
 

--- a/fe1-web/src/features/rollCall/screens/ViewSingleRollCall.tsx
+++ b/fe1-web/src/features/rollCall/screens/ViewSingleRollCall.tsx
@@ -4,18 +4,18 @@ import PropTypes from 'prop-types';
 import React, { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
+import { ConfirmModal } from 'core/components';
+import BackButton from 'core/components/BackButton';
+import ButtonPadding from 'core/components/ButtonPadding';
+import PoPIcon from 'core/components/PoPIcon';
+import PoPTouchableOpacity from 'core/components/PoPTouchableOpacity';
 import { AppParamList } from 'core/navigation/typing/AppParamList';
 import { LaoEventsParamList } from 'core/navigation/typing/LaoEventsParamList';
 import { LaoParamList } from 'core/navigation/typing/LaoParamList';
 import { Hash, PublicKey } from 'core/objects';
+import { Color, Icon } from 'core/styles';
 import STRINGS from 'resources/strings';
 
-import { ConfirmModal } from '../../../core/components';
-import backButton from '../../../core/components/BackButton';
-import ButtonPadding from '../../../core/components/ButtonPadding';
-import PoPIcon from '../../../core/components/PoPIcon';
-import PoPTouchableOpacity from '../../../core/components/PoPTouchableOpacity';
-import { Color, Icon } from '../../../core/styles';
 import RollCallClosed from '../components/RollCallClosed';
 import RollCallCreated from '../components/RollCallCreated';
 import RollCallOpen from '../components/RollCallOpen';
@@ -123,14 +123,14 @@ const ReturnButton = ({ padding }: IPropTypes) => {
     // only the organizer -> no new scanned attendees
     attendeePopTokensStrings.length <= 1
   ) {
-    return backButton({ padding, testID: 'backButton' });
+    return <BackButton padding={padding} testID="backButton" />;
   }
 
   // attendees are undefined but poptokens are not -> new scanned attendees
   if (rollCall.attendees !== undefined) {
     // attendeesPopTokens longer than rollCall.attendees -> new scanned attendees
     if (attendeePopTokensStrings?.length <= rollCall.attendees.length) {
-      return backButton({ padding, testID: 'backButton' });
+      return <BackButton padding={padding} testID="backButton" />;
     }
   }
 

--- a/fe1-web/src/features/rollCall/screens/ViewSingleRollCall.tsx
+++ b/fe1-web/src/features/rollCall/screens/ViewSingleRollCall.tsx
@@ -123,21 +123,21 @@ const ReturnButton = ({ padding }: IPropTypes) => {
     // only the organizer -> no new scanned attendees
     attendeePopTokensStrings.length <= 1
   ) {
-    return backButton({ padding });
+    return backButton({ padding, testID: 'backButton' });
   }
 
   // attendees are undefined but poptokens are not -> new scanned attendees
   if (rollCall.attendees !== undefined) {
     // attendeesPopTokens longer than rollCall.attendees -> new scanned attendees
     if (attendeePopTokensStrings?.length <= rollCall.attendees.length) {
-      return backButton({ padding });
+      return backButton({ padding, testID: 'backButton' });
     }
   }
 
   // new scanned attendees -> leaving will not save the new attendees
   return (
     <>
-      <PoPTouchableOpacity onPress={() => setShowConfirmModal(true)}>
+      <PoPTouchableOpacity onPress={() => setShowConfirmModal(true)} testID="backButton">
         <PoPIcon name="arrowBack" color={Color.inactive} size={Icon.size} />
       </PoPTouchableOpacity>
       <ButtonPadding paddingAmount={padding || 0} nextToIcon />

--- a/fe1-web/src/features/rollCall/screens/__tests__/ViewSingleRollCall.test.tsx
+++ b/fe1-web/src/features/rollCall/screens/__tests__/ViewSingleRollCall.test.tsx
@@ -169,7 +169,11 @@ describe('EventRollCall', () => {
       });
 
       it('should show confirmation modal if new scanned attendees', () => {
-        const { getByTestId } = getRenderedComponent(mockRollCallOpened, ['attendee1', 'attendee2', 'attendee3']);
+        const { getByTestId } = getRenderedComponent(mockRollCallOpened, [
+          'attendee1',
+          'attendee2',
+          'attendee3',
+        ]);
         const returnButton = getByTestId('backButton');
         fireEvent.press(returnButton);
         // should have confirmation modal

--- a/fe1-web/src/resources/strings.ts
+++ b/fe1-web/src/resources/strings.ts
@@ -328,6 +328,9 @@ namespace STRINGS {
   export const roll_call_open = 'Open Roll-Call';
   export const roll_call_reopen = 'Re-open Roll-Call';
   export const roll_call_close = 'Close Roll-Call';
+  export const roll_call_leave_confirmation_title = 'Leave screen?';
+  export const roll_call_leave_description =
+    'By leaving this screen, any new scanned tokens will be lost.\nAre you sure you want to proceed?';
 
   /* --- Roll-call scanning Strings --- */
   export const roll_call_scan_attendees = 'Scan Attendees';


### PR DESCRIPTION
This PR makes that if there are new scanned tokens (not including the organizer token), there would be a confirmation window appearing to ask the user if he really wants to leave the screen

I am currently writing tests, but since we're a bit short in time I already opened the PR to get some early feedback

In my code the `SingleRollCallProps` is not really clean, but I got type error otherwise with the goBack, and I was not sure of a nice way to do it