### PR TITLE
Fix#1668 wrapping of empty chirp error message

### DIFF
--- a/fe1-web/src/features/social/components/TextInputChirp.tsx
+++ b/fe1-web/src/features/social/components/TextInputChirp.tsx
@@ -30,6 +30,7 @@ const styles = StyleSheet.create({
     display: 'flex',
     flexDirection: 'column',
     flexGrow: 1,
+    flexShrink: 1,
   } as ViewStyle,
   textInput: {
     alignContent: 'flex-end',

--- a/fe1-web/src/features/social/components/__tests__/__snapshots__/NewChirp.test.tsx.snap
+++ b/fe1-web/src/features/social/components/__tests__/__snapshots__/NewChirp.test.tsx.snap
@@ -40,6 +40,7 @@ exports[`NewChirp renders correctly 1`] = `
           "display": "flex",
           "flexDirection": "column",
           "flexGrow": 1,
+          "flexShrink": 1,
         }
       }
     >
@@ -221,6 +222,7 @@ exports[`NewChirp shows the error message on empty trimmed message 1`] = `
           "display": "flex",
           "flexDirection": "column",
           "flexGrow": 1,
+          "flexShrink": 1,
         }
       }
     >
@@ -278,7 +280,7 @@ exports[`NewChirp shows the error message on empty trimmed message 1`] = `
             ]
           }
         >
-          You chirp will be cropped to an empty chirp. You cannot send an empty chirp.
+          Your chirp will be cropped to an empty chirp. You cannot send an empty chirp.
         </Text>
         <View
           style={
@@ -421,6 +423,7 @@ exports[`NewChirp shows the modal on trimmed chirp and closes it 1`] = `
           "display": "flex",
           "flexDirection": "column",
           "flexGrow": 1,
+          "flexShrink": 1,
         }
       }
     >
@@ -778,6 +781,7 @@ exports[`NewChirp shows the modal on trimmed chirp and closes it 2`] = `
           "display": "flex",
           "flexDirection": "column",
           "flexGrow": 1,
+          "flexShrink": 1,
         }
       }
     >

--- a/fe1-web/src/features/social/components/__tests__/__snapshots__/TextInputChirp.test.tsx.snap
+++ b/fe1-web/src/features/social/components/__tests__/__snapshots__/TextInputChirp.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`TextInputChirp renders correctly when writing less than 300 chars 1`] =
         "display": "flex",
         "flexDirection": "column",
         "flexGrow": 1,
+        "flexShrink": 1,
       }
     }
   >
@@ -212,6 +213,7 @@ exports[`TextInputChirp renders correctly when writing more than 300 chars 1`] =
         "display": "flex",
         "flexDirection": "column",
         "flexGrow": 1,
+        "flexShrink": 1,
       }
     }
   >
@@ -391,6 +393,7 @@ exports[`TextInputChirp renders correctly with placeholder 1`] = `
         "display": "flex",
         "flexDirection": "column",
         "flexGrow": 1,
+        "flexShrink": 1,
       }
     }
   >
@@ -550,6 +553,7 @@ exports[`TextInputChirp renders correctly with undefined public key 1`] = `
         "display": "flex",
         "flexDirection": "column",
         "flexGrow": 1,
+        "flexShrink": 1,
       }
     }
   >
@@ -715,6 +719,7 @@ exports[`TextInputChirp renders correctly without placeholder 1`] = `
         "display": "flex",
         "flexDirection": "column",
         "flexGrow": 1,
+        "flexShrink": 1,
       }
     }
   >

--- a/fe1-web/src/features/social/screens/__tests__/__snapshots__/SocialHome.test.tsx.snap
+++ b/fe1-web/src/features/social/screens/__tests__/__snapshots__/SocialHome.test.tsx.snap
@@ -88,6 +88,7 @@ exports[`SocialHome renders correctly 1`] = `
                 "display": "flex",
                 "flexDirection": "column",
                 "flexGrow": 1,
+                "flexShrink": 1,
               }
             }
           >

--- a/fe1-web/src/resources/strings.ts
+++ b/fe1-web/src/resources/strings.ts
@@ -159,7 +159,7 @@ namespace STRINGS {
   export const social_media_create_chirp_no_pop_token =
     'In order to post chirps, you first need to participate in a roll-call.';
   export const social_media_empty_chirp =
-    'You chirp will be cropped to an empty chirp. You cannot send an empty chirp.';
+    'Your chirp will be cropped to an empty chirp. You cannot send an empty chirp.';
   export const social_media_user_list_unavailable =
     'In order to see other roll call participants you yourself first need to participate in one.';
   export const social_media_your_profile_unavailable =


### PR DESCRIPTION
Added "flexShrink: 1"  to rightView in TextInputChirp.tsx.
Additionally fixed typo in the empty chirp error Message
![Screenshot_20240227_204652](https://github.com/dedis/popstellar/assets/67443413/94f1d15b-15ed-49e9-ab1f-1a4f5ebde284)
