### PR TITLE
Constants for feature paths

### DIFF
--- a/tests/karate/src/test/java/be/features/LAO/create.feature
+++ b/tests/karate/src/test/java/be/features/LAO/create.feature
@@ -7,9 +7,9 @@ Feature: Create a pop LAO
     # Call read(...) makes this feature and the called feature share the same scope
     # Meaning they share def variables, configurations ...
     # Especially JS functions defined in the called features can be directly used here thanks to Karate shared scopes
-    * call read('classpath:be/features/utils/server.feature')
-    * call read('classpath:be/features/utils/mockClient.feature')
     * call read('classpath:be/features/utils/constants.feature')
+    * call read(serverFeature)
+    * call read(mockClientFeature)
     * def organizer = call createMockClient
     * def validLao = organizer.createValidLao()
 

--- a/tests/karate/src/test/java/be/features/LAO/update.feature
+++ b/tests/karate/src/test/java/be/features/LAO/update.feature
@@ -6,15 +6,15 @@ Feature: Update a LAO
     # Call read(...) makes this feature and the called feature share the same scope
     # Meaning they share def variables, configurations ...
     # Especially JS functions defined in the called features can be directly used here thanks to Karate shared scopes
-    * call read('classpath:be/features/utils/server.feature')
-    * call read('classpath:be/features/utils/mockClient.feature')
     * call read('classpath:be/features/utils/constants.feature')
+    * call read(serverFeature)
+    * call read(mockClientFeature)
     * def organizer = call createMockClient
     * def lao = organizer.createValidLao()
 
     # This call executes all the steps to create a valid lao on the server before every scenario
     # (lao creation, subscribe, catchup)
-    * call read('classpath:be/features/utils/simpleScenarios.feature@name=valid_lao') { organizer: '#(organizer)', lao: '#(lao)' }
+    * call read(createLaoScenario) { organizer: '#(organizer)', lao: '#(lao)' }
 
   Scenario: Update Lao should succeed with a valid update request with new lao name
     Given def updateLaoRequest =

--- a/tests/karate/src/test/java/be/features/decentralizedCom/getMessagesById.feature
+++ b/tests/karate/src/test/java/be/features/decentralizedCom/getMessagesById.feature
@@ -6,9 +6,9 @@ Feature: Request messages by id from other servers
     # Call read(...) makes this feature and the called feature share the same scope
     # Meaning they share def variables, configurations ...
     # Especially JS functions defined in the called features can be directly used here thanks to Karate shared scopes
-    * call read('classpath:be/features/utils/server.feature')
-    * call read('classpath:be/features/utils/mockClient.feature')
     * call read('classpath:be/features/utils/constants.feature')
+    * call read(serverFeature)
+    * call read(mockClientFeature)
     * def mockServer = call createMockClient
     * def lao = mockServer.createValidLao()
 
@@ -24,7 +24,7 @@ Feature: Request messages by id from other servers
 
     # This call executes all the steps to create a valid lao on the server before every scenario
     # (lao creation, subscribe, catchup)
-    * call read('classpath:be/features/utils/simpleScenarios.feature@name=valid_lao') { organizer: '#(mockServer)', lao: '#(lao)' }
+    * call read(createLaoScenario) { organizer: '#(mockServer)', lao: '#(lao)' }
 
   # Check that after sending a heartbeat message with unknown message id, the server responds with a
   # getMessagesByID requesting this message

--- a/tests/karate/src/test/java/be/features/decentralizedCom/heartbeat.feature
+++ b/tests/karate/src/test/java/be/features/decentralizedCom/heartbeat.feature
@@ -6,16 +6,16 @@ Feature: Send heartbeats to other servers
     # Call read(...) makes this feature and the called feature share the same scope
     # Meaning they share def variables, configurations ...
     # Especially JS functions defined in the called features can be directly used here thanks to Karate shared scopes
-    * call read('classpath:be/features/utils/server.feature')
-    * call read('classpath:be/features/utils/mockClient.feature')
     * call read('classpath:be/features/utils/constants.feature')
+    * call read(serverFeature)
+    * call read(mockClientFeature)
     * def mockServer = call createMockClient
     * def lao = mockServer.createValidLao()
     * def validRollCall = mockServer.createValidRollCall(lao)
 
     # This call executes all the steps to create a valid lao on the server before every scenario
     # (lao creation, subscribe, catchup)
-    * call read('classpath:be/features/utils/simpleScenarios.feature@name=valid_lao') { organizer: '#(mockServer)', lao: '#(lao)' }
+    * call read(createLaoScenario) { organizer: '#(mockServer)', lao: '#(lao)' }
 
   # After lao creation, wait and do nothing (30 seconds for now) and check that a heartbeat message was received
   Scenario: Server should send heartbeat messages automatically after a time interval

--- a/tests/karate/src/test/java/be/features/digitalCash/transaction.feature
+++ b/tests/karate/src/test/java/be/features/digitalCash/transaction.feature
@@ -5,16 +5,16 @@ Feature: Simple Transactions for digital cash
     # Call read(...) makes this feature and the called feature share the same scope
     # Meaning they share def variables, configurations ...
     # Especially JS functions defined in the called features can be directly used here thanks to Karate shared scopes
-    * call read('classpath:be/features/utils/server.feature')
-    * call read('classpath:be/features/utils/mockClient.feature')
     * call read('classpath:be/features/utils/constants.feature')
+    * call read(serverFeature)
+    * call read(mockClientFeature)
     * def organizer = call createMockClient
     * def recipient = call createMockClient
     * def lao = organizer.createValidLao()
     * def rollCall = organizer.createValidRollCall(lao)
 
     # This call executes all the steps to set up a lao, complete a roll call and subscribe to the coin channel
-    * call read('classpath:be/features/utils/simpleScenarios.feature@name=setup_coin_channel') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
+    * call read(setupCoinChannelScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
 
   Scenario: Valid transaction: issue 32 mini-Laos to an attendee
     Given def transaction = organizer.issueCoins(recipient, 32);
@@ -60,7 +60,7 @@ Feature: Simple Transactions for digital cash
   Scenario: Transfer valid amount should work
     # This call issues initialAmount coins to the recipient
     Given def initialAmount = 32
-    And call read('classpath:be/utils/simpleScenarios.feature@name=valid_coin_issuance') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)', recipient: '#(recipient)', amount: '#(initialAmount)' }
+    And call read(validCoinIssuanceScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)', recipient: '#(recipient)', amount: '#(initialAmount)' }
     And def transaction = organizer.issueCoins(recipient, 20);
     And def postTransaction = transaction.post()
     And def input = transaction.inputs[1]

--- a/tests/karate/src/test/java/be/features/election/castVote.feature
+++ b/tests/karate/src/test/java/be/features/election/castVote.feature
@@ -5,9 +5,9 @@ Feature: Cast a vote
     # Call read(...) makes this feature and the called feature share the same scope
     # Meaning they share def variables, configurations ...
     # Especially JS functions defined in the called features can be directly used here thanks to Karate shared scopes
-    * call read('classpath:be/features/utils/server.feature')
-    * call read('classpath:be/features/utils/mockClient.feature')
     * call read('classpath:be/features/utils/constants.feature')
+    * call read(serverFeature)
+    * call read(mockClientFeature)
     * def organizer = call createMockClient
     * def lao = organizer.createValidLao()
     * def rollCall = organizer.createValidRollCall(lao)
@@ -15,7 +15,7 @@ Feature: Cast a vote
     * def question = election.createQuestion()
 
     # This call executes all the steps to set up a lao, complete a roll call and open an election with one question
-    * call read('classpath:be/features/utils/simpleScenarios.feature@name=election_open') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)',  election: '#(election)', question: '#(question)' }
+    * call read(openElectionScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)',  election: '#(election)', question: '#(question)' }
     * def vote = question.createVote(0)
     * def castVote = election.castVote(vote)
 

--- a/tests/karate/src/test/java/be/features/election/electionEnd.feature
+++ b/tests/karate/src/test/java/be/features/election/electionEnd.feature
@@ -5,9 +5,9 @@ Feature: Terminate an election
     # Call read(...) makes this feature and the called feature share the same scope
     # Meaning they share def variables, configurations ...
     # Especially JS functions defined in the called features can be directly used here thanks to Karate shared scopes
-    * call read('classpath:be/features/utils/server.feature')
-    * call read('classpath:be/features/utils/mockClient.feature')
     * call read('classpath:be/features/utils/constants.feature')
+    * call read(serverFeature)
+    * call read(mockClientFeature)
     * def organizer = call createMockClient
     * def lao = organizer.createValidLao()
     * def rollCall = organizer.createValidRollCall(lao)
@@ -15,7 +15,7 @@ Feature: Terminate an election
     * def question = election.createQuestion()
 
     # This call executes all the steps to set up a lao, complete a roll call, open an election and cast a vote
-    * call read('classpath:be/features/utils/simpleScenarios.feature@name=cast_vote') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)',  election: '#(election)', question: '#(question)' }
+    * call read(castVoteScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)',  election: '#(election)', question: '#(question)' }
     * def electionEnd = election.close()
 
   # After a successful election setup and cast vote sending a valid election end

--- a/tests/karate/src/test/java/be/features/election/electionOpen.feature
+++ b/tests/karate/src/test/java/be/features/election/electionOpen.feature
@@ -5,9 +5,9 @@ Feature: Open an Election
     # Call read(...) makes this feature and the called feature share the same scope
     # Meaning they share def variables, configurations ...
     # Especially JS functions defined in the called features can be directly used here thanks to Karate shared scopes
-    * call read('classpath:be/features/utils/server.feature')
-    * call read('classpath:be/features/utils/mockClient.feature')
     * call read('classpath:be/features/utils/constants.feature')
+    * call read(serverFeature)
+    * call read(mockClientFeature)
     * def organizer = call createMockClient
     * def lao = organizer.createValidLao()
     * def rollCall = organizer.createValidRollCall(lao)
@@ -15,7 +15,7 @@ Feature: Open an Election
     * def question = election.createQuestion()
 
     # This call executes all the steps to set up a lao, complete a roll call and create an election with one question
-    * call read('classpath:be/features/utils/simpleScenarios.feature@name=election_setup') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)',  election: '#(election)', question: '#(question)' }
+    * call read(setupElectionScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)',  election: '#(election)', question: '#(question)' }
     * def electionOpen = election.open()
 
   # Testing after creating an election, the backend returns an result

--- a/tests/karate/src/test/java/be/features/election/electionSetup.feature
+++ b/tests/karate/src/test/java/be/features/election/electionSetup.feature
@@ -5,9 +5,9 @@ Feature: Setup an Election
     # Call read(...) makes this feature and the called feature share the same scope
     # Meaning they share def variables, configurations ...
     # Especially JS functions defined in the called features can be directly used here thanks to Karate shared scopes
-    * call read('classpath:be/features/utils/server.feature')
-    * call read('classpath:be/features/utils/mockClient.feature')
     * call read('classpath:be/features/utils/constants.feature')
+    * call read(serverFeature)
+    * call read(mockClientFeature)
     * def organizer = call createMockClient
     * def lao = organizer.createValidLao()
     * def rollCall = organizer.createValidRollCall(lao)
@@ -16,7 +16,7 @@ Feature: Setup an Election
 
     # This call executes all the steps to set up a lao and complete a roll call, to get a valid pop token
     # (lao creation, subscribe, catchup, roll call creation, roll call open, roll call close)
-    * call read('classpath:be/features/utils/simpleScenarios.feature@name=close_roll_call') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
+    * call read(closeRollCallScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
 
   # Testing if after a successful roll call, sending a valid election
   # setup results in a valid response from the backend

--- a/tests/karate/src/test/java/be/features/rollCall/closeRollCall.feature
+++ b/tests/karate/src/test/java/be/features/rollCall/closeRollCall.feature
@@ -7,16 +7,16 @@ Feature: Close a Roll Call
     # Call read(...) makes this feature and the called feature share the same scope
     # Meaning they share def variables, configurations ...
     # Especially JS functions defined in the called features can be directly used here thanks to Karate shared scopes
-    * call read('classpath:be/features/utils/server.feature')
-    * call read('classpath:be/features/utils/mockClient.feature')
     * call read('classpath:be/features/utils/constants.feature')
+    * call read(serverFeature)
+    * call read(mockClientFeature)
     * def organizer = call createMockClient
     * def lao = organizer.createValidLao()
     * def rollCall = organizer.createValidRollCall(lao)
 
     # This call executes all the steps to open a valid roll call on the server before every scenario
     # (lao creation, subscribe, catchup, roll call creation, roll call open)
-    * call read('classpath:be/features/utils/simpleScenarios.feature@name=open_roll_call') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
+    * call read(openRollCallScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
     * def closeRollCall = rollCall.close()
 
   # Testing if after setting up a valid lao, subscribing to it, sending a catchup
@@ -79,7 +79,7 @@ Feature: Close a Roll Call
   Scenario: Closing a Roll Call that was not opened on the server returns an error
     Given def newRollCall = organizer.createValidRollCall(lao)
     # This call creates the new roll call on the server without opening it
-    And call read('classpath:be/utils/simpleScenarios.feature@name=valid_roll_call') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(newRollCall)' }
+    And call read(createRollCallScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(newRollCall)' }
     And def closeNewRollCall = newRollCall.close()
     And def validCloseRollCall =
       """

--- a/tests/karate/src/test/java/be/features/rollCall/createRollCall.feature
+++ b/tests/karate/src/test/java/be/features/rollCall/createRollCall.feature
@@ -7,16 +7,16 @@ Feature: Create a Roll Call
     # Call read(...) makes this feature and the called feature share the same scope
     # Meaning they share def variables, configurations ...
     # Especially JS functions defined in the called features can be directly used here thanks to Karate shared scopes
-    * call read('classpath:be/features/utils/server.feature')
-    * call read('classpath:be/features/utils/mockClient.feature')
     * call read('classpath:be/features/utils/constants.feature')
+    * call read(serverFeature)
+    * call read(mockClientFeature)
     * def organizer = call createMockClient
     * def lao = organizer.createValidLao()
     * def validRollCall = organizer.createValidRollCall(lao)
 
     # This call executes all the steps to create a valid lao on the server before every scenario
     # (lao creation, subscribe, catchup)
-    * call read('classpath:be/features/utils/simpleScenarios.feature@name=valid_lao') { organizer: '#(organizer)', lao: '#(lao)' }
+    * call read(createLaoScenario) { organizer: '#(organizer)', lao: '#(lao)' }
 
   # Testing if after setting up a valid lao, subscribing to it and sending a catchup
   # we send a valid roll call create request and expect to receive a valid response

--- a/tests/karate/src/test/java/be/features/rollCall/openRollCall.feature
+++ b/tests/karate/src/test/java/be/features/rollCall/openRollCall.feature
@@ -7,16 +7,16 @@ Feature: Roll Call Open
     # Call read(...) makes this feature and the called feature share the same scope
     # Meaning they share def variables, configurations ...
     # Especially JS functions defined in the called features can be directly used here thanks to Karate shared scopes
-    * call read('classpath:be/features/utils/server.feature')
-    * call read('classpath:be/features/utils/mockClient.feature')
     * call read('classpath:be/features/utils/constants.feature')
+    * call read(serverFeature)
+    * call read(mockClientFeature)
     * def organizer = call createMockClient
     * def lao = organizer.createValidLao()
     * def rollCall = organizer.createValidRollCall(lao)
 
     # This call executes all the steps to create a valid roll call on the server before every scenario
     # (lao creation, subscribe, catchup, roll call creation)
-    * call read('classpath:be/features/utils/simpleScenarios.feature@name=valid_roll_call') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
+    * call read(createRollCallScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
     * def openRollCall = rollCall.open()
 
   # This scenario tests a valid roll call open message.

--- a/tests/karate/src/test/java/be/features/utils/constants.feature
+++ b/tests/karate/src/test/java/be/features/utils/constants.feature
@@ -12,3 +12,20 @@ Feature: Constants
 
     * def rootChannel = '/root'
     * def random = Java.type('be.utils.RandomUtils')
+
+    # Paths to util features
+    * def utilsPath = 'classpath:be/features/utils/'
+    * def serverFeature = utilsPath + 'server.feature'
+    * def mockClientFeature = utilsPath + 'mockClient.feature'
+
+    # Paths to scenarios defined in simpleScenarios
+    * def simpleScenario = 'classpath:be/features/utils/simpleScenarios.feature@name='
+    * def createLaoScenario = simpleScenario + 'valid_lao'
+    * def createRollCallScenario = simpleScenario + 'valid_roll_call'
+    * def openRollCallScenario = simpleScenario + 'open_roll_call'
+    * def closeRollCallScenario = simpleScenario + 'close_roll_call'
+    * def setupElectionScenario = simpleScenario + 'election_setup'
+    * def openElectionScenario = simpleScenario + 'election_open'
+    * def castVoteScenario = simpleScenario + 'cast_vote'
+    * def setupCoinChannelScenario = simpleScenario + 'setup_coin_channel'
+    * def validCoinIssuanceScenario = simpleScenario + 'valid_coin_issuance'

--- a/tests/karate/src/test/java/be/features/utils/constants.feature
+++ b/tests/karate/src/test/java/be/features/utils/constants.feature
@@ -20,8 +20,8 @@ Feature: Constants
 
     # Paths to scenarios defined in simpleScenarios
     * def simpleScenario = 'classpath:be/features/utils/simpleScenarios.feature@name='
-    * def createLaoScenario = simpleScenario + 'valid_lao'
-    * def createRollCallScenario = simpleScenario + 'valid_roll_call'
+    * def createLaoScenario = simpleScenario + 'create_lao'
+    * def createRollCallScenario = simpleScenario + 'create_roll_call'
     * def openRollCallScenario = simpleScenario + 'open_roll_call'
     * def closeRollCallScenario = simpleScenario + 'close_roll_call'
     * def setupElectionScenario = simpleScenario + 'election_setup'

--- a/tests/karate/src/test/java/be/features/utils/simpleScenarios.feature
+++ b/tests/karate/src/test/java/be/features/utils/simpleScenarios.feature
@@ -5,8 +5,8 @@
     # This file contains a set of simple scenarios that can be used when
     # testing the validity of other features. By calling one scenario from
     # this file simply use the allocated name for the particular feature.
-      * call read('classpath:be/features/utils/mockClient.feature')
       * call read('classpath:be/features/utils/constants.feature')
+      * call read(mockClientFeature)
 
     # organizer and lao need to be passed as arguments when calling this scenario
     @name=valid_lao
@@ -60,7 +60,7 @@
     # organizer, lao and rollCall need to be passed as arguments when calling this scenario
     @name=valid_roll_call
     Scenario: Creates a valid Roll Call
-      * call read('classpath:be/features/utils/simpleScenarios.feature@name=valid_lao') { organizer: '#(organizer)', lao: '#(lao)' }
+      * call read(createLaoScenario) { organizer: '#(organizer)', lao: '#(lao)' }
       * def validCreateRollCall =
          """
            {
@@ -82,7 +82,7 @@
     # organizer, lao and rollCall need to be passed as arguments when calling this scenario
     @name=open_roll_call
     Scenario: Opens a valid Roll Call
-      * call read('classpath:be/features/utils/simpleScenarios.feature@name=valid_roll_call') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
+      * call read(createRollCallScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
       * def openRollCall = rollCall.open()
       * def validOpenRollCall =
         """
@@ -101,7 +101,7 @@
     # organizer, lao and rollCall need to be passed as arguments when calling this scenario
     @name=close_roll_call
     Scenario: Closes a valid Roll Call
-      * call read('classpath:be/features/utils/simpleScenarios.feature@name=open_roll_call') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
+      * call read(openRollCallScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
       * def closeRollCall = rollCall.close()
       * def validRollCallClose =
         """
@@ -121,7 +121,7 @@
     # organizer, lao, rollCall, election and the question need to be passed as arguments when calling this scenario
     @name=election_setup
     Scenario: Sets up a valid election with one question
-      * call read('classpath:be/features/utils/simpleScenarios.feature@name=close_roll_call') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
+      * call read(closeRollCallScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
       Given def validElectionSetup =
       """
         {
@@ -182,7 +182,7 @@
     # organizer, lao, rollCall, election and the question need to be passed as arguments when calling this scenario
     @name=election_open
     Scenario: Opens an election with one question
-      * call read('classpath:be/features/utils/simpleScenarios.feature@name=election_setup') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)',  election: '#(election)', question: '#(question)' }
+      * call read(setupElectionScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)',  election: '#(election)', question: '#(question)' }
       * def electionOpen = election.open()
       * def validElectionOpen =
         """
@@ -201,7 +201,7 @@
     # organizer, lao, rollCall, election and the question need to be passed as arguments when calling this scenario
     @name=cast_vote
     Scenario: Casts a valid vote
-      * call read('classpath:be/features/utils/simpleScenarios.feature@name=election_open') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)',  election: '#(election)', question: '#(question)' }
+      * call read(openElectionScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)',  election: '#(election)', question: '#(question)' }
       * def vote = question.createVote(0)
       * def castVote = election.castVote(vote)
       * def validCastVote =
@@ -228,7 +228,7 @@
     # organizer, lao and rollCall need to be passed as arguments when calling this scenario
     @name=setup_coin_channel
     Scenario: Sets up the coin channel and subscribes to it
-      * call read('classpath:be/features/utils/simpleScenarios.feature@name=close_roll_call') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
+      * call read(closeRollCallScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
       Given def subscribe =
         """
           {
@@ -262,7 +262,7 @@
     # organizer, lao, rollCall, recipient and amount need to be passed as arguments when calling this scenario
     @name=valid_coin_issuance
     Scenario: Issues a certain amount of coins to an attendee
-      * call read('classpath:be/features/utils/simpleScenarios.feature@name=setup_coin_channel') { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
+      * call read(setupCoinChannelScenario) { organizer: '#(organizer)', lao: '#(lao)', rollCall: '#(rollCall)' }
       * def transaction = organizer.issueCoins(recipient, amount);
       * def postTransaction = transaction.post()
       * def input = transaction.inputs[0]

--- a/tests/karate/src/test/java/be/features/utils/simpleScenarios.feature
+++ b/tests/karate/src/test/java/be/features/utils/simpleScenarios.feature
@@ -9,7 +9,7 @@
       * call read(mockClientFeature)
 
     # organizer and lao need to be passed as arguments when calling this scenario
-    @name=valid_lao
+    @name=create_lao
     Scenario: Creates valid lao
       Given def laoCreateRequest =
       """
@@ -58,7 +58,7 @@
       * def catchup_response = organizer.takeTimeout(timeout)
 
     # organizer, lao and rollCall need to be passed as arguments when calling this scenario
-    @name=valid_roll_call
+    @name=create_roll_call
     Scenario: Creates a valid Roll Call
       * call read(createLaoScenario) { organizer: '#(organizer)', lao: '#(lao)' }
       * def validCreateRollCall =


### PR DESCRIPTION
Paths to features and scenarios that are used across features are now defined as constants in `constants.feature`. 
This makes it easier to change paths in the future, as they will only have to be changed in one place. It also improves the readability of calls to `call read(...)` .