### PR TITLE
CI java update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -252,11 +252,11 @@ jobs:
         working-directory: ./be2-scala
 
     steps:
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
 
       - name: Setup repo
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,7 +255,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "17"
 
       - name: Setup repo

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -138,7 +138,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "17"
 
       - name: build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -135,11 +135,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
 
       - name: build
         run: |

--- a/.github/workflows/karate_be2-scala.yaml
+++ b/.github/workflows/karate_be2-scala.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: "17"
 
       - name: Setup repo

--- a/.github/workflows/karate_be2-scala.yaml
+++ b/.github/workflows/karate_be2-scala.yaml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
 
       - name: Setup repo
         uses: actions/checkout@v3

--- a/be2-scala/README.md
+++ b/be2-scala/README.md
@@ -95,8 +95,8 @@ environment:
 ```sh
 # install sdkman
 curl -s "https://get.sdkman.io" | bash
-# install java zulu 17
-sdk install java 17.0.8-zulu
+# install java temurin 17
+sdk install java 17.0.8-tem
 # install sbt
 sdk install sbt
 # check that everything went well

--- a/be2-scala/README.md
+++ b/be2-scala/README.md
@@ -95,13 +95,13 @@ environment:
 ```sh
 # install sdkman
 curl -s "https://get.sdkman.io" | bash
-# install java zulu 11
-sdk install java 11.0.18-zulu
+# install java zulu 17
+sdk install java 17.0.8-zulu
 # install sbt
 sdk install sbt
 # check that everything went well
 java -version
-> openjdk version "11.0.18" 2023-01-17 LTS
+> openjdk 17.0.8 2023-07-18 LTS
 ```
 
 ## Package and run


### PR DESCRIPTION
Java 11 will soon go unsupported on github CI. Java 17 should be good for at least 3 more years. The java requirement have been updated in the doc so that the CI env is closer to the local one. 