### PR TITLE
Fix meeting past date

### DIFF
--- a/fe1-web/src/features/events/functions/events.ts
+++ b/fe1-web/src/features/events/functions/events.ts
@@ -29,9 +29,7 @@ export const categorizeEventsByTime = (time: Timestamp, events: EventState[]) =>
     // TODO: should find a way to do this without relying on the event type
     // for example, by making that events ends when organizers mark them as ended (same as the others)
     if (
-      (e.eventType === 'MEETING' &&
-        e.end &&
-        e.end <= t) ||
+      (e.eventType === 'MEETING' && e.end && e.end <= t) ||
       (e.eventType !== 'MEETING' && e.end)
     ) {
       pastEvents.push(e);

--- a/fe1-web/src/features/events/functions/events.ts
+++ b/fe1-web/src/features/events/functions/events.ts
@@ -24,7 +24,7 @@ export const categorizeEventsByTime = (time: Timestamp, events: EventState[]) =>
 
   events.forEach((e: EventState) => {
     // ended events are either:
-    // - meetings that have ended more than {CURRENT_EVENTS_THRESHOLD_HOURS} hours ago
+    // - meetings that have ended
     // - other events that have been marked as ended (e.end is set)
     // TODO: should find a way to do this without relying on the event type
     // for example, by making that events ends when organizers mark them as ended (same as the others)

--- a/fe1-web/src/features/events/functions/events.ts
+++ b/fe1-web/src/features/events/functions/events.ts
@@ -31,7 +31,7 @@ export const categorizeEventsByTime = (time: Timestamp, events: EventState[]) =>
     if (
       (e.eventType === 'MEETING' &&
         e.end &&
-        e.end <= t - CURRENT_EVENTS_THRESHOLD_HOURS * 60 * 60) ||
+        e.end <= t) ||
       (e.eventType !== 'MEETING' && e.end)
     ) {
       pastEvents.push(e);

--- a/fe1-web/src/features/events/functions/events.ts
+++ b/fe1-web/src/features/events/functions/events.ts
@@ -23,21 +23,11 @@ export const categorizeEventsByTime = (time: Timestamp, events: EventState[]) =>
   const upcomingEvents: EventState[] = [];
 
   events.forEach((e: EventState) => {
-    // ended events are either:
-    // - meetings that have ended
-    // - other events that have been marked as ended (e.end is set)
-    // TODO: should find a way to do this without relying on the event type
-    // for example, by making that events ends when organizers mark them as ended (same as the others)
-    if (
-      (e.eventType === 'MEETING' && e.end && e.end <= t) ||
-      (e.eventType !== 'MEETING' && e.end)
-    ) {
+    // past events are event where the end time is defined and before current time
+    if (e.end && e.end <= t) {
       pastEvents.push(e);
       return;
     }
-
-    // if end time was not set yet, it is either a current event
-    // or an upcoming one
 
     // current events are the ones that already started or will start within
     // the next {CURRENT_EVENTS_THRESHOLD_HOURS} hours

--- a/fe1-web/src/features/events/functions/events.ts
+++ b/fe1-web/src/features/events/functions/events.ts
@@ -1,6 +1,7 @@
 import { Hash, Timestamp } from 'core/objects';
 import { getStore } from 'core/redux';
 
+import { Meeting } from '../../meeting/objects';
 import { EventState } from '../objects';
 import { getEvent } from '../reducer';
 
@@ -23,9 +24,15 @@ export const categorizeEventsByTime = (time: Timestamp, events: EventState[]) =>
   const upcomingEvents: EventState[] = [];
 
   events.forEach((e: EventState) => {
-    // ended events are events that have ended more than
-    // {CURRENT_EVENTS_THRESHOLD_HOURS} hours ago
-    if (e.end && e.end <= t - CURRENT_EVENTS_THRESHOLD_HOURS * 60 * 60) {
+    // ended events are either:
+    // - meetings that have ended more than {CURRENT_EVENTS_THRESHOLD_HOURS} hours ago
+    // - other events that have been marked as ended (e.end is set)
+    if (
+      (e.eventType === Meeting.EVENT_TYPE &&
+        e.end &&
+        e.end <= t - CURRENT_EVENTS_THRESHOLD_HOURS * 60 * 60) ||
+      (e.eventType !== Meeting.EVENT_TYPE && e.end)
+    ) {
       pastEvents.push(e);
       return;
     }

--- a/fe1-web/src/features/events/functions/events.ts
+++ b/fe1-web/src/features/events/functions/events.ts
@@ -1,7 +1,6 @@
 import { Hash, Timestamp } from 'core/objects';
 import { getStore } from 'core/redux';
 
-import { Meeting } from '../../meeting/objects';
 import { EventState } from '../objects';
 import { getEvent } from '../reducer';
 
@@ -27,11 +26,13 @@ export const categorizeEventsByTime = (time: Timestamp, events: EventState[]) =>
     // ended events are either:
     // - meetings that have ended more than {CURRENT_EVENTS_THRESHOLD_HOURS} hours ago
     // - other events that have been marked as ended (e.end is set)
+    // TODO: should find a way to do this without relying on the event type
+    // for example, by making that events ends when organizers mark them as ended (same as the others)
     if (
-      (e.eventType === Meeting.EVENT_TYPE &&
+      (e.eventType === 'MEETING' &&
         e.end &&
         e.end <= t - CURRENT_EVENTS_THRESHOLD_HOURS * 60 * 60) ||
-      (e.eventType !== Meeting.EVENT_TYPE && e.end)
+      (e.eventType !== 'MEETING' && e.end)
     ) {
       pastEvents.push(e);
       return;

--- a/fe1-web/src/features/events/functions/events.ts
+++ b/fe1-web/src/features/events/functions/events.ts
@@ -23,8 +23,9 @@ export const categorizeEventsByTime = (time: Timestamp, events: EventState[]) =>
   const upcomingEvents: EventState[] = [];
 
   events.forEach((e: EventState) => {
-    // if end time is set, the event has ended
-    if (e.end) {
+    // ended events are events that have ended more than
+    // {CURRENT_EVENTS_THRESHOLD_HOURS} hours ago
+    if (e.end && e.end <= t - CURRENT_EVENTS_THRESHOLD_HOURS * 60 * 60) {
       pastEvents.push(e);
       return;
     }

--- a/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
+++ b/fe1-web/src/features/rollCall/screens/__tests__/__snapshots__/ViewSingleRollCall.test.tsx.snap
@@ -8845,7 +8845,6 @@ exports[`EventRollCall render correctly organizers re-opened roll calls 1`] = `
                               }
                             }
                             testID="roll_call_close_button"
-
                           >
                             <View
                               style={


### PR DESCRIPTION
This PR fixes bug where meeting that had not ended would appear as past event, this happened because there was no verification on the end time (other then it was defined)

This works for all types of event expect Meetings (since for the other events, it is set when the organizer ends the event), but meetings are not ended by the organizer

This fix is really not clean, and in the future a better way to handle this should be found, one possibility would be that meetings like other events ends when organizer decides to, or we would need an additional field to know if an event has ended.

(I also had to use hardcoded 'MEETING' since I can not import in this module Meeting.id)