### PR TITLE
Fix Karate status badges

### DIFF
--- a/.github/workflows/karate_be1-go.yaml
+++ b/.github/workflows/karate_be1-go.yaml
@@ -116,7 +116,6 @@ jobs:
           branch: report-karate-be1-go
           directory: report-repo
 
-      - name: Fail job if the tests were not successful
-        # Catchup of tests failure such that the job fo fail
-        if: steps.tests.outcome == 'failure'
+      - name: Fail job if either the server or client tests were not successful
+        if: steps.tests_client.outcome == 'failure' || steps.tests_server.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/karate_be2-scala.yaml
+++ b/.github/workflows/karate_be2-scala.yaml
@@ -102,7 +102,6 @@ jobs:
           branch: report-karate-be2-scala
           directory: report-repo
           
-      - name: Fail job if the tests were not successful
-        # Catchup of tests failure such that the job fo fail
-        if: steps.tests.outcome == 'failure'
+      - name: Fail job if either the server or client tests were not successful
+        if: steps.tests_client.outcome == 'failure' || steps.tests_server.outcome == 'failure'
         run: exit 1


### PR DESCRIPTION
The Karate test status badges on the Readme always showed _passing_, despite there being failing tests. Fixed this in github action workflows.