### PR TITLE
Disabled witnessing for fe2

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessingFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessingFragment.java
@@ -2,10 +2,9 @@ package com.github.dedis.popstellar.ui.lao.witness;
 
 import android.os.Bundle;
 import android.view.*;
-
+import android.widget.Toast;
 import androidx.fragment.app.Fragment;
 import androidx.viewpager2.widget.ViewPager2;
-
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.ui.lao.LaoActivity;
 import com.github.dedis.popstellar.ui.lao.LaoViewModel;
@@ -41,6 +40,13 @@ public class WitnessingFragment extends Fragment {
             ((tab, position) ->
                 tab.setText(position == 0 ? R.string.messages : R.string.witnesses)))
         .attach();
+
+    if (!LaoActivity.obtainWitnessingViewModel(
+            requireActivity(), LaoActivity.obtainViewModel(requireActivity()).getLaoId())
+        .isWitness()) {
+      Toast.makeText(requireContext(), R.string.not_a_witness, Toast.LENGTH_SHORT).show();
+    }
+
     handleBackNav();
     return view;
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessingViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/witness/WitnessingViewModel.java
@@ -2,10 +2,8 @@ package com.github.dedis.popstellar.ui.lao.witness;
 
 import android.app.Application;
 import android.widget.Toast;
-
 import androidx.annotation.NonNull;
 import androidx.lifecycle.*;
-
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
 import com.github.dedis.popstellar.model.network.method.message.data.lao.StateLao;
@@ -24,18 +22,15 @@ import com.github.dedis.popstellar.utility.error.ErrorUtils;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 import com.github.dedis.popstellar.utility.security.KeyManager;
 import com.google.gson.Gson;
-
-import java.time.Instant;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import javax.inject.Inject;
-
 import dagger.hilt.android.lifecycle.HiltViewModel;
 import io.reactivex.Completable;
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
 import timber.log.Timber;
 
 @HiltViewModel
@@ -51,7 +46,7 @@ public class WitnessingViewModel extends AndroidViewModel implements QRCodeScann
   private final MutableLiveData<List<PublicKey>> witnesses = new MutableLiveData<>();
   private final MutableLiveData<List<WitnessMessage>> witnessMessages = new MutableLiveData<>();
   private final MutableLiveData<Integer> nbScanned = new MutableLiveData<>(0);
-  private MutableLiveData<Boolean> showPopup = new MutableLiveData<>(false);
+  private final MutableLiveData<Boolean> showPopup = new MutableLiveData<>(false);
 
   private final LAORepository laoRepo;
   private final WitnessingRepository witnessingRepo;
@@ -87,6 +82,10 @@ public class WitnessingViewModel extends AndroidViewModel implements QRCodeScann
 
   public void setWitnessMessages(List<WitnessMessage> messages) {
     this.witnessMessages.setValue(messages);
+  }
+  
+  public boolean isWitness() {
+    return witnessingRepo.isWitness(laoId, keyManager.getMainPublicKey());
   }
 
   public void setWitnesses(List<PublicKey> witnesses) {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
@@ -9,11 +9,8 @@ import com.github.dedis.popstellar.model.objects.view.LaoView;
 import com.github.dedis.popstellar.repository.*;
 import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.security.KeyManager;
-
 import java.util.*;
-
 import javax.inject.Inject;
-
 import timber.log.Timber;
 
 /** Lao messages handler class */
@@ -56,7 +53,8 @@ public final class LaoHandler {
   public void handleCreateLao(HandlerContext context, CreateLao createLao)
       throws UnknownLaoException {
     Channel channel = context.getChannel();
-    Set<PublicKey> witnesses = new HashSet<>(createLao.getWitnesses());
+    // TODO: Uncomment this line when we want to restore the witnessing functionalities
+    Set<PublicKey> witnesses = new HashSet<>(); // new HashSet<>(createLao.getWitnesses());
 
     Timber.tag(TAG).d("handleCreateLao: channel: %s, msg: %s", channel, createLao);
     Lao lao = new Lao(createLao.getId());

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
   <string name="sign">Sign</string>
   <string name="signed">Signed</string>
   <string name="confirm_delete_witnessed_messages">Do you want to delete the messages already passing the witnessing policy?</string>
+  <string name="not_a_witness">You\'re not a witness!</string>
 
   <!--  Roll Call -->
   <string name="roll_call_setup_title">Roll Call Setup</string>

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ConsensusHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ConsensusHandlerTest.java
@@ -1,10 +1,15 @@
 package com.github.dedis.popstellar.utility.handler;
 
-import android.app.Application;
+import static com.github.dedis.popstellar.model.objects.ElectInstance.State.ACCEPTED;
+import static com.github.dedis.popstellar.model.objects.ElectInstance.State.FAILED;
+import static com.github.dedis.popstellar.testutils.Base64DataUtils.generateKeyPair;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
+import android.app.Application;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
 import com.github.dedis.popstellar.di.DataRegistryModuleHelper;
 import com.github.dedis.popstellar.di.JsonModule;
 import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
@@ -26,28 +31,17 @@ import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
 import com.github.dedis.popstellar.utility.security.KeyManager;
 import com.google.gson.Gson;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.mockito.internal.util.collections.Sets;
-
+import io.reactivex.Completable;
+import io.reactivex.Single;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.Instant;
 import java.util.*;
-
-import io.reactivex.Completable;
-import io.reactivex.Single;
-
-import static com.github.dedis.popstellar.model.objects.ElectInstance.State.ACCEPTED;
-import static com.github.dedis.popstellar.model.objects.ElectInstance.State.FAILED;
-import static com.github.dedis.popstellar.testutils.Base64DataUtils.generateKeyPair;
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.internal.util.collections.Sets;
 
 @RunWith(AndroidJUnit4.class)
 public class ConsensusHandlerTest {
@@ -142,6 +136,7 @@ public class ConsensusHandlerTest {
   }
 
   @Test
+  @Ignore
   public void handleConsensusTests()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
           UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {
@@ -152,6 +147,7 @@ public class ConsensusHandlerTest {
   }
 
   @Test
+  @Ignore
   public void handleConsensusFailure()
       throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
           UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/LaoHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/LaoHandlerTest.java
@@ -1,10 +1,15 @@
 package com.github.dedis.popstellar.utility.handler;
 
-import android.app.Application;
+import static com.github.dedis.popstellar.testutils.Base64DataUtils.*;
+import static com.github.dedis.popstellar.utility.handler.data.LaoHandler.updateLaoNameWitnessMessage;
+import static com.github.dedis.popstellar.utility.handler.data.LaoHandler.updateLaoWitnessesWitnessMessage;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
+import android.app.Application;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
 import com.github.dedis.popstellar.di.DataRegistryModuleHelper;
 import com.github.dedis.popstellar.di.JsonModule;
 import com.github.dedis.popstellar.model.network.method.message.MessageGeneral;
@@ -26,27 +31,16 @@ import com.github.dedis.popstellar.utility.error.*;
 import com.github.dedis.popstellar.utility.error.keys.NoRollCallException;
 import com.github.dedis.popstellar.utility.security.KeyManager;
 import com.google.gson.Gson;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
+import io.reactivex.Completable;
+import io.reactivex.Single;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.Instant;
 import java.util.*;
-
-import io.reactivex.Completable;
-import io.reactivex.Single;
-
-import static com.github.dedis.popstellar.testutils.Base64DataUtils.*;
-import static com.github.dedis.popstellar.utility.handler.data.LaoHandler.updateLaoNameWitnessMessage;
-import static com.github.dedis.popstellar.utility.handler.data.LaoHandler.updateLaoWitnessesWitnessMessage;
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 @RunWith(AndroidJUnit4.class)
 public class LaoHandlerTest {
@@ -162,8 +156,12 @@ public class LaoHandlerTest {
 
   @Test
   public void testHandleCreateLaoOrganizer()
-      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-          UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {
+      throws DataHandlingException,
+          UnknownLaoException,
+          UnknownRollCallException,
+          UnknownElectionException,
+          NoRollCallException,
+          UnknownWitnessMessageException {
     // Create the message (new CreateLao) and call the message handler
     MessageGeneral message = new MessageGeneral(SENDER_KEY1, CREATE_LAO2, gson);
     messageHandler.handleMessage(messageSender, LAO_CHANNEL2, message);
@@ -188,9 +186,14 @@ public class LaoHandlerTest {
   }
 
   @Test
+  @Ignore
   public void testHandleCreateLaoWitness()
-      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-          UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {
+      throws DataHandlingException,
+          UnknownLaoException,
+          UnknownRollCallException,
+          UnknownElectionException,
+          NoRollCallException,
+          UnknownWitnessMessageException {
     // Main public key is a witness now, and not the organizer
     lenient().when(keyManager.getMainPublicKey()).thenReturn(SENDER2);
 
@@ -220,8 +223,12 @@ public class LaoHandlerTest {
 
   @Test
   public void testHandleUpdateLaoNewName()
-      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-          UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {
+      throws DataHandlingException,
+          UnknownLaoException,
+          UnknownRollCallException,
+          UnknownElectionException,
+          NoRollCallException,
+          UnknownWitnessMessageException {
     // Create the update LAO message with new LAO name
     UpdateLao updateLao =
         new UpdateLao(
@@ -249,8 +256,12 @@ public class LaoHandlerTest {
 
   @Test
   public void testHandleUpdateLaoNewWitness()
-      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-          UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {
+      throws DataHandlingException,
+          UnknownLaoException,
+          UnknownRollCallException,
+          UnknownElectionException,
+          NoRollCallException,
+          UnknownWitnessMessageException {
     // Set LAO to have one witness
     lao.initKeyToNode(new HashSet<>(WITNESS));
 
@@ -327,8 +338,12 @@ public class LaoHandlerTest {
 
   @Test
   public void testHandleStateLaoOrganizer()
-      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-          UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {
+      throws DataHandlingException,
+          UnknownLaoException,
+          UnknownRollCallException,
+          UnknownElectionException,
+          NoRollCallException,
+          UnknownWitnessMessageException {
     // Create a valid list of modification signatures
     List<PublicKeySignaturePair> modificationSignatures =
         getValidModificationSignatures(createLaoMessage);
@@ -358,8 +373,12 @@ public class LaoHandlerTest {
 
   @Test
   public void testHandleStateLaoWitness()
-      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-          UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {
+      throws DataHandlingException,
+          UnknownLaoException,
+          UnknownRollCallException,
+          UnknownElectionException,
+          NoRollCallException,
+          UnknownWitnessMessageException {
     // Main public key is a witness now, and not the organizer
     lenient().when(keyManager.getMainPublicKey()).thenReturn(SENDER2);
 
@@ -388,8 +407,12 @@ public class LaoHandlerTest {
 
   @Test
   public void testHandleStateLaoRemovesStalePendingUpdates()
-      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-          UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {
+      throws DataHandlingException,
+          UnknownLaoException,
+          UnknownRollCallException,
+          UnknownElectionException,
+          NoRollCallException,
+          UnknownWitnessMessageException {
     // Create a list of 2 pending updates: one newer and one older than the stateLao message
     long targetTime = CREATE_LAO1.getCreation() + 5;
     PendingUpdate oldPendingUpdate = mock(PendingUpdate.class);
@@ -474,8 +497,12 @@ public class LaoHandlerTest {
 
   @Test()
   public void testGreetLao()
-      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-          UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {
+      throws DataHandlingException,
+          UnknownLaoException,
+          UnknownRollCallException,
+          UnknownElectionException,
+          NoRollCallException,
+          UnknownWitnessMessageException {
     // Create the Greet Lao
     GreetLao greetLao =
         new GreetLao(


### PR DESCRIPTION
Disable the witnessing functionality to be compatible with FE1, to be restored when also FE1 will implement it.