### PR TITLE
change signature of readRumor for more intuitive

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/storage/DbActor.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/storage/DbActor.scala
@@ -613,10 +613,10 @@ final case class DbActor(
         case failure    => sender() ! failure.recover(Status.Failure(_))
       }
 
-    case ReadRumors(desiredRumor) =>
+    case ReadRumor(desiredRumor) =>
       log.info(s"Actor $self (db) received a ReadRumor request")
       Try(readRumor(desiredRumor)) match {
-        case Success(foundRumor) => sender() ! DbActorReadRumors(foundRumor)
+        case Success(foundRumor) => sender() ! DbActorReadRumor(foundRumor)
         case failure             => sender() ! failure.recover(Status.Failure(_))
       }
 
@@ -855,7 +855,7 @@ object DbActor {
     * @param desiredRumor
     *   Map of server public keys and list of desired rumor id for each
     */
-  final case class ReadRumors(desiredRumor: (PublicKey, Int)) extends Event
+  final case class ReadRumor(desiredRumor: (PublicKey, Int)) extends Event
 
   /** Requests the Db for the list of rumorId received for a senderPk
     * @param senderPk
@@ -944,9 +944,9 @@ object DbActor {
     */
   final case class DbActorGenerateHeartbeatAck(heartbeatMap: HashMap[Channel, Set[Hash]]) extends DbActorMessage
 
-  /** Response for a [[ReadRumors]]
+  /** Response for a [[ReadRumor]]
     */
-  final case class DbActorReadRumors(foundRumor: Option[Rumor]) extends DbActorMessage
+  final case class DbActorReadRumor(foundRumor: Option[Rumor]) extends DbActorMessage
 
   /** Response for a [[ReadRumorData]]
     */

--- a/be2-scala/src/main/scala/ch/epfl/pop/storage/DbActor.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/storage/DbActor.scala
@@ -404,17 +404,12 @@ final case class DbActor(
   }
 
   @throws[DbActorNAckException]
-  private def readRumors(desiredRumors: Map[PublicKey, List[Int]]): Map[PublicKey, List[Rumor]] = {
-    desiredRumors.map { case (senderPk, rumorIds) =>
-      val rumorsForSender: List[Rumor] = rumorIds.flatMap { rumorId =>
-        val rumorKey = generateRumorKey(senderPk, rumorId)
-        Try(storage.read(rumorKey)) match {
-          case Success(Some(json)) => Some(Rumor.buildFromJson(json))
-          case Success(None)       => None
-          case Failure(ex)         => throw ex
-        }
-      }
-      senderPk -> rumorsForSender
+  private def readRumor(desiredRumor: (PublicKey, Int)): Option[Rumor] = {
+    val rumorKey = generateRumorKey(desiredRumor._1, desiredRumor._2)
+    Try(storage.read(rumorKey)) match {
+      case Success(Some(json)) => Some(Rumor.buildFromJson(json))
+      case Success(None)       => None
+      case Failure(ex)         => throw ex
     }
   }
 
@@ -618,11 +613,11 @@ final case class DbActor(
         case failure    => sender() ! failure.recover(Status.Failure(_))
       }
 
-    case ReadRumors(desiredRumors) =>
+    case ReadRumors(desiredRumor) =>
       log.info(s"Actor $self (db) received a ReadRumor request")
-      Try(readRumors(desiredRumors)) match {
-        case Success(foundRumors) => sender() ! DbActorReadRumors(foundRumors)
-        case failure              => sender() ! failure.recover(Status.Failure(_))
+      Try(readRumor(desiredRumor)) match {
+        case Success(foundRumor) => sender() ! DbActorReadRumors(foundRumor)
+        case failure             => sender() ! failure.recover(Status.Failure(_))
       }
 
     case ReadRumorData(senderPk) =>
@@ -857,10 +852,10 @@ object DbActor {
   final case class WriteRumor(rumor: Rumor) extends Event
 
   /** Requests the Db for rumors corresponding to keys {server public key:rumor id}
-    * @param desiredRumors
+    * @param desiredRumor
     *   Map of server public keys and list of desired rumor id for each
     */
-  final case class ReadRumors(desiredRumors: Map[PublicKey, List[Int]]) extends Event
+  final case class ReadRumors(desiredRumor: (PublicKey, Int)) extends Event
 
   /** Requests the Db for the list of rumorId received for a senderPk
     * @param senderPk
@@ -951,7 +946,7 @@ object DbActor {
 
   /** Response for a [[ReadRumors]]
     */
-  final case class DbActorReadRumors(foundRumors: Map[PublicKey, List[Rumor]]) extends DbActorMessage
+  final case class DbActorReadRumors(foundRumor: Option[Rumor]) extends DbActorMessage
 
   /** Response for a [[ReadRumorData]]
     */

--- a/be2-scala/src/test/scala/ch/epfl/pop/storage/DbActorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/storage/DbActorSuite.scala
@@ -955,8 +955,8 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     val write = dbActor ? DbActor.WriteRumor(rumor)
     Await.result(write, duration) shouldBe a[DbActor.DbActorAck]
 
-    val read = dbActor ? DbActor.ReadRumors(rumor.senderPk -> rumor.rumorId)
-    val foundRumor = Await.result(read, duration).asInstanceOf[DbActorReadRumors].foundRumor
+    val read = dbActor ? DbActor.ReadRumor(rumor.senderPk -> rumor.rumorId)
+    val foundRumor = Await.result(read, duration).asInstanceOf[DbActorReadRumor].foundRumor
 
     foundRumor.isDefined shouldBe true
 
@@ -985,8 +985,8 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
 
     val rumor: Rumor = RumorExample.rumorExample
-    val read = dbActor ? DbActor.ReadRumors(rumor.senderPk -> rumor.rumorId)
-    Await.result(read, duration) shouldBe DbActorReadRumors(None)
+    val read = dbActor ? DbActor.ReadRumor(rumor.senderPk -> rumor.rumorId)
+    Await.result(read, duration) shouldBe DbActorReadRumor(None)
   }
 
 }

--- a/be2-scala/src/test/scala/ch/epfl/pop/storage/DbActorSuite.scala
+++ b/be2-scala/src/test/scala/ch/epfl/pop/storage/DbActorSuite.scala
@@ -955,18 +955,12 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     val write = dbActor ? DbActor.WriteRumor(rumor)
     Await.result(write, duration) shouldBe a[DbActor.DbActorAck]
 
-    val desiredRumors: Map[PublicKey, List[Int]] = Map(rumor.senderPk -> List(rumor.rumorId))
+    val read = dbActor ? DbActor.ReadRumors(rumor.senderPk -> rumor.rumorId)
+    val foundRumor = Await.result(read, duration).asInstanceOf[DbActorReadRumors].foundRumor
 
-    val read = dbActor ? DbActor.ReadRumors(desiredRumors)
-    val foundRumors = Await.result(read, duration).asInstanceOf[DbActorReadRumors].foundRumors
+    foundRumor.isDefined shouldBe true
 
-    foundRumors.foreach { (serverPk, rumorList) =>
-      desiredRumors.keys should contain(serverPk)
-      desiredRumors(serverPk) should equal(rumorList.map(_.rumorId))
-      rumorList.foreach { rumorFromDb =>
-        rumorFromDb should equal(rumor)
-      }
-    }
+    foundRumor.get shouldBe rumor
   }
 
   test("can recover list of rumorId received for a senderPk") {
@@ -984,6 +978,15 @@ class DbActorSuite extends TestKit(ActorSystem("DbActorSuiteActorSystem")) with 
     val rumorData = foundRumorData.asInstanceOf[DbActorReadRumorData].rumorIds
 
     rumorData.rumorIds should equal(List(rumor.rumorId))
+  }
+
+  test("read of absent rumor should fail") {
+    val initialStorage = InMemoryStorage()
+    val dbActor: AskableActorRef = system.actorOf(Props(DbActor(mediatorRef, MessageRegistry(), initialStorage)))
+
+    val rumor: Rumor = RumorExample.rumorExample
+    val read = dbActor ? DbActor.ReadRumors(rumor.senderPk -> rumor.rumorId)
+    Await.result(read, duration) shouldBe DbActorReadRumors(None)
   }
 
 }


### PR DESCRIPTION
Changed from readRumors (db handle multiples queries at once) to readRumor that handles only one query at time. This shifts the responsibility of handling multiples query to the querier. It makes the use of the database more intuitive 