### PR TITLE
Enhance Invite Section with Copy Functionality for LAO Details

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.kt
@@ -1,15 +1,10 @@
 package com.github.dedis.popstellar.ui.lao
 
-import android.content.ClipData
-import android.content.ClipboardManager
-import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.github.dedis.popstellar.R
 import com.github.dedis.popstellar.databinding.InviteFragmentBinding
@@ -32,7 +27,7 @@ class InviteFragment : Fragment() {
 
   private lateinit var laoViewModel: LaoViewModel
   private lateinit var binding: InviteFragmentBinding
-  private lateinit var clipboardManager : GeneralUtils.ClipboardUtil
+  private lateinit var clipboardManager: GeneralUtils.ClipboardUtil
 
   override fun onCreateView(
       inflater: LayoutInflater,
@@ -68,8 +63,10 @@ class InviteFragment : Fragment() {
     }
 
     handleBackNav()
-    clipboardManager.setupCopyButton(binding.copyServerButton, binding.laoPropertiesServerText, "Server Address")
-    clipboardManager.setupCopyButton(binding.copyIdentifierButton, binding.laoPropertiesIdentifierText, "LAO ID")
+    clipboardManager.setupCopyButton(
+        binding.copyServerButton, binding.laoPropertiesServerText, "Server Address")
+    clipboardManager.setupCopyButton(
+        binding.copyIdentifierButton, binding.laoPropertiesIdentifierText, "LAO ID")
 
     return binding.root
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.github.dedis.popstellar.R
@@ -29,13 +30,14 @@ class InviteFragment : Fragment() {
   @Inject lateinit var networkManager: GlobalNetworkManager
 
   private lateinit var laoViewModel: LaoViewModel
+  private lateinit var binding: InviteFragmentBinding
 
   override fun onCreateView(
       inflater: LayoutInflater,
       container: ViewGroup?,
       savedInstanceState: Bundle?
   ): View? {
-    val binding = InviteFragmentBinding.inflate(inflater, container, false)
+    binding = InviteFragmentBinding.inflate(inflater, container, false)
     laoViewModel = LaoActivity.obtainViewModel(requireActivity())
 
     // Display the LAO identifier, not the device public key
@@ -63,8 +65,8 @@ class InviteFragment : Fragment() {
     }
 
     handleBackNav()
-    setupCopyServerButton(binding)
-    setupCopyIdentifierButton(binding)
+    setupCopyButton(binding.copyServerButton, binding.laoPropertiesServerText, "Server Address")
+    setupCopyButton(binding.copyIdentifierButton, binding.laoPropertiesIdentifierText, "LAO ID")
 
     return binding.root
   }
@@ -79,32 +81,18 @@ class InviteFragment : Fragment() {
     LaoActivity.addBackNavigationCallbackToEvents(requireActivity(), viewLifecycleOwner, TAG)
   }
 
-  private fun setupCopyServerButton(binding: InviteFragmentBinding) {
-    val serverTextView = binding.laoPropertiesServerText
-    val copyButton = binding.copyServerButton
-
-    copyButton.setOnClickListener {
-      val text = serverTextView.text.toString()
-      copyTextToClipboard(text)
+  private fun setupCopyButton(button: View, textView: TextView, label: String) {
+    button.setOnClickListener {
+      val text = textView.text.toString()
+      copyTextToClipboard(label, text)
       Toast.makeText(requireContext(), R.string.successful_copy, Toast.LENGTH_SHORT).show()
     }
   }
 
-  private fun setupCopyIdentifierButton(binding: InviteFragmentBinding) {
-    val identifierTextView = binding.laoPropertiesIdentifierText
-    val copyButton = binding.copyIdentifierButton
-
-    copyButton.setOnClickListener {
-      val text = identifierTextView.text.toString()
-      copyTextToClipboard(text)
-      Toast.makeText(requireContext(), R.string.successful_copy, Toast.LENGTH_SHORT).show()
-    }
-  }
-
-  private fun copyTextToClipboard(token: String) {
+  private fun copyTextToClipboard(label: String, content: String) {
     val clipboard =
         requireActivity().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-    val clip = ClipData.newPlainText(token, token)
+    val clip = ClipData.newPlainText(label, content)
     clipboard.setPrimaryClip(clip)
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.kt
@@ -17,6 +17,7 @@ import com.github.dedis.popstellar.model.Role
 import com.github.dedis.popstellar.model.qrcode.ConnectToLao
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager
 import com.github.dedis.popstellar.utility.ActivityUtils.getQRCodeColor
+import com.github.dedis.popstellar.utility.GeneralUtils
 import com.github.dedis.popstellar.utility.error.ErrorUtils.logAndShow
 import com.github.dedis.popstellar.utility.error.UnknownLaoException
 import com.google.gson.Gson
@@ -31,6 +32,7 @@ class InviteFragment : Fragment() {
 
   private lateinit var laoViewModel: LaoViewModel
   private lateinit var binding: InviteFragmentBinding
+  private lateinit var clipboardManager : GeneralUtils.ClipboardUtil
 
   override fun onCreateView(
       inflater: LayoutInflater,
@@ -39,6 +41,7 @@ class InviteFragment : Fragment() {
   ): View? {
     binding = InviteFragmentBinding.inflate(inflater, container, false)
     laoViewModel = LaoActivity.obtainViewModel(requireActivity())
+    clipboardManager = GeneralUtils.ClipboardUtil(requireActivity())
 
     // Display the LAO identifier, not the device public key
     binding.laoPropertiesIdentifierText.text = laoViewModel.laoId
@@ -65,8 +68,8 @@ class InviteFragment : Fragment() {
     }
 
     handleBackNav()
-    setupCopyButton(binding.copyServerButton, binding.laoPropertiesServerText, "Server Address")
-    setupCopyButton(binding.copyIdentifierButton, binding.laoPropertiesIdentifierText, "LAO ID")
+    clipboardManager.setupCopyButton(binding.copyServerButton, binding.laoPropertiesServerText, "Server Address")
+    clipboardManager.setupCopyButton(binding.copyIdentifierButton, binding.laoPropertiesIdentifierText, "LAO ID")
 
     return binding.root
   }
@@ -79,21 +82,6 @@ class InviteFragment : Fragment() {
 
   private fun handleBackNav() {
     LaoActivity.addBackNavigationCallbackToEvents(requireActivity(), viewLifecycleOwner, TAG)
-  }
-
-  private fun setupCopyButton(button: View, textView: TextView, label: String) {
-    button.setOnClickListener {
-      val text = textView.text.toString()
-      copyTextToClipboard(label, text)
-      Toast.makeText(requireContext(), R.string.successful_copy, Toast.LENGTH_SHORT).show()
-    }
-  }
-
-  private fun copyTextToClipboard(label: String, content: String) {
-    val clipboard =
-        requireActivity().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-    val clip = ClipData.newPlainText(label, content)
-    clipboard.setPrimaryClip(clip)
   }
 
   companion object {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.kt
@@ -8,8 +8,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageButton
-import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.github.dedis.popstellar.R
@@ -65,8 +63,8 @@ class InviteFragment : Fragment() {
     }
 
     handleBackNav()
-    setupCopyServerButton()
-    setupCopyIdentifierButton()
+    setupCopyServerButton(binding)
+    setupCopyIdentifierButton(binding)
 
     return binding.root
   }
@@ -81,31 +79,33 @@ class InviteFragment : Fragment() {
     LaoActivity.addBackNavigationCallbackToEvents(requireActivity(), viewLifecycleOwner, TAG)
   }
 
-  private fun setupCopyServerButton() {
-    val serverTextView = view?.findViewById<TextView>(R.id.lao_properties_server_text)
+  private fun setupCopyServerButton(binding: InviteFragmentBinding) {
+    val serverTextView = binding.laoPropertiesServerText
+    val copyButton = binding.copyServerButton
 
-    view?.findViewById<ImageButton>(R.id.copy_server_button)?.setOnClickListener {
-      if (serverTextView != null) {
-        copyTextToClipboard(serverTextView.text.toString())
-      }
+    copyButton.setOnClickListener {
+      val text = serverTextView.text.toString()
+      copyTextToClipboard(text)
+      Toast.makeText(requireContext(), R.string.successful_copy, Toast.LENGTH_SHORT).show()
     }
   }
 
-  private fun setupCopyIdentifierButton() {
-    val identifierTextView = view?.findViewById<TextView>(R.id.lao_properties_identifier_text)
+  private fun setupCopyIdentifierButton(binding: InviteFragmentBinding) {
+    val identifierTextView = binding.laoPropertiesIdentifierText
+    val copyButton = binding.copyIdentifierButton
 
-    view?.findViewById<ImageButton>(R.id.copy_identifier_button)?.setOnClickListener {
-      if (identifierTextView != null) {
-        copyTextToClipboard(identifierTextView.text.toString())
-      }
+    copyButton.setOnClickListener {
+      val text = identifierTextView.text.toString()
+      copyTextToClipboard(text)
+      Toast.makeText(requireContext(), R.string.successful_copy, Toast.LENGTH_SHORT).show()
     }
   }
 
-  private fun copyTextToClipboard(text: String) {
-    val clipboard = context?.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-    val clip = ClipData.newPlainText("", text)
+  private fun copyTextToClipboard(token: String) {
+    val clipboard =
+        requireActivity().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    val clip = ClipData.newPlainText(token, token)
     clipboard.setPrimaryClip(clip)
-    Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
   }
 
   companion object {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/InviteFragment.kt
@@ -1,10 +1,16 @@
 package com.github.dedis.popstellar.ui.lao
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageButton
+import android.widget.TextView
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.github.dedis.popstellar.R
 import com.github.dedis.popstellar.databinding.InviteFragmentBinding
@@ -59,6 +65,8 @@ class InviteFragment : Fragment() {
     }
 
     handleBackNav()
+    setupCopyServerButton()
+    setupCopyIdentifierButton()
 
     return binding.root
   }
@@ -71,6 +79,33 @@ class InviteFragment : Fragment() {
 
   private fun handleBackNav() {
     LaoActivity.addBackNavigationCallbackToEvents(requireActivity(), viewLifecycleOwner, TAG)
+  }
+
+  private fun setupCopyServerButton() {
+    val serverTextView = view?.findViewById<TextView>(R.id.lao_properties_server_text)
+
+    view?.findViewById<ImageButton>(R.id.copy_server_button)?.setOnClickListener {
+      if (serverTextView != null) {
+        copyTextToClipboard(serverTextView.text.toString())
+      }
+    }
+  }
+
+  private fun setupCopyIdentifierButton() {
+    val identifierTextView = view?.findViewById<TextView>(R.id.lao_properties_identifier_text)
+
+    view?.findViewById<ImageButton>(R.id.copy_identifier_button)?.setOnClickListener {
+      if (identifierTextView != null) {
+        copyTextToClipboard(identifierTextView.text.toString())
+      }
+    }
+  }
+
+  private fun copyTextToClipboard(text: String) {
+    val clipboard = context?.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    val clip = ClipData.newPlainText("", text)
+    clipboard.setPrimaryClip(clip)
+    Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
   }
 
   companion object {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenFragment.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/token/TokenFragment.kt
@@ -1,14 +1,10 @@
 package com.github.dedis.popstellar.ui.lao.token
 
-import android.content.ClipData
-import android.content.ClipboardManager
-import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.github.dedis.popstellar.R
 import com.github.dedis.popstellar.databinding.TokenFragmentBinding
@@ -22,6 +18,7 @@ import com.github.dedis.popstellar.ui.lao.LaoViewModel
 import com.github.dedis.popstellar.utility.ActivityUtils.buildBackButtonCallback
 import com.github.dedis.popstellar.utility.ActivityUtils.getQRCodeColor
 import com.github.dedis.popstellar.utility.Constants
+import com.github.dedis.popstellar.utility.GeneralUtils
 import com.github.dedis.popstellar.utility.error.ErrorUtils.logAndShow
 import com.github.dedis.popstellar.utility.error.UnknownRollCallException
 import com.github.dedis.popstellar.utility.error.keys.KeyException
@@ -42,6 +39,8 @@ class TokenFragment : Fragment() {
 
   private lateinit var laoViewModel: LaoViewModel
 
+  private lateinit var clipboardManager: GeneralUtils.ClipboardUtil
+
   override fun onResume() {
     super.onResume()
     laoViewModel.setPageTitle(R.string.token)
@@ -55,6 +54,7 @@ class TokenFragment : Fragment() {
   ): View? {
     val binding = TokenFragmentBinding.inflate(inflater, container, false)
     laoViewModel = obtainViewModel(requireActivity())
+    clipboardManager = GeneralUtils.ClipboardUtil(requireActivity())
 
     try {
       val laoId = laoViewModel.laoId!!
@@ -74,10 +74,7 @@ class TokenFragment : Fragment() {
 
       binding.tokenQrCode.setImageBitmap(bitmap)
       binding.tokenTextView.text = poPToken.publicKey.encoded
-      binding.tokenCopyButton.setOnClickListener {
-        copyTextToClipboard(poPToken.publicKey.encoded)
-        Toast.makeText(requireContext(), R.string.successful_copy, Toast.LENGTH_SHORT).show()
-      }
+      clipboardManager.setupCopyButton(binding.tokenCopyButton, binding.tokenTextView, "Token")
     } catch (e: Exception) {
       when (e) {
         is UnknownRollCallException,
@@ -95,13 +92,6 @@ class TokenFragment : Fragment() {
     handleBackNav()
 
     return binding.root
-  }
-
-  private fun copyTextToClipboard(token: String) {
-    val clipboard =
-        requireActivity().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-    val clip = ClipData.newPlainText(token, token)
-    clipboard.setPrimaryClip(clip)
   }
 
   private fun handleBackNav() {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/GeneralUtils.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/GeneralUtils.kt
@@ -78,7 +78,7 @@ object GeneralUtils {
    *
    * @param context the context of the application
    */
-  class ClipboardUtil(val context : Context) {
+  class ClipboardUtil(val context: Context) {
 
     fun setupCopyButton(button: View, textView: TextView, label: String) {
       button.setOnClickListener {
@@ -94,7 +94,6 @@ object GeneralUtils {
       clipboard.setPrimaryClip(clip)
     }
   }
-
 
   /**
    * This function converts a base64 string into some mnemonic words.

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/GeneralUtils.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/GeneralUtils.kt
@@ -2,8 +2,15 @@ package com.github.dedis.popstellar.utility
 
 import android.app.Activity
 import android.app.Application
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.os.Bundle
+import android.view.View
+import android.widget.TextView
+import android.widget.Toast
 import androidx.lifecycle.Lifecycle
+import com.github.dedis.popstellar.R
 import com.github.dedis.popstellar.model.objects.security.Base64URLData
 import io.github.novacrypto.bip39.MnemonicGenerator
 import io.github.novacrypto.bip39.wordlists.English
@@ -64,6 +71,30 @@ object GeneralUtils {
       }
     }
   }
+
+  /**
+   * This class is a utility to setup a copy button that copies the text of a TextView to the
+   * clipboard.
+   *
+   * @param context the context of the application
+   */
+  class ClipboardUtil(val context : Context) {
+
+    fun setupCopyButton(button: View, textView: TextView, label: String) {
+      button.setOnClickListener {
+        val text = textView.text.toString()
+        copyTextToClipboard(label, text)
+        Toast.makeText(context, R.string.successful_copy, Toast.LENGTH_SHORT).show()
+      }
+    }
+
+    private fun copyTextToClipboard(label: String, content: String) {
+      val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+      val clip = ClipData.newPlainText(label, content)
+      clipboard.setPrimaryClip(clip)
+    }
+  }
+
 
   /**
    * This function converts a base64 string into some mnemonic words.

--- a/fe2-android/app/src/main/res/drawable/ic_content_copy.xml
+++ b/fe2-android/app/src/main/res/drawable/ic_content_copy.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M16,1L4,1c-1.1,0 -2,0.9 -2,2v14h2L4,3h12L16,1zM19,5L8,5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h11c1.1,0 2,-0.9 2,-2L21,7c0,-1.1 -0.9,-2 -2,-2zM19,21L8,21L8,7h11v14z"/>
+</vector>

--- a/fe2-android/app/src/main/res/layout/invite_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/invite_fragment.xml
@@ -84,7 +84,7 @@
               android:layout_gravity="bottom"
               android:background="?android:attr/selectableItemBackgroundBorderless"
               app:srcCompat="@drawable/ic_content_copy"
-              android:contentDescription="@string/copy_to_clipboard"
+              android:contentDescription="@string/copy_to_clipboard_server"
               android:layout_marginStart="8dp"/>
         </LinearLayout>
 
@@ -120,7 +120,7 @@
               android:layout_height="wrap_content"
               app:srcCompat="@drawable/ic_content_copy"
               android:layout_gravity="bottom"
-              android:contentDescription="@string/copy_to_clipboard"
+              android:contentDescription="@string/copy_to_clipboard_lao_id"
               android:background="?android:attr/selectableItemBackgroundBorderless"
               android:layout_marginStart="8dp"/>
         </LinearLayout>

--- a/fe2-android/app/src/main/res/layout/invite_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/invite_fragment.xml
@@ -94,6 +94,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="start"
+            android:textIsSelectable="true"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/lao_properties_server_container" />
 
@@ -110,6 +111,7 @@
               style="@style/properties_section_title"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
+              android:textIsSelectable="true"
               android:text="@string/lao_properties_identifier_title" />
 
           <ImageButton
@@ -128,6 +130,7 @@
             style="@style/properties_section_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textIsSelectable="true"
             android:gravity="start"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/lao_properties_identifier_container" />

--- a/fe2-android/app/src/main/res/layout/invite_fragment.xml
+++ b/fe2-android/app/src/main/res/layout/invite_fragment.xml
@@ -61,41 +61,77 @@
           app:layout_constraintStart_toStartOf="parent"
           app:layout_constraintTop_toBottomOf="@id/lao_properties_role_title" />
 
-        <TextView
-          android:id="@+id/lao_properties_server_title"
-          style="@style/properties_section_title"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:text="@string/lao_properties_server_title"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@id/lao_properties_role_text" />
+        <LinearLayout
+            android:id="@+id/lao_properties_server_container"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:baselineAligned="false"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/lao_properties_role_text">
+
+          <TextView
+              android:id="@+id/lao_properties_server_title"
+              style="@style/properties_section_title"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:text="@string/lao_properties_server_title" />
+
+          <ImageButton
+              android:id="@+id/copy_server_button"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_gravity="bottom"
+              android:background="?android:attr/selectableItemBackgroundBorderless"
+              app:srcCompat="@drawable/ic_content_copy"
+              android:contentDescription="@string/copy_to_clipboard"
+              android:layout_marginStart="8dp"/>
+        </LinearLayout>
 
         <TextView
-          android:id="@+id/lao_properties_server_text"
-          style="@style/properties_section_text"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:gravity="start"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@id/lao_properties_server_title" />
+            android:id="@+id/lao_properties_server_text"
+            style="@style/properties_section_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="start"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/lao_properties_server_container" />
+
+        <LinearLayout
+            android:id="@+id/lao_properties_identifier_container"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/lao_properties_server_text">
+
+          <TextView
+              android:id="@+id/lao_properties_identifier_title"
+              style="@style/properties_section_title"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:text="@string/lao_properties_identifier_title" />
+
+          <ImageButton
+              android:id="@+id/copy_identifier_button"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              app:srcCompat="@drawable/ic_content_copy"
+              android:layout_gravity="bottom"
+              android:contentDescription="@string/copy_to_clipboard"
+              android:background="?android:attr/selectableItemBackgroundBorderless"
+              android:layout_marginStart="8dp"/>
+        </LinearLayout>
 
         <TextView
-          android:id="@+id/lao_properties_identifier_title"
-          style="@style/properties_section_title"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:text="@string/lao_properties_identifier_title"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@id/lao_properties_server_text" />
+            android:id="@+id/lao_properties_identifier_text"
+            style="@style/properties_section_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="start"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/lao_properties_identifier_container" />
 
-        <TextView
-          android:id="@+id/lao_properties_identifier_text"
-          style="@style/properties_section_text"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:gravity="start"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toBottomOf="@id/lao_properties_identifier_title" />
 
       </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -13,6 +13,10 @@
   <string name="witness">Witness</string>
   <string name="member">Member</string>
 
+  <!--  copy to clipboard -->
+  <string name="copy_to_clipboard_server">Copy to Clipboard Server Address</string>
+  <string name="copy_to_clipboard_lao_id">Copy to Clipboard Lao ID</string>
+
   <!-- bottom nav -->
   <string name="tab_social_media">Social Media</string>
   <string name="tab_digital_cash">Digital Cash</string>

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/InviteFragmentPageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/InviteFragmentPageObject.java
@@ -28,4 +28,18 @@ public class InviteFragmentPageObject {
   public static ViewInteraction channelQRCode() {
     return onView(withId(R.id.channel_qr_code));
   }
+
+  public static ViewInteraction copyIdentifierButton() {
+    return onView(withId(R.id.copy_identifier_button));
+  }
+
+  public static ViewInteraction copyServerButton() {
+      return onView(withId(R.id.copy_server_button));
+  }
+
+  public static ViewInteraction serverText() {
+    return onView(withId(R.id.lao_properties_server_text));
+  }
 }
+
+

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/InviteFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/InviteFragmentTest.kt
@@ -1,10 +1,18 @@
 package com.github.dedis.popstellar.ui.lao
 
+import android.content.ClipboardManager
+import android.content.Context
+import android.widget.Button
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.EspressoException
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
+import androidx.test.platform.app.InstrumentationRegistry
 import com.github.dedis.popstellar.model.objects.Lao
 import com.github.dedis.popstellar.repository.LAORepository
 import com.github.dedis.popstellar.testutils.Base64DataUtils
@@ -12,10 +20,12 @@ import com.github.dedis.popstellar.testutils.BundleBuilder
 import com.github.dedis.popstellar.testutils.fragment.ActivityFragmentScenarioRule
 import com.github.dedis.popstellar.testutils.pages.lao.InviteFragmentPageObject
 import com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject
+import com.github.dedis.popstellar.ui.lao.event.election.CastVoteOpenBallotFragmentTest
 import com.github.dedis.popstellar.utility.security.KeyManager
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import junit.framework.TestCase
 import javax.inject.Inject
 import org.junit.Rule
 import org.junit.Test
@@ -73,6 +83,31 @@ class InviteFragmentTest {
     InviteFragmentPageObject.identifierText()
       .check(ViewAssertions.matches(ViewMatchers.withText(LAO.id)))
   }
+
+  @Test
+  fun copyServerButton_CopiesCorrectText() {
+    InviteFragmentPageObject.copyServerButton().perform(scrollTo()).perform(ViewActions.click())
+    val clipboard = InstrumentationRegistry.getInstrumentation().targetContext.getSystemService(
+      Context.CLIPBOARD_SERVICE) as ClipboardManager
+    TestCase.assertTrue(clipboard.hasPrimaryClip())
+    val clipData = clipboard.primaryClip
+    TestCase.assertNotNull(clipData)
+    val copiedText = clipData!!.getItemAt(0).text.toString()
+    InviteFragmentPageObject.serverText().check(ViewAssertions.matches(ViewMatchers.withText(copiedText)))
+  }
+
+  @Test
+  fun copyIdentifierButton_CopiesCorrectText() {
+    InviteFragmentPageObject.copyIdentifierButton().perform(scrollTo()).perform(ViewActions.click())
+    val clipboard = InstrumentationRegistry.getInstrumentation().targetContext.getSystemService(
+      Context.CLIPBOARD_SERVICE) as ClipboardManager
+    TestCase.assertTrue(clipboard.hasPrimaryClip())
+    val clipData = clipboard.primaryClip
+    TestCase.assertNotNull(clipData)
+    val copiedText = clipData!!.getItemAt(0).text.toString()
+    InviteFragmentPageObject.identifierText().check(ViewAssertions.matches(ViewMatchers.withText(copiedText)))
+  }
+
 
   companion object {
     private const val LAO_NAME = "LAO"


### PR DESCRIPTION
## Description
This pull request addresses issue #1793 by introducing a copy button next to the LAO ID and server address within the invite section. Additionally, the LAO ID and server address fields have been made selectable for manual copying.

## Changes
- Added copy buttons for the LAO ID and server address.
- Enabled text selection on the LAO ID and server address TextViews for manual copying.

## Impact
- Enhances user experience by simplifying the sharing process of LAO information.
- Facilitates quick sharing without the need to manually type the details.

![image](https://github.com/dedis/popstellar/assets/100324323/fc44d741-2991-40aa-8fdf-c685efd506a3)