### PR TITLE
[BE2]: Fix social in multi-server context

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/MessageHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/MessageHandler.scala
@@ -20,7 +20,6 @@ trait MessageHandler extends AskPatternConstants {
     */
   def dbActor: AskableActorRef = PublishSubscribe.getDbActorRef
   def connectionMediator: AskableActorRef = PublishSubscribe.getConnectionMediatorRef
-
   def mediator: AskableActorRef = PublishSubscribe.getMediatorActorRef
 
   def extractParameters[T](rpcRequest: JsonRpcRequest, errorMsg: String): Future[(GraphMessage, Message, Option[T])] = {

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandler.scala
@@ -15,7 +15,7 @@ import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success}
 
 object SocialMediaHandler extends MessageHandler {
-  final lazy val handlerInstance = new SocialMediaHandler(super.dbActor)
+  final lazy val handlerInstance = new SocialMediaHandler(super.dbActor, super.mediator)
 
   def handleAddChirp(rpcMessage: JsonRpcRequest): GraphMessage = handlerInstance.handleAddChirp(rpcMessage)
 
@@ -30,11 +30,12 @@ object SocialMediaHandler extends MessageHandler {
   def handleDeleteReaction(rpcMessage: JsonRpcRequest): GraphMessage = handlerInstance.handleDeleteReaction(rpcMessage)
 }
 
-class SocialMediaHandler(dbRef: => AskableActorRef) extends MessageHandler {
+class SocialMediaHandler(dbRef: => AskableActorRef, mediatorRef: => AskableActorRef) extends MessageHandler {
 
   /** Overrides default DbActor with provided parameter
     */
   override final val dbActor: AskableActorRef = dbRef
+  override final val mediator: AskableActorRef = mediatorRef
 
   private final val unknownAnswerDatabase: String = "Database actor returned an unknown answer"
 

--- a/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandler.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandler.scala
@@ -54,7 +54,7 @@ class SocialMediaHandler(dbRef: => AskableActorRef) extends MessageHandler {
         //  create and propagate the notifyAddChirp message
         val notifyAddChirp: NotifyAddChirp = NotifyAddChirp(chirpId, channelChirp, data.timestamp)
         Await.result(
-          broadcast(rpcMessage, channelChirp, notifyAddChirp.toJson, broadcastChannel),
+          broadcast(rpcMessage, channelChirp, notifyAddChirp.toJson, broadcastChannel, writeToDb = false),
           duration
         )
 
@@ -86,7 +86,7 @@ class SocialMediaHandler(dbRef: => AskableActorRef) extends MessageHandler {
         // create and propagate the notifyDeleteChirp message
         val notifyDeleteChirp: NotifyDeleteChirp = NotifyDeleteChirp(chirpId, channelChirp, data.timestamp)
         Await.result(
-          broadcast(rpcMessage, channelChirp, notifyDeleteChirp.toJson, broadcastChannel),
+          broadcast(rpcMessage, channelChirp, notifyDeleteChirp.toJson, broadcastChannel, writeToDb = false),
           duration
         )
 

--- a/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandlerSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/pubsub/graph/handlers/SocialMediaHandlerSuite.scala
@@ -222,16 +222,6 @@ class SocialMediaHandlerSuite extends TestKit(ActorSystem("SocialMedia-DB-System
     system.stop(mockedDB.actorRef)
   }
 
-  test("AddChirp fails if the database succeeds storing the message and fails the notify") {
-    val mockedDB = mockDbWithAckAndNotifyNAck
-    val rc = new SocialMediaHandler(mockedDB)
-    val request = AddChirpMessages.addChirp
-
-    rc.handleAddChirp(request) shouldBe an[Left[PipelineError, _]]
-
-    system.stop(mockedDB.actorRef)
-  }
-
   test("DeleteChirp fails if the database fails storing the message") {
     val mockedDB = mockDbWithNack
     val rc = new SocialMediaHandler(mockedDB, mockMed)


### PR DESCRIPTION
Chirps notify_add is a server generated message in reaction to a chirp_add, it is not necessary to store it in the database. It causes issues when connecting a go and scala servers together. This pr fixes that. 