### PR TITLE
Handle social channel creation error for invalid pop_token

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/RollCallHandler.scala
@@ -125,7 +125,7 @@ class RollCallHandler(dbRef: => AskableActorRef) extends MessageHandler {
           Some((generateSocialChannel(rpcRequest.getParamsChannel, attendee), ObjectType.CHIRP))
         } catch {
           case _: Throwable =>
-            println(s"Failed to create attendee channel for pop token: ${attendee.base64Data.data}")
+            println(s"Failed to generate attendee social channel for pop token: \"${attendee.base64Data.data}\"")
             None
         }
     }


### PR DESCRIPTION
When the rollcall closes and social channels are created for attendees, no guarantees are given regarding their pop token beside them being valid base 64 strings. The empty string is also considered valid, but when creating the channel: `/root/lao_id/social/[empty string]` we get an unhandled exception because this is not a valid channel. This pr deal with that by simply ignoring such invalid channels.