### PR TITLE
Implement blacklist

### DIFF
--- a/be1-go/hub/standard_hub/message_handling.go
+++ b/be1-go/hub/standard_hub/message_handling.go
@@ -501,15 +501,16 @@ func getMissingIds(receivedIds map[string][]string, storedIds map[string][]strin
 		for _, messageId := range receivedMessageIds {
 			blacklisted := slices.Contains(blacklist, messageId)
 			storedIdsForChannel, channelKnown := storedIds[channelId]
-			if !blacklisted {
-				if channelKnown {
-					contains := slices.Contains(storedIdsForChannel, messageId)
-					if !contains {
-						missingIds[channelId] = append(missingIds[channelId], messageId)
-					}
-				} else {
+			if blacklisted {
+				break
+			}
+			if channelKnown {
+				contains := slices.Contains(storedIdsForChannel, messageId)
+				if !contains {
 					missingIds[channelId] = append(missingIds[channelId], messageId)
 				}
+			} else {
+				missingIds[channelId] = append(missingIds[channelId], messageId)
 			}
 		}
 	}

--- a/be1-go/hub/standard_hub/mod.go
+++ b/be1-go/hub/standard_hub/mod.go
@@ -95,6 +95,12 @@ type Hub struct {
 
 	// peersGreeted stores the peers that were greeted by the socket ID
 	peersGreeted []string
+
+	// blacklist stores the IDs of the messages that failed to be processed by the hub
+	// the server will not ask for them again in the heartbeat
+	// and will not process them if they are received again
+	// @TODO remove the messages from the blacklist after a certain amount of time by trying to process them again
+	blacklist []string
 }
 
 // newQueries creates a new queries struct
@@ -151,6 +157,7 @@ func NewHub(pubKeyOwner kyber.Point, clientServerAddress string, serverServerAdd
 		messageIdsByChannel: make(map[string][]string),
 		peersInfo:           make(map[string]method.ServerInfo),
 		peersGreeted:        make([]string, 0),
+		blacklist:           make([]string, 0),
 	}
 
 	return &hub, nil


### PR DESCRIPTION
This PR implements a simple blacklist that's used when handling the answer to getMessagesById to avoid blocking the hub. 
If it fails to handle a message after 10 tries it will put its id in the blacklist and not ask for it / avoid processing it again. 
