### PR TITLE
Fixes a test that randomly fails in be1-go

### DIFF
--- a/be1-go/channel/authentication/authentication_test.go
+++ b/be1-go/channel/authentication/authentication_test.go
@@ -158,6 +158,9 @@ func Test_Authenticate_User(t *testing.T) {
 	err = authCha.Publish(msg, socket.ClientSocket{})
 	require.NoError(t, err)
 
+	// The websocket server may take some time to receive and process a message
+	time.Sleep(time.Millisecond * 100)
+
 	require.True(t, rb.get())
 }
 


### PR DESCRIPTION
`Test_Authenticate_User` was failling randomly some time, without any code change.
In this test, a websocket server is started, a popcha_authenticate message is published, and a message is expected to be received by the ws server.
The problem was that the message was not always received soon enough.
This PR use channels instead of expecting the messages to be received after some time delay.