### PR TITLE
Block invalid poptoken

### DIFF
--- a/fe1-web/src/core/objects/ScannablePopToken.ts
+++ b/fe1-web/src/core/objects/ScannablePopToken.ts
@@ -19,6 +19,11 @@ export class ScannablePopToken {
       throw new ProtocolError("undefined 'pop_token' when creating 'ScannedPopToken'");
     }
 
+    const tokenMatcher = new RegExp('^[A-Za-z0-9_-]{43}=$');
+    if (!tokenMatcher.test(scannedPopToken.pop_token)) {
+      throw new ProtocolError('Invalid pop token format');
+    }
+
     this.pop_token = scannedPopToken.pop_token;
   }
 

--- a/fe1-web/src/core/objects/__tests__/ScannablePopToken.test.ts
+++ b/fe1-web/src/core/objects/__tests__/ScannablePopToken.test.ts
@@ -1,6 +1,7 @@
 import { mockPopToken } from '__tests__/utils';
 import { OmitMethods } from 'core/types';
 
+import { ProtocolError } from '../ProtocolError';
 import { ScannablePopToken } from '../ScannablePopToken';
 
 describe('ScannablePopToken object', () => {
@@ -20,6 +21,38 @@ describe('ScannablePopToken object', () => {
           pop_token: undefined,
         } as unknown as OmitMethods<ScannablePopToken>),
     ).toThrow(Error);
+  });
+
+  it('throws if the pop_token is not in a valid format', () => {
+    const validPopTokens = [
+      'QRf_GkuQI6-TviY6ZmW3sMZQzDYc66SWqcgfgKyiY00=',
+      '-r4fYiL7-uAnt4WIQ2-XopjzwCVBKyTECNr420juktI=',
+      'abcdefghijklwxyzABNOPQRSTUVWXYZ0123456789-_=',
+    ];
+
+    const invalidPopTokens = [
+      '', // empty string
+      'ockPublicKey2_fFcHDaVHcCcY8IBfHE7auXJ7h4ms=', // size not multiple of 44
+      'mockP!blicKey2_fFcHDaVHcCcY8IBfHE7auXJ7h4ms=', // invalid character
+    ];
+
+    validPopTokens.forEach((popToken) => {
+      expect(
+        () =>
+          new ScannablePopToken({
+            pop_token: popToken,
+          }),
+      ).not.toThrow(Error);
+    });
+
+    invalidPopTokens.forEach((popToken) => {
+      expect(
+        () =>
+          new ScannablePopToken({
+            pop_token: popToken,
+          }),
+      ).toThrow(ProtocolError);
+    });
   });
 
   it('can encode in json', () => {

--- a/fe1-web/src/features/digital-cash/screens/SendReceive/SendReceive.tsx
+++ b/fe1-web/src/features/digital-cash/screens/SendReceive/SendReceive.tsx
@@ -349,7 +349,7 @@ export const SendReceiveHeaderRight = () => {
 
           <View>
             <QRCode
-              value={serializedPopToken || ''}
+              value={serializedPopToken}
               overlayText={STRINGS.digital_cash_wallet_qrcode_text}
             />
           </View>

--- a/fe1-web/src/features/rollCall/components/RollCallOpen.tsx
+++ b/fe1-web/src/features/rollCall/components/RollCallOpen.tsx
@@ -182,7 +182,11 @@ const RollCallOpen = ({
           <Text style={Typography.paragraph}>{STRINGS.roll_call_open_attendee}</Text>
           <View>
             <QRCode
-              value={ScannablePopToken.encodePopToken({ pop_token: popToken })}
+              value={
+                popToken !== ''
+                  ? ScannablePopToken.encodePopToken({ pop_token: popToken })
+                  : undefined
+              }
               overlayText={STRINGS.roll_call_qrcode_text}
             />
             <Text

--- a/fe1-web/src/features/rollCall/components/RollCallOpen.tsx
+++ b/fe1-web/src/features/rollCall/components/RollCallOpen.tsx
@@ -151,6 +151,14 @@ const RollCallOpen = ({
       .catch((err) => console.error(`Could not generate token: ${err}`));
   }, [hasWalletBeenInitialized, generateToken, laoId, rollCall]);
 
+  const serializedPopToken = useMemo(() => {
+    try {
+      return ScannablePopToken.encodePopToken({ pop_token: popToken });
+    } catch {
+      return undefined;
+    }
+  }, [popToken]);
+
   return (
     <ScreenWrapper toolbarItems={toolbarItems}>
       <Text style={Typography.paragraph}>
@@ -181,14 +189,7 @@ const RollCallOpen = ({
         <>
           <Text style={Typography.paragraph}>{STRINGS.roll_call_open_attendee}</Text>
           <View>
-            <QRCode
-              value={
-                popToken !== ''
-                  ? ScannablePopToken.encodePopToken({ pop_token: popToken })
-                  : undefined
-              }
-              overlayText={STRINGS.roll_call_qrcode_text}
-            />
+            <QRCode value={serializedPopToken} overlayText={STRINGS.roll_call_qrcode_text} />
             <Text
               style={[
                 Typography.paragraph,

--- a/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
@@ -111,11 +111,6 @@ const RollCallOpened = () => {
 
   const addAttendeePopToken = useCallback(
     (popToken: string) => {
-      // if popToken is not in base64 format, do not add it
-      if (!popToken.match(/^[a-zA-Z0-9_-]+={0,3}$/) || popToken.length % 4 !== 0) {
-        throw new Error('Invalid popToken format');
-      }
-
       // if the token is already part of attendeePopTokens, do not trigger a state update
       // and return false indicating the pop token was not added since it's a duplicate
       if (attendeePopTokens.current.includes(popToken)) {

--- a/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
+++ b/fe1-web/src/features/rollCall/screens/RollCallScanner.tsx
@@ -111,9 +111,13 @@ const RollCallOpened = () => {
 
   const addAttendeePopToken = useCallback(
     (popToken: string) => {
+      // if popToken is not in base64 format, do not add it
+      if (!popToken.match(/^[a-zA-Z0-9_-]+={0,3}$/) || popToken.length % 4 !== 0) {
+        throw new Error('Invalid popToken format');
+      }
+
       // if the token is already part of attendeePopTokens, do not trigger a state update
       // and return false indicating the pop token was not added since it's a duplicate
-
       if (attendeePopTokens.current.includes(popToken)) {
         return false;
       }

--- a/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
+++ b/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
@@ -267,7 +267,7 @@ describe('RollCallOpened', () => {
     }
 
     for (const invalidPopToken of invalidPopTokens) {
-      fakeQrReaderScan(ScannablePopToken.encodePopToken({ pop_token: invalidPopToken }));
+      fakeQrReaderScan(JSON.stringify({ pop_token: invalidPopToken }));
       expect(mockToastShow).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ type: 'danger' }),

--- a/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
+++ b/fe1-web/src/features/rollCall/screens/__tests__/RollCallScanner.test.tsx
@@ -151,8 +151,8 @@ describe('RollCallOpened', () => {
   it('shows toast when scanning attendees', async () => {
     renderRollCallOpened();
 
-    fakeQrReaderScan(mockPublicKey2.valueOf());
-    fakeQrReaderScan(mockPublicKey3.valueOf());
+    fakeQrReaderScan(ScannablePopToken.encodePopToken({ pop_token: mockPublicKey2.valueOf() }));
+    fakeQrReaderScan(ScannablePopToken.encodePopToken({ pop_token: mockPublicKey2.valueOf() }));
 
     expect(mockToastShow).toHaveBeenCalledTimes(2);
   });
@@ -240,5 +240,49 @@ describe('RollCallOpened', () => {
 
     // counter should be at 2
     expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('accepts only valid pop tokens', async () => {
+    const validPopTokens = [
+      mockPublicKey2.valueOf(),
+      mockPublicKey3.valueOf(),
+      'abcdefghijklwxyzABNOPQRSTUVWXYZ0123456789-_=',
+    ];
+
+    const invalidPopTokens = [
+      '', // empty string
+      'ockPublicKey2_fFcHDaVHcCcY8IBfHE7auXJ7h4ms=', // size not multiple of 4
+      'mockP!blicKey2_fFcHDaVHcCcY8IBfHE7auXJ7h4ms=', // invalid character
+    ];
+
+    renderRollCallOpened();
+
+    for (const validPopToken of validPopTokens) {
+      fakeQrReaderScan(ScannablePopToken.encodePopToken({ pop_token: validPopToken }));
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ type: 'success' }),
+      );
+      mockToastShow.mockReset();
+    }
+
+    for (const invalidPopToken of invalidPopTokens) {
+      fakeQrReaderScan(ScannablePopToken.encodePopToken({ pop_token: invalidPopToken }));
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ type: 'danger' }),
+      );
+      mockToastShow.mockReset();
+    }
+
+    // should have correct json format
+    for (const validPopToken of validPopTokens) {
+      fakeQrReaderScan(validPopToken);
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ type: 'danger' }),
+      );
+      mockToastShow.mockReset();
+    }
   });
 });

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
@@ -8845,7 +8845,6 @@ exports[`EventRollCall render correctly organizers re-opened roll calls 1`] = `
                               }
                             }
                             testID="roll_call_close_button"
-
                           >
                             <View
                               style={

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
@@ -447,7 +447,7 @@ exports[`EventRollCall render correctly no duplicate attendees opened roll calls
                                         "width": "100%",
                                       }
                                     }
-                                    value="{"pop_token":""}"
+                                    value=""
                                     viewBox="0 0 256 256"
                                   />
                                   <View
@@ -1490,7 +1490,7 @@ exports[`EventRollCall render correctly no duplicate attendees re-opened roll ca
                                         "width": "100%",
                                       }
                                     }
-                                    value="{"pop_token":""}"
+                                    value=""
                                     viewBox="0 0 256 256"
                                   />
                                   <View
@@ -3846,7 +3846,7 @@ exports[`EventRollCall render correctly non organizers opened roll calls 1`] = `
                                         "width": "100%",
                                       }
                                     }
-                                    value="{"pop_token":""}"
+                                    value=""
                                     viewBox="0 0 256 256"
                                   />
                                   <View
@@ -4889,7 +4889,7 @@ exports[`EventRollCall render correctly non organizers re-opened roll calls 1`] 
                                         "width": "100%",
                                       }
                                     }
-                                    value="{"pop_token":""}"
+                                    value=""
                                     viewBox="0 0 256 256"
                                   />
                                   <View

--- a/fe1-web/src/resources/strings.ts
+++ b/fe1-web/src/resources/strings.ts
@@ -510,6 +510,8 @@ namespace STRINGS {
     'Issue to every attendee of this roll call';
 
   export const digital_cash_infinity = '∞';
+  export const digital_cash_error_rollcall_not_defined =
+    'RollcallId not defined, cannot generate PoP token';
 
   /* --- Witness Feature Strings --- */
   export const witness_message_witness = 'Witness Message';


### PR DESCRIPTION
This PR blocks invalid pop token when scanning (this avoid bugs with wrong channel created, and then when trying to connect to these channel it fails, which could lead to the app thinking it is offline)

PS: the updated snap test is due to the current state of the release not being correct