### PR TITLE
Fixes #1784 Clear the previous PoP tokens before adding new ones

### DIFF
--- a/be1-go/channel/lao/lao.go
+++ b/be1-go/channel/lao/lao.go
@@ -429,6 +429,7 @@ func (c *Channel) processRollCallClose(msg message.Message, msgData interface{},
 	c.rollCall.id = data.UpdateID
 	c.rollCall.state = Closed
 
+	c.attendees = make(map[string]struct{})
 	for _, attendee := range data.Attendees {
 		c.attendees[attendee] = struct{}{}
 


### PR DESCRIPTION
fixes #1784 
When a valid lao#close is received, the attendees map in the lao is replace by an empty one, before the new keys are added.