### PR TITLE
remove non-empty condition on hubInbox for heartbeats

### DIFF
--- a/be1-go/hub/standard_hub/mod.go
+++ b/be1-go/hub/standard_hub/mod.go
@@ -483,9 +483,6 @@ func (h *Hub) sendGetMessagesByIdToServer(socket socket.Socket, missingIds map[s
 
 // sendHeartbeatToServers sends a heartbeat message to all servers
 func (h *Hub) sendHeartbeatToServers() {
-	if h.hubInbox.IsEmpty() {
-		return
-	}
 	heartbeatMessage := method.Heartbeat{
 		Base: query.Base{
 			JSONRPCBase: jsonrpc.JSONRPCBase{


### PR DESCRIPTION
Just removes the check if the hubInbox is empty before sending heartbeats.
This is done in accordance to #1680 -- to match the behaviour of the scala backend. 