### PR TITLE
Adapt the JSON Schema of the federation result message

### DIFF
--- a/protocol/examples/messageData/federation_result/federation_result.json
+++ b/protocol/examples/messageData/federation_result/federation_result.json
@@ -1,0 +1,12 @@
+{
+    "object": "federation",
+    "action": "result",
+    "status": "success",
+    "challenge": {
+        "data": "eyJvYmplY3QiOiJmZWRlcmF0aW9uIiwiYWN0aW9uIjoiY2hhbGxlbmdlIiwidmFsdWUiOiJlYmEzZTI0ZWZjZDBiNTNmYTY5OTA4YmFkNWQxY2I2OTlkNzk4MGQ5MzEwOWRhMGIyYmZkNTAzN2MyYzg5ZWUwIiwidGltZXN0YW1wIjoxNzEzMzg1NTY4fQ==",
+        "sender": "zXgzQaa_NpUe-v0Zk_4q8k184ohQ5nTQhBDKgncHzq4=",
+        "signature": "BILYwYkT5tOBL4rCD7yvhBkhAYqRXOI3ajQ2uJ1gAk-g6nRc38vMMnlHShuNCQ3dQFXYZPn37cCFelhWGjY8Bg==",
+        "message_id": "sD_PdryBuOr14_65h8L-e1lzdQpDWxUAngtu1uwqgEI=",
+        "witness_signatures": []
+    }
+}

--- a/protocol/examples/messageData/federation_result/federation_result.json
+++ b/protocol/examples/messageData/federation_result/federation_result.json
@@ -2,6 +2,7 @@
     "object": "federation",
     "action": "result",
     "status": "success",
+    "public_key": "UvViTxoKsB3XVP_ctkmOKCJpMWb7fCzrcb1XDmhNe7Q=",
     "challenge": {
         "data": "eyJvYmplY3QiOiJmZWRlcmF0aW9uIiwiYWN0aW9uIjoiY2hhbGxlbmdlIiwidmFsdWUiOiJlYmEzZTI0ZWZjZDBiNTNmYTY5OTA4YmFkNWQxY2I2OTlkNzk4MGQ5MzEwOWRhMGIyYmZkNTAzN2MyYzg5ZWUwIiwidGltZXN0YW1wIjoxNzEzMzg1NTY4fQ==",
         "sender": "zXgzQaa_NpUe-v0Zk_4q8k184ohQ5nTQhBDKgncHzq4=",

--- a/protocol/query/method/message/data/data.json
+++ b/protocol/query/method/message/data/data.json
@@ -65,6 +65,9 @@
             "$ref": "dataFederationChallenge.json"
         },
         {
+            "$ref": "dataFederationResult.json"
+        },
+        {
             "$ref": "dataWitnessMessage.json"
         },
         {

--- a/protocol/query/method/message/data/dataFederationResult.json
+++ b/protocol/query/method/message/data/dataFederationResult.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://raw.githubusercontent.com/dedis/popstellar/master/protocol/query/method/message/data/dataFederationResult.json",
+    "description": "Sent by an server to a remote server, to inform them about the result of the authentication procedure",
+    "type": "object",
+    "oneOf": [
+        {
+            "type": "object",
+            "properties": {
+                "object": {
+                    "const": "federation"
+                },
+                "action": {
+                    "const": "result"
+                },
+                "status": {
+                    "type": "string",
+                    "$comment": "status of the authentication attempt"
+                },
+                "reason": {
+                    "type": "string",
+                    "$comment": "to be used in failures, describing the error that happened"
+                },
+                "challenge": {
+                    "$ref": "../message.json",
+                    "$comment": "message/message containing a FederationChallenge data"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "object",
+                "action",
+                "status",
+                "challenge"
+            ]
+        },
+        {
+            "type": "object",
+            "properties": {
+                "object": {
+                    "const": "federation"
+                },
+                "action": {
+                    "const": "result"
+                },
+                "status": {
+                    "type": "string",
+                    "$comment": "status of the authentication attempt"
+                },
+                "public_key": {
+                    "type": "string",
+                    "contentEncoding": "base64",
+                    "$comment": "public key of the remote organizer"
+                },
+                "challenge": {
+                    "$ref": "../message.json",
+                    "$comment": "message/message containing a FederationChallenge data"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "object",
+                "action",
+                "status",
+                "public_key",
+                "challenge"
+            ]
+        }
+    ]
+}

--- a/protocol/query/method/message/data/dataFederationResult.json
+++ b/protocol/query/method/message/data/dataFederationResult.json
@@ -15,6 +15,7 @@
                 },
                 "status": {
                     "type": "string",
+                    "pattern": "^(success|failure)$",
                     "$comment": "status of the authentication attempt"
                 },
                 "reason": {
@@ -31,6 +32,7 @@
                 "object",
                 "action",
                 "status",
+                "reason",
                 "challenge"
             ]
         },
@@ -45,6 +47,7 @@
                 },
                 "status": {
                     "type": "string",
+                    "pattern": "^(success|failure)$",
                     "$comment": "status of the authentication attempt"
                 },
                 "public_key": {

--- a/protocol/query/method/message/data/dataFederationResult.json
+++ b/protocol/query/method/message/data/dataFederationResult.json
@@ -15,7 +15,7 @@
                 },
                 "status": {
                     "type": "string",
-                    "pattern": "^(success|failure)$",
+                    "pattern": "^failure$",
                     "$comment": "status of the authentication attempt"
                 },
                 "reason": {
@@ -47,7 +47,7 @@
                 },
                 "status": {
                     "type": "string",
-                    "pattern": "^(success|failure)$",
+                    "pattern": "^success$",
                     "$comment": "status of the authentication attempt"
                 },
                 "public_key": {

--- a/protocol/test/main.js
+++ b/protocol/test/main.js
@@ -43,6 +43,7 @@ const message_data_federation_init_schema = require("../query/method/message/dat
 const message_data_federation_expect_schema = require("../query/method/message/data/dataFederationExpect.json")
 const message_data_federation_challenge_request_schema = require("../query/method/message/data/dataFederationChallengeRequest.json")
 const message_data_federation_challenge_schema = require("../query/method/message/data/dataFederationChallenge.json")
+const message_data_federation_result_schema = require("../query/method/message/data/dataFederationResult.json")
 
 const message_data_chirp_add_schema = require("../query/method/message/data/dataAddChirp.json");
 const message_data_chirp_notify_add_schema = require("../query/method/message/data/dataNotifyAddChirp.json");
@@ -112,6 +113,7 @@ ajv.addSchema([
     message_data_federation_expect_schema,
     message_data_federation_challenge_request_schema,
     message_data_federation_challenge_schema,
+    message_data_federation_result_schema,
 
     message_data_chirp_notify_add_schema,
     message_data_chirp_add_schema,

--- a/protocol/test/main.test.js
+++ b/protocol/test/main.test.js
@@ -7,7 +7,7 @@ const ajv = require("./main");
 const rootSchema =
     "https://raw.githubusercontent.com/dedis/popstellar/master/protocol/jsonRPC.json";
 const messageDataSchema =
-    "https://raw.githubusercontent.com/dedis/popstellar/master/protocol/query/method/message/data/data.json";
+    require("../query/method/message/data/data.json");
 
 // custom validator to display better error message.
 expect.extend({
@@ -262,6 +262,9 @@ test("message data: federation", () => {
 
     federation_challenge = require("../examples/messageData/federation_challenge/federation_challenge.json");
     expect(federation_challenge).toBeValid(messageDataSchema);
+
+    federation_result = require("../examples/messageData/federation_result/federation_result.json");
+    expect(federation_result).toBeValid(messageDataSchema);
 
 });
 

--- a/protocol/test/main.test.js
+++ b/protocol/test/main.test.js
@@ -6,8 +6,9 @@ const ajv = require("./main");
 
 const rootSchema =
     "https://raw.githubusercontent.com/dedis/popstellar/master/protocol/jsonRPC.json";
+
 const messageDataSchema =
-    require("../query/method/message/data/data.json");
+    "https://raw.githubusercontent.com/dedis/popstellar/master/protocol/query/method/message/data/data.json";
 
 // custom validator to display better error message.
 expect.extend({


### PR DESCRIPTION
As discussed in our last meeting. This PR adds the challenge and public_key objects to the schema (+ validation in the form of oneOf)