### PR TITLE
Adding merge queues to workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ on:
       - opened
       - synchronize
       - reopened
+  merge_group:
 
 jobs:
   fe1-web:


### PR DESCRIPTION
Change CI to add merge queue functionality to the workflow.  Pull request will now be required to go through a merge queue before merge to be sure that master is not broken on merge. Merge queue puts pull request in queue and incrementally runs CI and merge waiting PR. Merges to master PRs from queue that could successfully be merged together and passed CI.