### PR TITLE
replaced all relative paths for files by absolute, raw github URLS.

### DIFF
--- a/be1-go/channel/authentication/mod_test.go
+++ b/be1-go/channel/authentication/mod_test.go
@@ -33,13 +33,11 @@ import (
 const (
 	relativeMsgDataExamplePath string = "../../../protocol/examples/messageData"
 	relativeQueryExamplePath   string = "../../../protocol/examples/query"
-	secPathTest                       = "../../crypto/popcha.rsa"
-	pubPathtest                       = "../../crypto/popcha.rsa.pub"
 )
 
 // TestJWTToken creates a JWT token with arbitrary parameters, and parse it to assert its correctness.
 func TestJWTToken(t *testing.T) {
-	sk, pk, err := loadRSAKeys(secPathTest, pubPathtest)
+	sk, pk, err := loadRSAKeys(secretKeyURL, publicKeyURL)
 	require.NoError(t, err)
 
 	webAddr := "https://server.example.com"
@@ -88,7 +86,7 @@ func TestURIParamsConstruction(t *testing.T) {
 		PopchaAddress:   "https://server.example.com",
 	}
 	// creating a fake channel, we will not use it in this test
-	c := NewChannel("", nil, zerolog.New(io.Discard), secPathTest, pubPathtest)
+	c := NewChannel("", nil, zerolog.New(io.Discard))
 	_, err := constructRedirectURIParams(c, authMsg, authMsg.Nonce)
 	require.NoError(t, err)
 }
@@ -102,7 +100,7 @@ func Test_Authenticate_User(t *testing.T) {
 	require.NoError(t, err)
 	name := "3hfd5xSty1VShCdcfLUDsgNF_EnMSRiFk74xvH5LRjM=/authenticate"
 	// Create the channel
-	authCha := NewChannel("3hfd5xSty1VShCdcfLUDsgNF_EnMSRiFk74xvH5LRjM=/authenticate", fakeHub, popstellar.Logger, secPathTest, pubPathtest)
+	authCha := NewChannel("3hfd5xSty1VShCdcfLUDsgNF_EnMSRiFk74xvH5LRjM=/authenticate", fakeHub, popstellar.Logger)
 
 	fakeHub.RegisterNewChannel(name, authCha)
 	_, found := fakeHub.channelByID[name]

--- a/be1-go/channel/lao/mod.go
+++ b/be1-go/channel/lao/mod.go
@@ -48,11 +48,6 @@ const (
 	chirps = "chirps"
 	// endpoint for the PoPCHA authentication channel
 	auth = "/authentication"
-	// skAbsolutePath represents the absolute path to the rsa secret key for the popcha authentication channel
-	skAbsolutePath = "crypto/popcha.rsa"
-	// pkAbsolutePath represents the absolute path to the rsa public key for the popcha authentication channel
-	pkAbsolutePath = "crypto/popcha.rsa.pub"
-
 	// Open represents the open roll call state.
 	Open rollCallState = "open"
 
@@ -613,7 +608,7 @@ func (c *Channel) createChirpingChannel(publicKey string, socket socket.Socket) 
 // createAuthChannel creates an authentication channel associated to the laoID, handling PopCHA requests
 func (c *Channel) createAuthChannel(hub channel.HubFunctionalities, socket socket.Socket) {
 	chanPath := c.channelID + auth
-	authChan := authentication.NewChannel(chanPath, hub, popstellar.Logger, skAbsolutePath, pkAbsolutePath)
+	authChan := authentication.NewChannel(chanPath, hub, popstellar.Logger)
 	hub.NotifyNewChannel(chanPath, authChan, socket)
 	c.log.Info().Msgf("storing new authentication channel '%s' ", chanPath)
 

--- a/be1-go/cli/mod.go
+++ b/be1-go/cli/mod.go
@@ -38,8 +38,6 @@ const (
 
 	// connectionRetryRate is the rate at which the time to wait before retrying to connect to a server increases
 	connectionRetryRate = 2
-
-	popchaHTMLPath = "popcha/qrcode/popcha.html"
 )
 
 // ServerConfig contains the configuration for the server
@@ -109,7 +107,7 @@ func Serve(cliCtx *cli.Context) error {
 
 	// Start the PoPCHA Authorization Server. It will run internally on localhost, the address of the server given in
 	// the config file will be the one used externally.
-	authorizationSrv := popcha.NewAuthServer(h, "localhost", serverConfig.AuthPort, popchaHTMLPath,
+	authorizationSrv := popcha.NewAuthServer(h, "localhost", serverConfig.AuthPort,
 		log.With().Str("role", "authorization server").Logger())
 	authorizationSrv.Start()
 	<-authorizationSrv.Started

--- a/be1-go/popcha/server.go
+++ b/be1-go/popcha/server.go
@@ -348,7 +348,13 @@ func (as *AuthorizationServer) generateQRCode(w http.ResponseWriter, req *http.R
 	}
 
 	response, err := http.Get(qrCodeURL)
+	if err != nil {
+		return err
+	}
 	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
 
 	// reading the template bytes into a template object
 	tmpl := template.Must(template.New("").Parse(string(body)))

--- a/be1-go/popcha/server.go
+++ b/be1-go/popcha/server.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"github.com/zitadel/oidc/v2/pkg/oidc"
 	"github.com/zitadel/oidc/v2/pkg/op"
 	"golang.org/x/xerrors"
@@ -350,7 +349,6 @@ func (as *AuthorizationServer) generateQRCode(w http.ResponseWriter, req *http.R
 
 	response, err := http.Get(qrCodeURL)
 	body, err := io.ReadAll(response.Body)
-	log.Info().Msg(string(body))
 
 	// reading the template bytes into a template object
 	tmpl := template.Must(template.New("").Parse(string(body)))

--- a/be1-go/popcha/server_test.go
+++ b/be1-go/popcha/server_test.go
@@ -33,9 +33,6 @@ const (
 
 	//message content for the websocket workflow test
 	wsData = "Hello receiver!"
-
-	// qrCodeWebPage file path for valid QRCode Displaying page
-	qrCodeWebPage = "qrcode/popcha.html"
 )
 
 // genString is a helper method generating a string in the alphanumerical alphabet
@@ -58,7 +55,7 @@ func TestAuthServerStartAndShutdown(t *testing.T) {
 	h, err := standard_hub.NewHub(crypto.Suite.Point(), "", "", l, nil)
 	require.NoError(t, err, "could not create hub")
 
-	s := NewAuthServer(h, "localhost", 2003, qrCodeWebPage, l)
+	s := NewAuthServer(h, "localhost", 2003, l)
 
 	require.NoError(t, err, "could not create AuthServer")
 	s.Start()
@@ -73,7 +70,7 @@ func TestAuthServerStartAndShutdown(t *testing.T) {
 // the server serves a webpage with the associated QRCode.
 func TestAuthorizationServerHandleValidateRequest(t *testing.T) {
 	l := popstellar.Logger
-	s := NewAuthServer(fakeHub{}, "localhost", 3003, qrCodeWebPage, l)
+	s := NewAuthServer(fakeHub{}, "localhost", 3003, l)
 	s.Start()
 	<-s.Started
 
@@ -123,7 +120,7 @@ func TestAuthRequestFails(t *testing.T) {
 	logTester := zltest.New(t)
 
 	l := zerolog.New(logTester).With().Timestamp().Logger()
-	s := NewAuthServer(fakeHub{}, "localhost", 3007, qrCodeWebPage, l)
+	s := NewAuthServer(fakeHub{}, "localhost", 3007, l)
 	s.Start()
 	<-s.Started
 
@@ -213,7 +210,7 @@ func TestAuthorizationServerWebsocket(t *testing.T) {
 
 	// starting the authorization server
 	l := popstellar.Logger
-	s := NewAuthServer(fakeHub{}, "localhost", 3004, qrCodeWebPage, l)
+	s := NewAuthServer(fakeHub{}, "localhost", 3004, l)
 	s.Start()
 	<-s.Started
 
@@ -263,7 +260,7 @@ func TestAuthorizationServerWorkflow(t *testing.T) {
 	logTester := zltest.New(t)
 
 	l := zerolog.New(logTester).With().Timestamp().Logger()
-	s := NewAuthServer(fakeHub{}, "localhost", 3005, qrCodeWebPage, l)
+	s := NewAuthServer(fakeHub{}, "localhost", 3005, l)
 	s.Start()
 	<-s.Started
 
@@ -324,7 +321,7 @@ func TestAuthorizationServerWorkflow(t *testing.T) {
 func TestGenerateQrCodeOnEdgeCases(t *testing.T) {
 	// create authorization server
 	l := zerolog.New(io.Discard)
-	s := NewAuthServer(fakeHub{}, "localhost", 3006, qrCodeWebPage, l)
+	s := NewAuthServer(fakeHub{}, "localhost", 3006, l)
 
 	// testing that the QRCode can't be generated if the data is too long
 	longURL := &url.URL{
@@ -356,7 +353,7 @@ func TestGenerateQrCodeOnEdgeCases(t *testing.T) {
 // TestClientParams tests the validity of the client parameters
 func TestClientParams(t *testing.T) {
 	l := zerolog.New(io.Discard)
-	s := NewAuthServer(fakeHub{}, "localhost", 3009, qrCodeWebPage, l)
+	s := NewAuthServer(fakeHub{}, "localhost", 3009, l)
 	s.Start()
 	<-s.Started
 


### PR DESCRIPTION
Relative paths for retrieving resource such as the QR Code HTML page, or the key-pair int he /crypto package, might not work when the back-end is deployed, as the location of the binary can break those paths.Introducing URLs as absolute paths might give a constant, reliable way of retrieving the resources.