### PR TITLE
Added automatic signature mechanism for organiser

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/ConnectingActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/ConnectingActivity.java
@@ -32,10 +32,33 @@ public class ConnectingActivity extends AppCompatActivity {
   public static final String TAG = ConnectingActivity.class.getSimpleName();
 
   private final CompositeDisposable disposables = new CompositeDisposable();
-  private ConnectingActivityBinding binding;
-
   @Inject GlobalNetworkManager networkManager;
   @Inject KeyManager keyManager;
+  private ConnectingActivityBinding binding;
+
+  public static Intent newIntentForJoiningDetail(Context ctx, String laoId) {
+    Intent intent = new Intent(ctx, ConnectingActivity.class);
+    intent.putExtra(Constants.LAO_ID_EXTRA, laoId);
+    intent.putExtra(Constants.CONNECTION_PURPOSE_EXTRA, Constants.JOINING_EXTRA);
+    intent.putExtra(Constants.ACTIVITY_TO_OPEN_EXTRA, Constants.LAO_DETAIL_EXTRA);
+    intent.addFlags(FLAG_ACTIVITY_NEW_TASK);
+    return intent;
+  }
+
+  public static Intent newIntentForCreatingDetail(
+      Context ctx, String laoName, List<PublicKey> witnesses, boolean isWitnessingEnabled) {
+    Intent intent = new Intent(ctx, ConnectingActivity.class);
+    intent.putExtra(Constants.LAO_NAME, laoName);
+    intent.putStringArrayListExtra(
+        Constants.WITNESSES,
+        new ArrayList<>(
+            witnesses.stream().map(PublicKey::getEncoded).collect(Collectors.toList())));
+    intent.putExtra(Constants.CONNECTION_PURPOSE_EXTRA, Constants.CREATING_EXTRA);
+    intent.putExtra(Constants.ACTIVITY_TO_OPEN_EXTRA, Constants.LAO_DETAIL_EXTRA);
+    intent.putExtra(Constants.WITNESSING_FLAG_EXTRA, isWitnessingEnabled);
+    intent.addFlags(FLAG_ACTIVITY_NEW_TASK);
+    return intent;
+  }
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -122,14 +145,14 @@ public class ConnectingActivity extends AppCompatActivity {
       List<String> witnessesList = getIntent().getStringArrayListExtra(Constants.WITNESSES);
       boolean isWitnessingEnabled =
           getIntent().getExtras().getBoolean(Constants.WITNESSING_FLAG_EXTRA);
-      List<PublicKey> witnesses =
-          isWitnessingEnabled
-              ? witnessesList.stream().map(PublicKey::new).collect(Collectors.toList())
-              : Collections.emptyList();
 
-      // Add the organizer to the list of witnesses
+      List<PublicKey> witnesses;
       if (isWitnessingEnabled) {
+        witnesses = witnessesList.stream().map(PublicKey::new).collect(Collectors.toList());
+        // Add the organizer to the list of witnesses
         witnesses.add(keyManager.getMainPublicKey());
+      } else {
+        witnesses = Collections.emptyList();
       }
 
       CreateLao createLao = new CreateLao(laoName, keyManager.getMainPublicKey(), witnesses);
@@ -178,29 +201,5 @@ public class ConnectingActivity extends AppCompatActivity {
           startActivity(HomeActivity.newIntent(this));
           finish();
         });
-  }
-
-  public static Intent newIntentForJoiningDetail(Context ctx, String laoId) {
-    Intent intent = new Intent(ctx, ConnectingActivity.class);
-    intent.putExtra(Constants.LAO_ID_EXTRA, laoId);
-    intent.putExtra(Constants.CONNECTION_PURPOSE_EXTRA, Constants.JOINING_EXTRA);
-    intent.putExtra(Constants.ACTIVITY_TO_OPEN_EXTRA, Constants.LAO_DETAIL_EXTRA);
-    intent.addFlags(FLAG_ACTIVITY_NEW_TASK);
-    return intent;
-  }
-
-  public static Intent newIntentForCreatingDetail(
-      Context ctx, String laoName, List<PublicKey> witnesses, boolean isWitnessingEnabled) {
-    Intent intent = new Intent(ctx, ConnectingActivity.class);
-    intent.putExtra(Constants.LAO_NAME, laoName);
-    intent.putStringArrayListExtra(
-        Constants.WITNESSES,
-        new ArrayList<>(
-            witnesses.stream().map(PublicKey::getEncoded).collect(Collectors.toList())));
-    intent.putExtra(Constants.CONNECTION_PURPOSE_EXTRA, Constants.CREATING_EXTRA);
-    intent.putExtra(Constants.ACTIVITY_TO_OPEN_EXTRA, Constants.LAO_DETAIL_EXTRA);
-    intent.putExtra(Constants.WITNESSING_FLAG_EXTRA, isWitnessingEnabled);
-    intent.addFlags(FLAG_ACTIVITY_NEW_TASK);
-    return intent;
   }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/HomeViewModel.java
@@ -2,10 +2,8 @@ package com.github.dedis.popstellar.ui.home;
 
 import android.app.Application;
 import android.widget.Toast;
-
 import androidx.annotation.NonNull;
 import androidx.lifecycle.*;
-
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.model.objects.Wallet;
 import com.github.dedis.popstellar.model.objects.view.LaoView;
@@ -22,18 +20,15 @@ import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 import com.github.dedis.popstellar.utility.error.keys.SeedValidationException;
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
-
-import java.security.GeneralSecurityException;
-import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.inject.Inject;
-
 import dagger.hilt.android.lifecycle.HiltViewModel;
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
+import java.security.GeneralSecurityException;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.inject.Inject;
 import timber.log.Timber;
 
 @HiltViewModel
@@ -50,6 +45,8 @@ public class HomeViewModel extends AndroidViewModel
 
   /** This LiveData boolean is used to indicate whether the HomeFragment is displayed */
   private final MutableLiveData<Boolean> isHome = new MutableLiveData<>(Boolean.TRUE);
+
+  private final MutableLiveData<Boolean> isWitnessingEnabled = new MutableLiveData<>(Boolean.FALSE);
 
   /**
    * This atomic flag is used to avoid the scanner fragment to open multiple connecting activities,
@@ -215,6 +212,10 @@ public class HomeViewModel extends AndroidViewModel
     return isHome;
   }
 
+  public MutableLiveData<Boolean> isWitnessingEnabled() {
+    return isWitnessingEnabled;
+  }
+
   /**
    * Function to set the liveData isHome.
    *
@@ -223,6 +224,17 @@ public class HomeViewModel extends AndroidViewModel
   public void setIsHome(boolean isHome) {
     if (!Boolean.valueOf(isHome).equals(this.isHome.getValue())) {
       this.isHome.setValue(isHome);
+    }
+  }
+
+  /**
+   * Function to set the liveData isWitnessingEnabled.
+   *
+   * @param isWitnessingEnabled true if we want to enable witnessing, false otherwise
+   */
+  public void setIsWitnessingEnabled(boolean isWitnessingEnabled) {
+    if (!Boolean.valueOf(isWitnessingEnabled).equals(this.isWitnessingEnabled.getValue())) {
+      this.isWitnessingEnabled.setValue(isWitnessingEnabled);
     }
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
@@ -164,12 +164,10 @@ public final class LaoCreateFragment extends Fragment {
               binding.witnessesTitle.setVisibility(View.VISIBLE);
               binding.witnessesList.setVisibility(View.VISIBLE);
             }
-            binding.enableWitnessingSwitch.setText(R.string.lao_create_disable_witnessing_switch);
           } else {
             binding.addWitnessButton.setVisibility(View.GONE);
             binding.witnessesTitle.setVisibility(View.GONE);
             binding.witnessesList.setVisibility(View.GONE);
-            binding.enableWitnessingSwitch.setText(R.string.lao_create_enable_witnessing_switch);
           }
         });
     // Use this to save the preference after opening and closing the QR code

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/LaoCreateFragment.java
@@ -164,10 +164,12 @@ public final class LaoCreateFragment extends Fragment {
               binding.witnessesTitle.setVisibility(View.VISIBLE);
               binding.witnessesList.setVisibility(View.VISIBLE);
             }
+            binding.enableWitnessingSwitch.setText(R.string.lao_create_disable_witnessing_switch);
           } else {
             binding.addWitnessButton.setVisibility(View.GONE);
             binding.witnessesTitle.setVisibility(View.GONE);
             binding.witnessesList.setVisibility(View.GONE);
+            binding.enableWitnessingSwitch.setText(R.string.lao_create_enable_witnessing_switch);
           }
         });
     // Use this to save the preference after opening and closing the QR code

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/home/SettingsFragment.java
@@ -3,20 +3,16 @@ package com.github.dedis.popstellar.ui.home;
 import android.os.Bundle;
 import android.view.*;
 import android.widget.Toast;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.preference.SwitchPreference;
-
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.utility.MessageValidator;
 import com.github.dedis.popstellar.utility.NetworkLogger;
 import com.takisoft.preferencex.EditTextPreference;
 import com.takisoft.preferencex.PreferenceFragmentCompat;
-
-import java.util.Objects;
-
 import dagger.hilt.android.AndroidEntryPoint;
+import java.util.Objects;
 
 @AndroidEntryPoint
 public class SettingsFragment extends PreferenceFragmentCompat {
@@ -43,6 +39,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     setDebuggingPreferences();
   }
 
+  @NonNull
   @Override
   public View onCreateView(
       @NonNull LayoutInflater inflater,

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
@@ -365,8 +365,7 @@ public class LaoActivity extends AppCompatActivity {
         new ViewModelProvider(activity).get(WitnessingViewModel.class);
     try {
       witnessingViewModel.initialize(laoId);
-    } catch (UnknownLaoException e) {
-      throw new RuntimeException(e);
+    } catch (UnknownLaoException ignored) {
     }
     return witnessingViewModel;
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
@@ -365,7 +365,10 @@ public class LaoActivity extends AppCompatActivity {
         new ViewModelProvider(activity).get(WitnessingViewModel.class);
     try {
       witnessingViewModel.initialize(laoId);
-    } catch (UnknownLaoException ignored) {
+    } catch (UnknownLaoException e) {
+      Timber.tag(TAG)
+          .e(e, "Unable to initialize the witnessing model: not found lao with lao id=%s", laoId);
+      return witnessingViewModel;
     }
     return witnessingViewModel;
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/LaoActivity.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.widget.TextView;
-
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.IdRes;
 import androidx.annotation.Nullable;
@@ -13,7 +12,6 @@ import androidx.core.view.GravityCompat;
 import androidx.fragment.app.*;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.ViewModelProvider;
-
 import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.databinding.LaoActivityBinding;
 import com.github.dedis.popstellar.model.Role;
@@ -36,11 +34,9 @@ import com.github.dedis.popstellar.utility.error.ErrorUtils;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 import com.google.android.material.snackbar.BaseTransientBottomBar;
 import com.google.android.material.snackbar.Snackbar;
-
+import dagger.hilt.android.AndroidEntryPoint;
 import java.util.*;
 import java.util.function.Supplier;
-
-import dagger.hilt.android.AndroidEntryPoint;
 import timber.log.Timber;
 
 @AndroidEntryPoint
@@ -367,7 +363,11 @@ public class LaoActivity extends AppCompatActivity {
       FragmentActivity activity, String laoId) {
     WitnessingViewModel witnessingViewModel =
         new ViewModelProvider(activity).get(WitnessingViewModel.class);
-    witnessingViewModel.initialize(laoId);
+    try {
+      witnessingViewModel.initialize(laoId);
+    } catch (UnknownLaoException e) {
+      throw new RuntimeException(e);
+    }
     return witnessingViewModel;
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/Constants.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/Constants.java
@@ -12,6 +12,7 @@ public class Constants {
   public static final String LAO_NAME = "lao_name";
 
   public static final String WITNESSES = "witnesses";
+  public static final String WITNESSING_FLAG_EXTRA = "isWitnessingEnabled";
 
   /** The extra key given to transmit a roll call id */
   public static final String ROLL_CALL_ID = "roll_call_id";

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.java
@@ -53,8 +53,7 @@ public final class LaoHandler {
   public void handleCreateLao(HandlerContext context, CreateLao createLao)
       throws UnknownLaoException {
     Channel channel = context.getChannel();
-    // TODO: Uncomment this line when we want to restore the witnessing functionalities
-    Set<PublicKey> witnesses = new HashSet<>(); // new HashSet<>(createLao.getWitnesses());
+    Set<PublicKey> witnesses = new HashSet<>(createLao.getWitnesses());
 
     Timber.tag(TAG).d("handleCreateLao: channel: %s, msg: %s", channel, createLao);
     Lao lao = new Lao(createLao.getId());

--- a/fe2-android/app/src/main/res/layout/lao_create_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/lao_create_fragment.xml
@@ -44,6 +44,14 @@
 
       </com.google.android.material.textfield.TextInputLayout>
 
+      <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/enable_witnessing_switch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/lao_create_enable_witnessing_switch"
+        style="@style/text_medium_emphasis"
+        android:layout_marginTop="@dimen/margin_text" />
+
       <TextView
         android:id="@+id/witnesses_title"
         android:layout_width="match_parent"
@@ -52,7 +60,7 @@
         android:text="@string/witnesses"
         android:visibility="gone"
         android:layout_marginTop="@dimen/margin_text"
-        app:layout_constraintTop_toBottomOf="@id/server_url_entry_edit_text" />
+        app:layout_constraintTop_toBottomOf="@id/enable_witnessing_switch" />
 
       <ListView
         android:id="@+id/witnesses_list"
@@ -64,7 +72,8 @@
         android:scrollbarSize="@dimen/roll_call_attendees_scrollbar_size"
         android:scrollbars="vertical"
         android:scrollingCache="true"
-        android:smoothScrollbar="true" />
+        android:smoothScrollbar="true"
+        android:visibility="gone" />
 
       <LinearLayout
         android:layout_width="match_parent"
@@ -76,7 +85,8 @@
           android:id="@+id/add_witness_button"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:text="@string/lao_create_witnesses_button" />
+          android:text="@string/lao_create_witnesses_button"
+          android:visibility="gone" />
       </LinearLayout>
 
       <LinearLayout
@@ -89,12 +99,12 @@
         app:layout_constraintBottom_toBottomOf="parent">
 
         <Button
-          android:id="@+id/button_cancel_launch"
+          android:id="@+id/button_clear_launch"
           android:layout_width="@dimen/standard_button_width"
           android:layout_height="@dimen/standard_button_height"
           android:gravity="center"
           android:backgroundTint="@color/gray"
-          android:text="@string/button_cancel" />
+          android:text="@string/button_clear" />
 
         <Button
           android:id="@+id/button_create"

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -57,6 +57,9 @@
   <string name="lao_create_title">Create LAO</string>
   <string name="text_entry_create">Organization name</string>
   <string name="lao_create_witnesses_button">Add witnesses</string>
+  <string name="lao_create_enable_witnessing_switch">Enable witnessing protocol</string>
+  <string name="lao_create_disable_witnessing_switch">Disable witnessing protocol</string>
+  <string name="button_clear">Clear</string>
 
   <!--  Lao Detail-->
   <string name="add_election">New Election</string>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -58,7 +58,6 @@
   <string name="text_entry_create">Organization name</string>
   <string name="lao_create_witnesses_button">Add witnesses</string>
   <string name="lao_create_enable_witnessing_switch">Enable witnessing protocol</string>
-  <string name="lao_create_disable_witnessing_switch">Disable witnessing protocol</string>
   <string name="button_clear">Clear</string>
 
   <!--  Lao Detail-->

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/home/LaoCreatePageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/home/LaoCreatePageObject.java
@@ -1,13 +1,12 @@
 package com.github.dedis.popstellar.testutils.pages.home;
 
-import androidx.annotation.IdRes;
-import androidx.test.espresso.ViewInteraction;
-
-import com.github.dedis.popstellar.R;
-import com.github.dedis.popstellar.ui.home.LaoCreateFragment;
-
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+import androidx.annotation.IdRes;
+import androidx.test.espresso.ViewInteraction;
+import com.github.dedis.popstellar.R;
+import com.github.dedis.popstellar.ui.home.LaoCreateFragment;
 
 /**
  * Page object of {@link LaoCreateFragment}
@@ -33,8 +32,8 @@ public class LaoCreatePageObject {
     return onView(withId(R.id.server_url_entry_edit_text));
   }
 
-  public static ViewInteraction cancelButtonLaunch() {
-    return onView(withId(R.id.button_cancel_launch));
+  public static ViewInteraction clearButtonLaunch() {
+    return onView(withId(R.id.button_clear_launch));
   }
 
   public static ViewInteraction confirmButtonLaunch() {
@@ -47,5 +46,13 @@ public class LaoCreatePageObject {
 
   public static ViewInteraction witnessTitle() {
     return onView(withId(R.id.witnesses_title));
+  }
+
+  public static ViewInteraction witnessList() {
+    return onView(withId(R.id.witnesses_list));
+  }
+
+  public static ViewInteraction witnessingSwitch() {
+    return onView(withId(R.id.enable_witnessing_switch));
   }
 }

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/scanning/QrScanningPageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/scanning/QrScanningPageObject.java
@@ -1,27 +1,30 @@
 package com.github.dedis.popstellar.testutils.pages.scanning;
 
-import androidx.test.espresso.ViewInteraction;
-
-import com.github.dedis.popstellar.R;
-
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
+import androidx.test.espresso.ViewInteraction;
+import com.github.dedis.popstellar.R;
+
 public class QrScanningPageObject {
 
-    public static ViewInteraction manualAddConfirm(){
+  public static ViewInteraction manualAddConfirm() {
     return onView(withId(R.id.manual_add_button));
-    }
+  }
 
-    public static ViewInteraction manualAddEditText(){
-        return onView(withId(R.id.manual_add_edit_text));
-    }
+  public static ViewInteraction manualAddEditText() {
+    return onView(withId(R.id.manual_add_edit_text));
+  }
 
-    public static ViewInteraction openManualButton(){
-      return onView(withId(R.id.scanner_enter_manually));
-    }
+  public static ViewInteraction openManualButton() {
+    return onView(withId(R.id.scanner_enter_manually));
+  }
 
-    public static ViewInteraction attendeeCount(){
+  public static ViewInteraction attendeeCount() {
     return onView(withId(R.id.scanned_number));
-    }
+  }
+
+  public static ViewInteraction closeManualButton() {
+    return onView(withId(R.id.add_manual_close));
+  }
 }

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/home/LaoCreateFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/home/LaoCreateFragmentTest.java
@@ -1,11 +1,21 @@
 package com.github.dedis.popstellar.ui.home;
 
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra;
+import static androidx.test.espresso.matcher.ViewMatchers.*;
+import static com.github.dedis.popstellar.testutils.pages.home.HomePageObject.*;
+import static com.github.dedis.popstellar.testutils.pages.home.LaoCreatePageObject.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
 import com.github.dedis.popstellar.model.objects.Lao;
 import com.github.dedis.popstellar.model.objects.security.KeyPair;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
@@ -14,30 +24,18 @@ import com.github.dedis.popstellar.repository.LAORepository;
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager;
 import com.github.dedis.popstellar.repository.remote.MessageSender;
 import com.github.dedis.popstellar.testutils.Base64DataUtils;
+import com.github.dedis.popstellar.utility.Constants;
 import com.github.dedis.popstellar.utility.error.UnknownLaoException;
 import com.github.dedis.popstellar.utility.security.KeyManager;
-
+import dagger.hilt.android.testing.*;
+import io.reactivex.subjects.BehaviorSubject;
+import java.util.Collections;
 import org.junit.*;
 import org.junit.rules.ExternalResource;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoTestRule;
-
-import java.util.Collections;
-
-import dagger.hilt.android.testing.*;
-import io.reactivex.subjects.BehaviorSubject;
-
-import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.intent.Intents.intended;
-import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
-import static androidx.test.espresso.matcher.ViewMatchers.*;
-import static com.github.dedis.popstellar.testutils.pages.home.HomePageObject.*;
-import static com.github.dedis.popstellar.testutils.pages.home.LaoCreatePageObject.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
 
 @HiltAndroidTest
 @RunWith(AndroidJUnit4.class)
@@ -87,11 +85,18 @@ public class LaoCreateFragmentTest {
   }
 
   @Test
-  public final void uiElementsAreDisplayed() {
+  public final void uiElementsAreCorrectlyDisplayed() {
     laoNameEntry().check(matches(isDisplayed()));
-    cancelButtonLaunch().check(matches(isDisplayed()));
+    serverNameEntry().check(matches(isDisplayed()));
+    clearButtonLaunch().check(matches(isDisplayed()));
     confirmButtonLaunch().check(matches(isDisplayed()));
-    addWitnessButton().check(matches(isDisplayed()));
+    witnessingSwitch().check(matches(isDisplayed()));
+  }
+
+  @Test
+  public void uiElementsAreCorrectlyHidden() {
+    addWitnessButton().check(matches((withEffectiveVisibility(Visibility.GONE))));
+    witnessList().check(matches((withEffectiveVisibility(Visibility.GONE))));
     witnessTitle().check(matches(withEffectiveVisibility(Visibility.GONE)));
   }
 
@@ -108,14 +113,40 @@ public class LaoCreateFragmentTest {
   }
 
   @Test
-  public void cancelButtonGoesToHome() {
-    cancelButtonLaunch().perform(click());
-    fragmentContainer().check(matches(withChild(withId(homeFragmentId()))));
+  public void clearButtonEraseFields() {
+    clearButtonLaunch().perform(click());
+    laoNameEntry().check(matches(withText("")));
+    serverNameEntry().check(matches(withText("")));
+    witnessingSwitch().check(matches(isNotSelected()));
+    addWitnessButton().check(matches((withEffectiveVisibility(Visibility.GONE))));
+    witnessList().check(matches((withEffectiveVisibility(Visibility.GONE))));
+    witnessTitle().check(matches(withEffectiveVisibility(Visibility.GONE)));
   }
 
   @Test
   public void addWitnessButtonGoesToScanner() {
+    witnessingSwitch().perform(click());
     addWitnessButton().perform(click());
     fragmentContainer().check(matches(withChild(withId(qrScannerFragmentId()))));
+  }
+
+  @Test
+  public void witnessingSwitchDisplayButton() {
+    witnessingSwitch().perform(click());
+    addWitnessButton().check(matches((isDisplayed())));
+  }
+
+  @Test
+  public void witnessingSwitchEnabledPopulateWitnesses() {
+    witnessingSwitch().perform(click());
+    Intents.init();
+    laoNameEntry().perform(ViewActions.replaceText(LAO_NAME));
+    serverNameEntry().perform(ViewActions.replaceText(SERVER_URL));
+    confirmButtonLaunch().check(matches(isDisplayed()));
+    confirmButtonLaunch().check(matches(isEnabled()));
+    confirmButtonLaunch().perform(click());
+    intended(hasComponent(ConnectingActivity.class.getName()));
+    intended(hasExtra(Constants.WITNESSING_FLAG_EXTRA, true));
+    Intents.release();
   }
 }

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/home/LaoCreateFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/home/LaoCreateFragmentTest.java
@@ -101,6 +101,9 @@ public class LaoCreateFragmentTest {
 
   @Test
   public void uiElementsAreCorrectlyHidden() {
+    // The witnessing switch is disabled by default
+    witnessingSwitch().check(matches(isNotChecked()));
+
     addWitnessButton().check(matches((withEffectiveVisibility(Visibility.GONE))));
     witnessList().check(matches((withEffectiveVisibility(Visibility.GONE))));
     witnessTitle().check(matches(withEffectiveVisibility(Visibility.GONE)));
@@ -145,7 +148,6 @@ public class LaoCreateFragmentTest {
   @Test
   public void witnessingSwitchDisplayButton() {
     witnessingSwitch().perform(click());
-    witnessingSwitch().check(matches(withText(R.string.lao_create_disable_witnessing_switch)));
     addWitnessButton().check(matches((isDisplayed())));
   }
 

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/home/LaoCreateFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/home/LaoCreateFragmentTest.java
@@ -148,7 +148,7 @@ public class LaoCreateFragmentTest {
   @Test
   public void witnessingSwitchDisplayButton() {
     witnessingSwitch().perform(click());
-    addWitnessButton().check(matches((isDisplayed())));
+    addWitnessButton().check(matches(isDisplayed()));
   }
 
   @Test

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/home/LaoCreateFragmentTest.java
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/home/LaoCreateFragmentTest.java
@@ -19,6 +19,7 @@ import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.github.dedis.popstellar.R;
 import com.github.dedis.popstellar.model.objects.Lao;
 import com.github.dedis.popstellar.model.objects.security.KeyPair;
 import com.github.dedis.popstellar.model.objects.security.PublicKey;
@@ -128,6 +129,7 @@ public class LaoCreateFragmentTest {
     laoNameEntry().check(matches(withText("")));
     serverNameEntry().check(matches(withText("")));
     witnessingSwitch().check(matches(isNotSelected()));
+    witnessingSwitch().check(matches(withText(R.string.lao_create_enable_witnessing_switch)));
     addWitnessButton().check(matches((withEffectiveVisibility(Visibility.GONE))));
     witnessList().check(matches((withEffectiveVisibility(Visibility.GONE))));
     witnessTitle().check(matches(withEffectiveVisibility(Visibility.GONE)));
@@ -143,6 +145,7 @@ public class LaoCreateFragmentTest {
   @Test
   public void witnessingSwitchDisplayButton() {
     witnessingSwitch().perform(click());
+    witnessingSwitch().check(matches(withText(R.string.lao_create_disable_witnessing_switch)));
     addWitnessButton().check(matches((isDisplayed())));
   }
 

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ConsensusHandlerTest.java
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/ConsensusHandlerTest.java
@@ -89,8 +89,13 @@ public class ConsensusHandlerTest {
 
   @Before
   public void setup()
-      throws GeneralSecurityException, DataHandlingException, IOException, UnknownLaoException,
-          UnknownRollCallException, UnknownElectionException, NoRollCallException,
+      throws GeneralSecurityException,
+          DataHandlingException,
+          IOException,
+          UnknownLaoException,
+          UnknownRollCallException,
+          UnknownElectionException,
+          NoRollCallException,
           UnknownWitnessMessageException {
     MockitoAnnotations.openMocks(this);
     Application application = ApplicationProvider.getApplicationContext();
@@ -136,10 +141,13 @@ public class ConsensusHandlerTest {
   }
 
   @Test
-  @Ignore
   public void handleConsensusTests()
-      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-          UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {
+      throws DataHandlingException,
+          UnknownLaoException,
+          UnknownRollCallException,
+          UnknownElectionException,
+          NoRollCallException,
+          UnknownWitnessMessageException {
     // each test need to be run one after another
     handleConsensusElectTest();
     handleConsensusElectAcceptTest();
@@ -147,10 +155,13 @@ public class ConsensusHandlerTest {
   }
 
   @Test
-  @Ignore
   public void handleConsensusFailure()
-      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-          UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {
+      throws DataHandlingException,
+          UnknownLaoException,
+          UnknownRollCallException,
+          UnknownElectionException,
+          NoRollCallException,
+          UnknownWitnessMessageException {
     // handle an elect from node2 then handle a failure for this elect
     // the state of the node2 for this instanceId should be FAILED
 
@@ -175,8 +186,12 @@ public class ConsensusHandlerTest {
   // This should add an attempt from node2 to start a consensus (in this case for starting an
   // election)
   private void handleConsensusElectTest()
-      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-          UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {
+      throws DataHandlingException,
+          UnknownLaoException,
+          UnknownRollCallException,
+          UnknownElectionException,
+          NoRollCallException,
+          UnknownWitnessMessageException {
     messageHandler.handleMessage(messageSender, CONSENSUS_CHANNEL, electMsg);
 
     Lao updatedLao = laoRepo.getLaoViewByChannel(Channel.getLaoChannel(LAO_ID)).createLaoCopy();
@@ -222,8 +237,12 @@ public class ConsensusHandlerTest {
   // handle an electAccept from node3 for the elect of node2
   // This test need be run after the elect message was handled, else the messageId would be invalid
   private void handleConsensusElectAcceptTest()
-      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-          UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {
+      throws DataHandlingException,
+          UnknownLaoException,
+          UnknownRollCallException,
+          UnknownElectionException,
+          NoRollCallException,
+          UnknownWitnessMessageException {
     ConsensusElectAccept electAccept = new ConsensusElectAccept(INSTANCE_ID, messageId, true);
     MessageGeneral electAcceptMsg = getMsg(NODE_3_KEY, electAccept);
     messageHandler.handleMessage(messageSender, CONSENSUS_CHANNEL, electAcceptMsg);
@@ -259,8 +278,12 @@ public class ConsensusHandlerTest {
   // handle a learn from node3 for the elect of node2
   // This test need be run after the elect message was handled, else the messageId would be invalid
   private void handleConsensusLearnTest()
-      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-          UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {
+      throws DataHandlingException,
+          UnknownLaoException,
+          UnknownRollCallException,
+          UnknownElectionException,
+          NoRollCallException,
+          UnknownWitnessMessageException {
     ConsensusLearn learn =
         new ConsensusLearn(INSTANCE_ID, messageId, CREATION_TIME, true, Collections.emptyList());
     MessageGeneral learnMsg = getMsg(NODE_3_KEY, learn);
@@ -304,8 +327,12 @@ public class ConsensusHandlerTest {
 
   @Test
   public void handleConsensusDoNothingOnBackendMessageTest()
-      throws DataHandlingException, UnknownLaoException, UnknownRollCallException,
-          UnknownElectionException, NoRollCallException, UnknownWitnessMessageException {
+      throws DataHandlingException,
+          UnknownLaoException,
+          UnknownRollCallException,
+          UnknownElectionException,
+          NoRollCallException,
+          UnknownWitnessMessageException {
     LAORepository mockLAORepository = mock(LAORepository.class);
 
     ConsensusPrepare prepare = new ConsensusPrepare(INSTANCE_ID, messageId, CREATION_TIME, 3);


### PR DESCRIPTION
This CR allows to re-enable the witnessing feature by implementing an automatic signature mechanism for the organiser. By having this mechanism in place, if no witness is added to the LAO (other than the organiser which is implicitly considered a witness) the behaviour between FE1 and FE2 is going to be coherent. Additionally, I've implemented a checkbox for fe2 when creating a lao which allows to intentionally disable the witnessing feature.

<img src="https://github.com/dedis/popstellar/assets/83547952/1d5d6ac2-8466-4426-809b-e11741422ea1" width="350"/>
<img src="https://github.com/dedis/popstellar/assets/83547952/c17ea573-62f1-43c8-b883-2c42402a214d" width="350"/>