### PR TITLE
Update WitnessHandler processing of signatures

### DIFF
--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandlerTest.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/WitnessHandlerTest.scala
@@ -60,7 +60,7 @@ class WitnessHandlerTest extends TestKit(ActorSystem("Witness-DB-System")) with 
   def mockDbWithAck: AskableActorRef = {
     val dbActorMock = Props(new Actor() {
       override def receive: Receive = {
-        case DbActor.WriteAndPropagate(_, _) =>
+        case DbActor.WriteAndPropagate(_, _) | DbActor.Write(_, _) =>
           system.log.info("Received a message")
           system.log.info("Responding with a Ack")
           sender() ! DbActor.DbActorAck()

--- a/docs/messageData.md
+++ b/docs/messageData.md
@@ -499,8 +499,9 @@ Last but not least, the greeting message contains a list of peers that tells cli
 
 By sending the message/witness message to the LAO’s main channel (LAO's “id”), a
 witness can attest to the message. Upon reception, the server and the witnesses
-add this signature to the existing message’s `witness_signatures` field. When a
-new client retrieves this message, the `witness_signatures` field will be
+add this signature to the existing message’s `witness_signatures` field. It also save the signature message in its database and broadcast it on the channel.
+The witness message is saved in the database so that it appears in the heartbeat leading to the signature being propagated among servers. 
+When a new client retrieves this message, the `witness_signatures` field will be
 populated with all the witness signatures received by the server.
 
 <details>


### PR DESCRIPTION
It was decided during the semester that signature message from witnesses would be broadcasted instead of broadcasting the signed message with the signature itself. This pr adds this behavior to the scala backend. 