### PR TITLE
Work be1 stuart fix query already answered

### DIFF
--- a/be1-go/hub/standard_hub/hub_state/Queries.go
+++ b/be1-go/hub/standard_hub/hub_state/Queries.go
@@ -4,6 +4,7 @@ import (
 	"popstellar/message/query/method"
 	"sync"
 
+	"github.com/rs/zerolog"
 	"golang.org/x/xerrors"
 )
 
@@ -17,13 +18,16 @@ type Queries struct {
 	getMessagesByIdQueries map[int]method.GetMessagesById
 	// nextID store the ID of the next query
 	nextID int
+	// zerolog
+	log zerolog.Logger
 }
 
 // NewQueries creates a new queries struct
-func NewQueries() Queries {
+func NewQueries(log zerolog.Logger) Queries {
 	return Queries{
 		state:                  make(map[int]bool),
 		getMessagesByIdQueries: make(map[int]method.GetMessagesById),
+		log:                    log,
 	}
 }
 
@@ -61,7 +65,8 @@ func (q *Queries) SetQueryReceived(id int) error {
 	}
 
 	if currentState {
-		return xerrors.Errorf("query with id %d already answered", id)
+		q.log.Info().Msgf("query with id %d already answered", id)
+		return nil
 	}
 
 	q.state[id] = true

--- a/be1-go/hub/standard_hub/message_handling.go
+++ b/be1-go/hub/standard_hub/message_handling.go
@@ -83,8 +83,8 @@ func (h *Hub) handleRootChannelPublishMessage(sock socket.Socket, publish method
 
 // handleRootChannelPublishMessage handles an incoming publish message on the root channel.
 func (h *Hub) handleRootChannelBroadcastMessage(sock socket.Socket,
-	broadcast method.Broadcast) error {
-
+	broadcast method.Broadcast,
+) error {
 	jsonData, err := base64.URLEncoding.DecodeString(broadcast.Params.Message.Data)
 	if err != nil {
 		err := xerrors.Errorf("failed to decode message data: %v", err)
@@ -145,8 +145,8 @@ func (h *Hub) handleRootChannelBroadcastMessage(sock socket.Socket,
 
 // handleRootCatchup handles an incoming catchup message on the root channel
 func (h *Hub) handleRootCatchup(senderSocket socket.Socket,
-	byteMessage []byte) ([]message.Message, int, error) {
-
+	byteMessage []byte,
+) ([]message.Message, int, error) {
 	var catchup method.Catchup
 
 	err := json.Unmarshal(byteMessage, &catchup)
@@ -374,8 +374,8 @@ func (h *Hub) handleUnsubscribe(socket socket.Socket, byteMessage []byte) (int, 
 }
 
 func (h *Hub) handleCatchup(socket socket.Socket,
-	byteMessage []byte) ([]message.Message, int, error) {
-
+	byteMessage []byte,
+) ([]message.Message, int, error) {
 	var catchup method.Catchup
 
 	err := json.Unmarshal(byteMessage, &catchup)
@@ -401,8 +401,8 @@ func (h *Hub) handleCatchup(socket socket.Socket,
 }
 
 func (h *Hub) handleHeartbeat(socket socket.Socket,
-	byteMessage []byte) error {
-
+	byteMessage []byte,
+) error {
 	var heartbeat method.Heartbeat
 
 	err := json.Unmarshal(byteMessage, &heartbeat)
@@ -425,8 +425,8 @@ func (h *Hub) handleHeartbeat(socket socket.Socket,
 }
 
 func (h *Hub) handleGetMessagesById(socket socket.Socket,
-	byteMessage []byte) (map[string][]message.Message, int, error) {
-
+	byteMessage []byte,
+) (map[string][]message.Message, int, error) {
 	var getMessagesById method.GetMessagesById
 
 	err := json.Unmarshal(byteMessage, &getMessagesById)
@@ -571,7 +571,7 @@ func (h *Hub) loopOverMessages(messages *map[string][]json.RawMessage, senderSoc
 	for channel, messageArray := range *messages {
 		newMessageArray := make([]json.RawMessage, 0)
 
-		//Try to process each message
+		// Try to process each message
 		for _, msg := range messageArray {
 			var messageData message.Message
 			err := json.Unmarshal(msg, &messageData)

--- a/be1-go/hub/standard_hub/mod.go
+++ b/be1-go/hub/standard_hub/mod.go
@@ -97,8 +97,8 @@ type Hub struct {
 
 // NewHub returns a new Hub.
 func NewHub(pubKeyOwner kyber.Point, clientServerAddress string, serverServerAddress string, log zerolog.Logger,
-	laoFac channel.LaoFactory) (*Hub, error) {
-
+	laoFac channel.LaoFactory,
+) (*Hub, error) {
 	schemaValidator, err := validation.NewSchemaValidator(log)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create the schema validator: %v", err)
@@ -124,7 +124,7 @@ func NewHub(pubKeyOwner kyber.Point, clientServerAddress string, serverServerAdd
 		laoFac:              laoFac,
 		serverSockets:       channel.NewSockets(),
 		hubInbox:            *inbox.NewHubInbox(rootChannel),
-		queries:             state.NewQueries(),
+		queries:             state.NewQueries(log),
 		peers:               state.NewPeers(),
 		blacklist:           make([]string, 0),
 	}
@@ -451,7 +451,6 @@ func (h *Hub) handleIncomingMessage(incomingMessage *socket.IncomingMessage) err
 	default:
 		return xerrors.Errorf("invalid socket type")
 	}
-
 }
 
 // sendGetMessagesByIdToServer sends a getMessagesById message to a server
@@ -505,8 +504,8 @@ func (h *Hub) sendHeartbeatToServers() {
 
 // createLao creates a new LAO using the data in the publish parameter.
 func (h *Hub) createLao(msg message.Message, laoCreate messagedata.LaoCreate,
-	socket socket.Socket) error {
-
+	socket socket.Socket,
+) error {
 	laoChannelPath := rootPrefix + laoCreate.ID
 
 	if _, ok := h.channelByID.Get(laoChannelPath); ok {

--- a/be1-go/hub/standard_hub/mod_test.go
+++ b/be1-go/hub/standard_hub/mod_test.go
@@ -821,7 +821,7 @@ func Test_Handle_Answer(t *testing.T) {
 		c: &fakeChannel{},
 	}
 
-	hub, err := NewHub(keypair.public, "", "", nolog, fakeChannelFac.newChannel)
+	hub, err := NewHub(keypair.public, "", "", yeslog, fakeChannelFac.newChannel)
 	require.NoError(t, err)
 
 	result := struct {
@@ -917,8 +917,8 @@ func Test_Handle_Answer(t *testing.T) {
 		Socket:  sock,
 		Message: answerBuf,
 	})
-	require.Error(t, sock.err, "query %v already got an answer", serverAnswer.ID)
-	sock.err = nil
+	// Check that receiving twice an answer for a query doesn't return an error
+	require.NoError(t, sock.err)
 
 	hub.handleMessageFromServer(&socket.IncomingMessage{
 		Socket:  sock,
@@ -1630,7 +1630,7 @@ func Test_Send_Heartbeat_Message(t *testing.T) {
 
 	messageIdsSent := heartbeat.Params
 
-	//Check that all the stored messages where sent
+	// Check that all the stored messages where sent
 	for storedChannel, storedIds := range hub.hubInbox.GetIDsTable() {
 		sentIds, exists := messageIdsSent[storedChannel]
 		require.True(t, exists)
@@ -1638,7 +1638,6 @@ func Test_Send_Heartbeat_Message(t *testing.T) {
 			require.True(t, slices.Contains(sentIds, storedId))
 		}
 	}
-
 }
 
 // Test that the heartbeat messages are properly handled
@@ -1652,12 +1651,12 @@ func Test_Handle_Heartbeat(t *testing.T) {
 
 	sock := &fakeSocket{}
 
-	//The message Ids sent in hearbeat message
+	// The message Ids sent in hearbeat message
 	messageIds := make(map[string][]string)
 	messageIds["/root"] = idsRoot
 	messageIds["/root/channel1"] = idsChannel1
 
-	//The missing Ids the server should request
+	// The missing Ids the server should request
 	missingIds := make(map[string][]string)
 	missingIds["/root"] = []string{msg2.MessageID}
 	missingIds["/root/channel1"] = idsChannel1
@@ -1682,7 +1681,7 @@ func Test_Handle_Heartbeat(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, sock.err)
 
-	//socket should receive a getMessagesById query after handling of heartbeat
+	// socket should receive a getMessagesById query after handling of heartbeat
 	var getMessagesById method.GetMessagesById
 
 	err = json.Unmarshal(sock.msg, &getMessagesById)
@@ -1714,12 +1713,12 @@ func Test_Handle_GetMessagesById(t *testing.T) {
 	hub.hubInbox.StoreMessage("/root", msg2)
 	hub.hubInbox.StoreMessage("/root/channel1", msg3)
 
-	//The missing Ids requested by the server
+	// The missing Ids requested by the server
 	missingIds := make(map[string][]string)
 	missingIds["/root"] = []string{msg2.MessageID}
 	missingIds["/root/channel1"] = idsChannel1
 
-	//The missing messages the server should receive
+	// The missing messages the server should receive
 	missingMessages := make(map[string][]message.Message)
 	missingMessages["/root"] = []message.Message{msg2}
 	missingMessages["/root/channel1"] = res2
@@ -1818,7 +1817,7 @@ func Test_Handle_GreetServer_First_Time(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, sock.err)
 
-	//socket should receive a server greet back after handling of server greet
+	// socket should receive a server greet back after handling of server greet
 	var serverGreetResponse method.GreetServer
 
 	err = json.Unmarshal(sock.msg, &serverGreetResponse)
@@ -1844,7 +1843,7 @@ func Test_Handle_GreetServer_Already_Greeted(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, hub.peers.IsPeerGreeted(sock.ID()))
 
-	//reset socket message
+	// reset socket message
 	sock.msg = nil
 
 	serverInfo := method.ServerInfo{
@@ -1873,7 +1872,7 @@ func Test_Handle_GreetServer_Already_Greeted(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, sock.err)
 
-	//socket should not receive anything back after handling of server greet
+	// socket should not receive anything back after handling of server greet
 	require.Nil(t, sock.msg)
 }
 
@@ -1886,7 +1885,10 @@ type keypair struct {
 	private   kyber.Scalar
 }
 
-var nolog = zerolog.New(io.Discard)
+var (
+	yeslog = zerolog.New(os.Stdout)
+	nolog  = zerolog.New(io.Discard)
+)
 
 // var suite = crypto.Suite
 
@@ -1911,8 +1913,8 @@ type fakeChannelFac struct {
 
 // newChannel implement the type channel.LaoFactory
 func (c *fakeChannelFac) newChannel(channelID string, hub channel.HubFunctionalities,
-	msg message.Message, log zerolog.Logger, organizerKey kyber.Point, socket socket.Socket) (channel.Channel, error) {
-
+	msg message.Message, log zerolog.Logger, organizerKey kyber.Point, socket socket.Socket,
+) (channel.Channel, error) {
 	c.chanID = channelID
 	c.msg = msg
 	c.log = log
@@ -2052,6 +2054,7 @@ var msg1 = message.Message{
 	MessageID:         "message1",
 	WitnessSignatures: nil,
 }
+
 var msg2 = message.Message{
 	Data:              "data2",
 	Sender:            "sender2",
@@ -2070,5 +2073,7 @@ var msg3 = message.Message{
 
 var res2 = []message.Message{msg3}
 
-var idsRoot = []string{msg1.MessageID, msg2.MessageID}
-var idsChannel1 = []string{msg3.MessageID}
+var (
+	idsRoot     = []string{msg1.MessageID, msg2.MessageID}
+	idsChannel1 = []string{msg3.MessageID}
+)


### PR DESCRIPTION
the `SetQueryReceived` function now doesn't return an error when receiving more than once an answer to one of its query and just logs it.

the `Test_Handle_Answer` test has also been fix to work with this bug fix.