### PR TITLE
[BE2] #1749 Start connection upon start

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/decentralized/Monitor.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/decentralized/Monitor.scala
@@ -105,6 +105,8 @@ private class FileMonitor(mediatorRef: ActorRef) extends Runnable {
   directory.register(watchService, ENTRY_MODIFY)
 
   override def run(): Unit = {
+    // Upon start, we connect to the servers
+    mediatorRef ! ConnectionMediator.ConnectTo(readServerPeers())
     try {
       while (!Thread.currentThread().isInterrupted) {
         // Blocks until an event happen

--- a/be2-scala/src/test/scala/ch/epfl/pop/decentralized/MonitorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/decentralized/MonitorSuite.scala
@@ -105,7 +105,7 @@ class MonitorSuite extends TestKit(ActorSystem("MonitorSuiteActorSystem")) with 
     testProbe.expectMsgType[Monitor.GenerateAndSendHeartbeat](timeout)
   }
 
-  test("monitor should send a ConnectTo() upon creation"){
+  test("monitor should send a ConnectTo() upon creation") {
     val mockConnectionMediator = TestProbe()
 
     // Write to mock server peers config file
@@ -119,7 +119,6 @@ class MonitorSuite extends TestKit(ActorSystem("MonitorSuiteActorSystem")) with 
 
     // Expect first read of the server peers list
     mockConnectionMediator.expectMsgType[ConnectionMediator.ConnectTo](timeout)
-
 
   }
 
@@ -173,5 +172,3 @@ class MonitorSuite extends TestKit(ActorSystem("MonitorSuiteActorSystem")) with 
     mockConnectionMediator.expectNoMessage(timeout)
   }
 }
-
-

--- a/be2-scala/src/test/scala/ch/epfl/pop/decentralized/MonitorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/decentralized/MonitorSuite.scala
@@ -105,12 +105,38 @@ class MonitorSuite extends TestKit(ActorSystem("MonitorSuiteActorSystem")) with 
     testProbe.expectMsgType[Monitor.GenerateAndSendHeartbeat](timeout)
   }
 
-  test("monitor should send ConnectTo() requests to ConnectionMediator upon relevant config file change") {
+  test("monitor should send a ConnectTo() upon creation"){
     val mockConnectionMediator = TestProbe()
+
+    // Write to mock server peers config file
+    val mockConfig = List("mockConfig")
+    testWriteToServerPeersConfig(mockConfig)
+
     val monitorRef = system.actorOf(Monitor.props(ActorRef.noSender))
 
     // Ping monitor to inform it of ConnectionMediatorRef
     mockConnectionMediator.send(monitorRef, ConnectionMediator.Ping())
+
+    // Expect first read of the server peers list
+    mockConnectionMediator.expectMsgType[ConnectionMediator.ConnectTo](timeout)
+
+
+  }
+
+  test("monitor should send ConnectTo() requests to ConnectionMediator upon relevant config file change besides first read") {
+    val mockConnectionMediator = TestProbe()
+
+    // Write to mock server peers config file
+    val mockConfig = List("mockConfig")
+    testWriteToServerPeersConfig(mockConfig)
+
+    val monitorRef = system.actorOf(Monitor.props(ActorRef.noSender))
+
+    // Ping monitor to inform it of ConnectionMediatorRef
+    mockConnectionMediator.send(monitorRef, ConnectionMediator.Ping())
+
+    // Expect first read of the server peers list
+    mockConnectionMediator.expectMsgType[ConnectionMediator.ConnectTo](timeout)
 
     // Expect no message as long as the server peers list is untouched
     mockConnectionMediator.expectNoMessage(timeout)
@@ -121,12 +147,19 @@ class MonitorSuite extends TestKit(ActorSystem("MonitorSuiteActorSystem")) with 
     mockConnectionMediator.expectMsgType[ConnectionMediator.ConnectTo](timeout)
   }
 
-  test("monitor should not react upon non relevant events in config directory") {
+  test("monitor should not react upon non relevant events in config directory besides first read") {
     val mockConnectionMediator = TestProbe()
     val monitorRef = system.actorOf(Monitor.props(ActorRef.noSender))
 
+    // Write to mock server peers config file
+    val mockConfig = List("mockConfig")
+    testWriteToServerPeersConfig(mockConfig)
+
     // Ping monitor to inform it of ConnectionMediatorRef
     mockConnectionMediator.send(monitorRef, ConnectionMediator.Ping())
+
+    // Expect first read of the server peers list
+    mockConnectionMediator.expectMsgType[ConnectionMediator.ConnectTo](timeout)
 
     // Create new file in the directory
     val filePath = Path.of(serverPeersListPath).getParent.toString + File.separator + "DELETE_ME"
@@ -140,3 +173,5 @@ class MonitorSuite extends TestKit(ActorSystem("MonitorSuiteActorSystem")) with 
     mockConnectionMediator.expectNoMessage(timeout)
   }
 }
+
+


### PR DESCRIPTION
- Added read instruction at the start of the FileMonitor which is created in response to ping at the start of connectionMediator
