### PR TITLE
fixed copy clipoboard button appearing black on darkmode

### DIFF
--- a/fe2-android/app/src/main/res/drawable/ic_content_copy.xml
+++ b/fe2-android/app/src/main/res/drawable/ic_content_copy.xml
@@ -1,5 +1,5 @@
-<vector android:height="24dp" android:tint="#000000"
+<vector android:height="24dp" android:tint="?attr/colorOnSurface"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M16,1L4,1c-1.1,0 -2,0.9 -2,2v14h2L4,3h12L16,1zM19,5L8,5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h11c1.1,0 2,-0.9 2,-2L21,7c0,-1.1 -0.9,-2 -2,-2zM19,21L8,21L8,7h11v14z"/>
+    <path android:fillColor="?attr/colorOnSurface" android:pathData="M16,1L4,1c-1.1,0 -2,0.9 -2,2v14h2L4,3h12L16,1zM19,5L8,5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h11c1.1,0 2,-0.9 2,-2L21,7c0,-1.1 -0.9,-2 -2,-2zM19,21L8,21L8,7h11v14z"/>
 </vector>


### PR DESCRIPTION
Addressing issue #1828 

newly added button was not turning white when phone is set to darkmode