### PR TITLE
Highlighting Owned Token in Attendees List

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapter.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapter.kt
@@ -1,12 +1,12 @@
 package com.github.dedis.popstellar.ui.lao.event.rollcall
 
 import android.content.Context
-import android.graphics.Color
-import android.graphics.Typeface
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import android.widget.TextView
+import androidx.core.content.ContextCompat
+import com.github.dedis.popstellar.R
 import com.github.dedis.popstellar.model.objects.security.PoPToken
 
 class RollCallArrayAdapter(
@@ -22,8 +22,8 @@ class RollCallArrayAdapter(
         //highlights our token in the list
         val currentToken = getItem(position)
         if (myToken != null && currentToken == myToken.publicKey.encoded) {
-            (view as TextView).setTypeface(null, Typeface.BOLD)
-            view.setTextColor(Color.BLUE)
+            val colorAccent = ContextCompat.getColor(context, R.color.colorAccent)
+            (view as TextView).setTextColor(colorAccent)
         }
 
         return view

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapter.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapter.kt
@@ -10,10 +10,10 @@ import com.github.dedis.popstellar.R
 import com.github.dedis.popstellar.model.objects.security.PoPToken
 
 class RollCallArrayAdapter(
-  private val context: Context,
-  private val layout: Int,
-  private val attendeesList: List<String>,
-  private val myToken: PoPToken?,
+    private val context: Context,
+    private val layout: Int,
+    private val attendeesList: List<String>,
+    private val myToken: PoPToken?,
 ) : ArrayAdapter<String>(context, layout, attendeesList) {
 
   override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapter.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapter.kt
@@ -1,0 +1,31 @@
+package com.github.dedis.popstellar.ui.lao.event.rollcall
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.Typeface
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.TextView
+import com.github.dedis.popstellar.model.objects.security.PoPToken
+
+class RollCallArrayAdapter(
+        private val context: Context,
+        private val layout: Int,
+        private val attendeesList: List<String>,
+        private val myToken: PoPToken?
+) : ArrayAdapter<String>(context, layout, attendeesList) {
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val view = super.getView(position, convertView, parent)
+
+        //highlights our token in the list
+        val currentToken = getItem(position)
+        if (myToken != null && currentToken == myToken.publicKey.encoded) {
+            (view as TextView).setTypeface(null, Typeface.BOLD)
+            view.setTextColor(Color.BLUE)
+        }
+
+        return view
+    }
+}

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapter.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapter.kt
@@ -10,22 +10,22 @@ import com.github.dedis.popstellar.R
 import com.github.dedis.popstellar.model.objects.security.PoPToken
 
 class RollCallArrayAdapter(
-        private val context: Context,
-        private val layout: Int,
-        private val attendeesList: List<String>,
-        private val myToken: PoPToken?
+  private val context: Context,
+  private val layout: Int,
+  private val attendeesList: List<String>,
+  private val myToken: PoPToken?,
 ) : ArrayAdapter<String>(context, layout, attendeesList) {
 
-    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
-        val view = super.getView(position, convertView, parent)
+  override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+    val view = super.getView(position, convertView, parent)
 
-        //highlights our token in the list
-        val currentToken = getItem(position)
-        if (myToken != null && currentToken == myToken.publicKey.encoded) {
-            val colorAccent = ContextCompat.getColor(context, R.color.colorAccent)
-            (view as TextView).setTextColor(colorAccent)
-        }
-
-        return view
+    // highlights our token in the list
+    val currentToken = getItem(position)
+    if (myToken != null && currentToken == myToken.publicKey.encoded) {
+      val colorAccent = ContextCompat.getColor(context, R.color.colorAccent)
+      (view as TextView).setTextColor(colorAccent)
     }
+
+    return view
+  }
 }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
@@ -34,11 +34,11 @@ import com.github.dedis.popstellar.utility.error.UnknownRollCallException
 import com.github.dedis.popstellar.utility.error.keys.KeyException
 import com.github.dedis.popstellar.utility.error.keys.NoRollCallException
 import dagger.hilt.android.AndroidEntryPoint
-import net.glxn.qrgen.android.QRCode
-import timber.log.Timber
 import java.util.EnumMap
 import java.util.stream.Collectors
 import javax.inject.Inject
+import net.glxn.qrgen.android.QRCode
+import timber.log.Timber
 
 @AndroidEntryPoint
 class RollCallFragment : AbstractEventFragment {
@@ -271,10 +271,10 @@ class RollCallFragment : AbstractEventFragment {
     if (attendeesList != null) {
       binding.listViewAttendees.adapter =
           RollCallArrayAdapter(
-                  requireContext(),
-                  android.R.layout.simple_list_item_1,
-                  attendeesList,
-                  popToken,
+              requireContext(),
+              android.R.layout.simple_list_item_1,
+              attendeesList,
+              popToken,
           )
     }
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ArrayAdapter
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.content.res.AppCompatResources
 import com.github.dedis.popstellar.R
@@ -271,7 +270,12 @@ class RollCallFragment : AbstractEventFragment {
 
     if (attendeesList != null) {
       binding.listViewAttendees.adapter =
-          ArrayAdapter(requireContext(), android.R.layout.simple_list_item_1, attendeesList)
+          RollCallArrayAdapter(
+                  requireContext(),
+                  android.R.layout.simple_list_item_1,
+                  attendeesList,
+                  popToken
+          )
     }
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
@@ -34,11 +34,11 @@ import com.github.dedis.popstellar.utility.error.UnknownRollCallException
 import com.github.dedis.popstellar.utility.error.keys.KeyException
 import com.github.dedis.popstellar.utility.error.keys.NoRollCallException
 import dagger.hilt.android.AndroidEntryPoint
+import net.glxn.qrgen.android.QRCode
+import timber.log.Timber
 import java.util.EnumMap
 import java.util.stream.Collectors
 import javax.inject.Inject
-import net.glxn.qrgen.android.QRCode
-import timber.log.Timber
 
 @AndroidEntryPoint
 class RollCallFragment : AbstractEventFragment {
@@ -274,7 +274,7 @@ class RollCallFragment : AbstractEventFragment {
                   requireContext(),
                   android.R.layout.simple_list_item_1,
                   attendeesList,
-                  popToken
+                  popToken,
           )
     }
   }

--- a/fe2-android/app/src/main/res/layout/token_list_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/token_list_fragment.xml
@@ -18,6 +18,7 @@
       app:layout_constraintTop_toTopOf="parent">
 
       <TextView
+        android:id="@+id/valid_token_layout_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="start"

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapterTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapterTest.kt
@@ -1,9 +1,11 @@
 package com.github.dedis.popstellar.ui.lao.event.rollcall
 
+import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.test.core.app.ApplicationProvider
 import com.github.dedis.popstellar.R
 import com.github.dedis.popstellar.model.objects.security.PoPToken
 import net.i2p.crypto.eddsa.Utils
@@ -14,7 +16,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class RollCallArrayAdapterTest {
@@ -23,6 +24,8 @@ class RollCallArrayAdapterTest {
     private lateinit var mockView: View
 
     private lateinit var adapter: RollCallArrayAdapter
+
+    val context = ApplicationProvider.getApplicationContext<Context>()
 
     private val MY_PRIVATE_KEY =
             Utils.hexToBytes("3b28b4ab2fe355a13d7b24f90816ff0676f7978bf462fc84f1d5d948b119ec66")
@@ -41,23 +44,23 @@ class RollCallArrayAdapterTest {
         val myToken = PoPToken(MY_PRIVATE_KEY, MY_PUBLIC_KEY)
         val otherToken = PoPToken(OTHER_PRIVATE_KEY, OTHER_PUBLIC_KEY)
         attendeesList = listOf(myToken.publicKey.encoded, otherToken.publicKey.encoded)
-        adapter = RollCallArrayAdapter(RuntimeEnvironment.application, R.id.valid_token_layout_text, attendeesList, myToken)
-        mockView = TextView(RuntimeEnvironment.application)
-        val colorAccent = ContextCompat.getColor(RuntimeEnvironment.application, R.color.textOnBackground)
+        adapter = RollCallArrayAdapter(context, R.id.valid_token_layout_text, attendeesList, myToken)
+        mockView = TextView(context)
+        val colorAccent = ContextCompat.getColor(context, R.color.textOnBackground)
         (mockView as TextView).setTextColor(colorAccent)
     }
 
     @Test
     fun verify_our_token_is_highlighted() {
         val view = adapter.getView(0, mockView, mock(ViewGroup::class.java)) as TextView
-        val color = ContextCompat.getColor(RuntimeEnvironment.application, R.color.colorAccent)
+        val color = ContextCompat.getColor(context, R.color.colorAccent)
         Assert.assertEquals(color, view.currentTextColor)
     }
 
     @Test
     fun verify_other_token_is_not_highlighted() {
         val view = adapter.getView(1, mockView, mock(ViewGroup::class.java)) as TextView
-        val color = ContextCompat.getColor(RuntimeEnvironment.application, R.color.textOnBackground)
+        val color = ContextCompat.getColor(context, R.color.textOnBackground)
         Assert.assertEquals(color, view.currentTextColor)
     }
 

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapterTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapterTest.kt
@@ -1,0 +1,64 @@
+package com.github.dedis.popstellar.ui.lao.event.rollcall
+
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import com.github.dedis.popstellar.R
+import com.github.dedis.popstellar.model.objects.security.PoPToken
+import net.i2p.crypto.eddsa.Utils
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class RollCallArrayAdapterTest {
+
+    @Mock
+    private lateinit var mockView: View
+
+    private lateinit var adapter: RollCallArrayAdapter
+
+    private val MY_PRIVATE_KEY =
+            Utils.hexToBytes("3b28b4ab2fe355a13d7b24f90816ff0676f7978bf462fc84f1d5d948b119ec66")
+    private val MY_PUBLIC_KEY =
+            Utils.hexToBytes("e5cdb393fe6e0abacd99d521400968083a982400b6ac3e0a1e8f6018d1554bd7")
+    private val OTHER_PRIVATE_KEY =
+            Utils.hexToBytes("cf74d353042400806ee94c3e77eef983d9a1434d21c0a7568f203f5b091dde1d")
+    private val OTHER_PUBLIC_KEY =
+            Utils.hexToBytes("6015ae4d770294f94e651a9fd6ba9c6a11e5c80803c63ee472ad525f4c3523a6")
+
+    private lateinit var attendeesList: List<String>
+
+    @Before
+    fun setup() {
+        // Setting up a list of two tokens and the view
+        val myToken = PoPToken(MY_PRIVATE_KEY, MY_PUBLIC_KEY)
+        val otherToken = PoPToken(OTHER_PRIVATE_KEY, OTHER_PUBLIC_KEY)
+        attendeesList = listOf(myToken.publicKey.encoded, otherToken.publicKey.encoded)
+        adapter = RollCallArrayAdapter(RuntimeEnvironment.application, R.id.valid_token_layout_text, attendeesList, myToken)
+        mockView = TextView(RuntimeEnvironment.application)
+        val colorAccent = ContextCompat.getColor(RuntimeEnvironment.application, R.color.textOnBackground)
+        (mockView as TextView).setTextColor(colorAccent)
+    }
+
+    @Test
+    fun verify_our_token_is_highlighted() {
+        val view = adapter.getView(0, mockView, mock(ViewGroup::class.java)) as TextView
+        val color = ContextCompat.getColor(RuntimeEnvironment.application, R.color.colorAccent)
+        Assert.assertEquals(color, view.currentTextColor)
+    }
+
+    @Test
+    fun verify_other_token_is_not_highlighted() {
+        val view = adapter.getView(1, mockView, mock(ViewGroup::class.java)) as TextView
+        val color = ContextCompat.getColor(RuntimeEnvironment.application, R.color.textOnBackground)
+        Assert.assertEquals(color, view.currentTextColor)
+    }
+
+}


### PR DESCRIPTION
I created an Adapter with a new getView() function. This function is then called when the tokens are displayed in a rollcall, changed how our token is displayed (to highlight only our token)
This solves issue #1776 