### PR TITLE
Fixed constant display of error message when Social tab without Token

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaHomeFragment.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaHomeFragment.kt
@@ -39,6 +39,7 @@ class SocialMediaHomeFragment : Fragment() {
 
     val viewModel = obtainViewModel(requireActivity())
     socialMediaViewModel = obtainSocialMediaViewModel(requireActivity(), viewModel.laoId!!)
+    socialMediaViewModel.checkValidPoPToken()
 
     setupBottomNavBar()
     openChirpList()

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.kt
@@ -61,9 +61,9 @@ constructor(
   private val mNumberCharsLeft = MutableLiveData<Int>()
   val bottomNavigationTab = MutableLiveData(SocialMediaTab.HOME)
 
-    private val _hasValidToken = MutableLiveData<Boolean>()
+  private val _hasValidToken = MutableLiveData<Boolean>()
 
-    private val disposables: CompositeDisposable = CompositeDisposable()
+  private val disposables: CompositeDisposable = CompositeDisposable()
 
   override fun onCleared() {
     super.onCleared()
@@ -75,7 +75,6 @@ constructor(
      * Getters for MutableLiveData instances declared above
      */
     get() = mNumberCharsLeft
-
 
   /*
    * Methods that modify the state or post an Event to update the UI.
@@ -275,10 +274,10 @@ constructor(
 
       sender == token.publicKey.encoded
     } catch (e: KeyException) {
-        if (_hasValidToken.value == true) {
-            logAndShow(getApplication(), TAG, e, R.string.error_retrieve_own_token)
-        }
-        false
+      if (_hasValidToken.value == true) {
+        logAndShow(getApplication(), TAG, e, R.string.error_retrieve_own_token)
+      }
+      false
     }
   }
 
@@ -289,19 +288,17 @@ constructor(
    * @return true if we have sent such reaction, false otherwise
    */
   fun isReactionPresent(senders: Set<String?>): Boolean {
-      return try {
-          val token = validPoPToken
-          val toSearch = token.publicKey.encoded
-          senders.contains(toSearch)
-      } catch (e: KeyException) {
-          if (_hasValidToken.value == true) {
-              logAndShow(getApplication(), TAG, e, R.string.error_retrieve_own_token)
-          }
-          false
+    return try {
+      val token = validPoPToken
+      val toSearch = token.publicKey.encoded
+      senders.contains(toSearch)
+    } catch (e: KeyException) {
+      if (_hasValidToken.value == true) {
+        logAndShow(getApplication(), TAG, e, R.string.error_retrieve_own_token)
       }
+      false
+    }
   }
-
-
 
   fun setLaoId(laoId: String) {
     this.laoId = laoId
@@ -315,26 +312,25 @@ constructor(
   private val lao: LaoView
     get() = laoRepo.getLaoView(laoId)
 
-    fun checkValidPoPToken() {
-        disposables.add(
-            Single.fromCallable { keyManager.getValidPoPToken(laoId, rollCallRepo.getLastClosedRollCall(laoId)) }
-                .subscribeOn(schedulerProvider.io())
-                .observeOn(schedulerProvider.mainThread())
-                .subscribe({ _ ->
-                    _hasValidToken.postValue(true)
-                }, { error ->
-                    if (error is InvalidPoPTokenException) {
-                        _hasValidToken.postValue(false)
-                    } else {
-                        Timber.tag(TAG).e(error, "Error checking PoPToken validity")
-                    }
-                })
-        )
-    }
+  fun checkValidPoPToken() {
+    disposables.add(
+        Single.fromCallable {
+              keyManager.getValidPoPToken(laoId, rollCallRepo.getLastClosedRollCall(laoId))
+            }
+            .subscribeOn(schedulerProvider.io())
+            .observeOn(schedulerProvider.mainThread())
+            .subscribe(
+                { _ -> _hasValidToken.postValue(true) },
+                { error ->
+                  if (error is InvalidPoPTokenException) {
+                    _hasValidToken.postValue(false)
+                  } else {
+                    Timber.tag(TAG).e(error, "Error checking PoPToken validity")
+                  }
+                }))
+  }
 
-
-
-    companion object {
+  companion object {
     // TODO : looks like those constants need to be moved to resources
     val TAG: String = SocialMediaViewModel::class.java.simpleName
     private const val LAO_FAILURE_MESSAGE = "failed to retrieve lao"

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.kt
@@ -23,6 +23,7 @@ import com.github.dedis.popstellar.utility.error.ErrorUtils.logAndShow
 import com.github.dedis.popstellar.utility.error.UnknownChirpException
 import com.github.dedis.popstellar.utility.error.UnknownLaoException
 import com.github.dedis.popstellar.utility.error.UnknownReactionException
+import com.github.dedis.popstellar.utility.error.keys.InvalidPoPTokenException
 import com.github.dedis.popstellar.utility.error.keys.KeyException
 import com.github.dedis.popstellar.utility.scheduler.SchedulerProvider
 import com.github.dedis.popstellar.utility.security.KeyManager
@@ -268,6 +269,7 @@ constructor(
 
     return try {
       val token = validPoPToken
+
       sender == token.publicKey.encoded
     } catch (e: KeyException) {
       logAndShow(getApplication(), TAG, e, R.string.error_retrieve_own_token)
@@ -286,6 +288,11 @@ constructor(
       val token = validPoPToken
       val toSearch = token.publicKey.encoded
       senders.contains(toSearch)
+    } catch (e: InvalidPoPTokenException) {
+      // InvalidPoPTokenException means the user did not attend any roll calls and had no token.
+      // This is not an issue worth displaying the error for every single chirps.
+      // This error will already show once in isOwner.
+      return false
     } catch (e: KeyException) {
       logAndShow(getApplication(), TAG, e, R.string.error_retrieve_own_token)
       false
@@ -305,6 +312,7 @@ constructor(
     get() = laoRepo.getLaoView(laoId)
 
   companion object {
+    // TODO : looks like those constants need to be moved to resources
     val TAG: String = SocialMediaViewModel::class.java.simpleName
     private const val LAO_FAILURE_MESSAGE = "failed to retrieve lao"
     private const val SOCIAL = "social"

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.kt
@@ -61,7 +61,7 @@ constructor(
   private val mNumberCharsLeft = MutableLiveData<Int>()
   val bottomNavigationTab = MutableLiveData(SocialMediaTab.HOME)
 
-  private val _hasValidToken = MutableLiveData<Boolean>()
+  private val hasValidToken = MutableLiveData<Boolean>()
 
   private val disposables: CompositeDisposable = CompositeDisposable()
 
@@ -274,7 +274,7 @@ constructor(
 
       sender == token.publicKey.encoded
     } catch (e: KeyException) {
-      if (hasValidToken()) {
+      if (hasValidToken.value == true) {
         logAndShow(getApplication(), TAG, e, R.string.error_retrieve_own_token)
       }
       false
@@ -293,7 +293,7 @@ constructor(
       val toSearch = token.publicKey.encoded
       senders.contains(toSearch)
     } catch (e: KeyException) {
-      if (hasValidToken()) {
+      if (hasValidToken.value == true) {
         logAndShow(getApplication(), TAG, e, R.string.error_retrieve_own_token)
       }
       false
@@ -312,10 +312,6 @@ constructor(
   private val lao: LaoView
     get() = laoRepo.getLaoView(laoId)
 
-    fun hasValidToken(): Boolean {
-        return _hasValidToken.value == true
-    }
-
   fun checkValidPoPToken() {
     disposables.add(
         Single.fromCallable {
@@ -324,10 +320,10 @@ constructor(
             .subscribeOn(schedulerProvider.io())
             .observeOn(schedulerProvider.mainThread())
             .subscribe(
-                { _ -> _hasValidToken.postValue(true) },
+                { hasValidToken.postValue(true) },
                 { error ->
                   if (error is InvalidPoPTokenException) {
-                    _hasValidToken.postValue(false)
+                    hasValidToken.postValue(false)
                   } else {
                     Timber.tag(TAG).e(error, "Error checking PoPToken validity")
                   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.kt
@@ -198,7 +198,7 @@ constructor(
         }
 
     return Single.fromCallable { validPoPToken }
-        .doOnSuccess { token: PoPToken ->
+        .doOnSuccess { token: PoPToken? ->
           Timber.tag(TAG).d("Retrieved PoPToken to delete Reaction : %s", token)
         }
         .flatMap { token: PoPToken ->

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.kt
@@ -274,7 +274,7 @@ constructor(
 
       sender == token.publicKey.encoded
     } catch (e: KeyException) {
-      if (_hasValidToken.value == true) {
+      if (hasValidToken()) {
         logAndShow(getApplication(), TAG, e, R.string.error_retrieve_own_token)
       }
       false
@@ -293,7 +293,7 @@ constructor(
       val toSearch = token.publicKey.encoded
       senders.contains(toSearch)
     } catch (e: KeyException) {
-      if (_hasValidToken.value == true) {
+      if (hasValidToken()) {
         logAndShow(getApplication(), TAG, e, R.string.error_retrieve_own_token)
       }
       false
@@ -311,6 +311,10 @@ constructor(
   @get:Throws(UnknownLaoException::class)
   private val lao: LaoView
     get() = laoRepo.getLaoView(laoId)
+
+    fun hasValidToken(): Boolean {
+        return _hasValidToken.value == true
+    }
 
   fun checkValidPoPToken() {
     disposables.add(

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaViewModel.kt
@@ -112,7 +112,7 @@ constructor(
     val addChirp = AddChirp(text, parentId, timestamp)
 
     return Single.fromCallable { validPoPToken }
-        .doOnSuccess { token: PoPToken ->
+        .doOnSuccess { token: PoPToken? ->
           Timber.tag(TAG).d("Retrieved PoPToken to send Chirp : %s", token)
         }
         .flatMap { token: PoPToken ->
@@ -145,7 +145,7 @@ constructor(
     val addReaction = AddReaction(codepoint, chirpId, timestamp)
 
     return Single.fromCallable { validPoPToken }
-        .doOnSuccess { token: PoPToken ->
+        .doOnSuccess { token: PoPToken? ->
           Timber.tag(TAG).d("Retrieved PoPToken to send Reaction : %s", token)
         }
         .flatMap { token: PoPToken ->

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/socialmedia/SocialMediaHomePageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/socialmedia/SocialMediaHomePageObject.java
@@ -23,10 +23,6 @@ public class SocialMediaHomePageObject {
     return onView(isRoot());
   }
 
-  public static ViewInteraction getAddChirpButton() {
-    return onView(withId(R.id.social_media_send_fragment_button));
-  }
-
   public static ViewInteraction getEventListFragment() {
     return onView(withId(R.id.fragment_event_list));
   }

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/socialmedia/SocialMediaHomePageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/socialmedia/SocialMediaHomePageObject.java
@@ -1,12 +1,12 @@
 package com.github.dedis.popstellar.testutils.pages.lao.socialmedia;
 
-import androidx.test.espresso.ViewInteraction;
-
-import com.github.dedis.popstellar.R;
-
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+import androidx.test.espresso.ViewInteraction;
+
+import com.github.dedis.popstellar.R;
 
 /**
  * This is the page object of SocialMediaHomeFragment
@@ -27,7 +27,47 @@ public class SocialMediaHomePageObject {
     return onView(withId(R.id.fragment_event_list));
   }
 
+  public static ViewInteraction getHomeFeedFragment() {
+    return onView(withId(R.id.fragment_social_media_home));
+  }
+
+  public static ViewInteraction getFollowingFragment() {
+    return onView(withId(R.id.fragment_social_media_following));
+  }
+
+    public static ViewInteraction getProfileFragment() {
+        return onView(withId(R.id.fragment_social_media_profile));
+    }
+
+    public static ViewInteraction getSearchFragment() {
+        return onView(withId(R.id.fragment_social_media_search));
+    }
+
+    public static ViewInteraction getUpVoteButton() {
+        return onView(withId(R.id.upvote_button));
+    }
+
+    public static ViewInteraction getSocialMediaFragment() {
+        return onView(withId(R.id.main_menu_social_media));
+    }
+
   public static ViewInteraction getAddChirpButton() {
     return onView(withId(R.id.social_media_send_fragment_button));
   }
+
+  public static ViewInteraction getProfileButton() {
+    return onView(withId(R.id.social_media_profile_menu));
+  }
+
+    public static ViewInteraction getSearchButton() {
+        return onView(withId(R.id.social_media_search_menu));
+    }
+
+    public static ViewInteraction getFollowingButton() {
+        return onView(withId(R.id.social_media_following_menu));
+    }
+
+    public static ViewInteraction getHomeButton() {
+        return onView(withId(R.id.social_media_home_menu));
+    }
 }

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/socialmedia/SocialMediaHomePageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/socialmedia/SocialMediaHomePageObject.java
@@ -23,6 +23,10 @@ public class SocialMediaHomePageObject {
     return onView(isRoot());
   }
 
+  public static ViewInteraction getAddChirpButton() {
+    return onView(withId(R.id.social_media_send_fragment_button));
+  }
+
   public static ViewInteraction getEventListFragment() {
     return onView(withId(R.id.fragment_event_list));
   }

--- a/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/testutils/UITestUtils.kt
+++ b/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/testutils/UITestUtils.kt
@@ -56,9 +56,10 @@ object UITestUtils {
   }
 
   @JvmStatic
-  fun assertToastContainsTextIsNotDisplayed(@StringRes resId: Int, vararg args: Any?) {
+  fun assertLatestToastContent(isContained: Boolean, @StringRes resId: Int, vararg args: Any?) {
     val expected = ApplicationProvider.getApplicationContext<Context>().getString(resId, *args)
-    Assert.assertFalse(ShadowToast.getTextOfLatestToast().contains(expected))
+    Assert.assertEquals(isContained, ShadowToast.getTextOfLatestToast()?.contains(expected)
+      ?: false)
   }
 
   /**

--- a/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/testutils/UITestUtils.kt
+++ b/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/testutils/UITestUtils.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.EditText
-import android.widget.TimePicker
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.test.core.app.ApplicationProvider
@@ -57,8 +56,9 @@ object UITestUtils {
   }
 
   @JvmStatic
-  fun assertToastIsDisplayedOnlyOnce() {
-    Assert.assertEquals(1, ShadowToast.shownToastCount())
+  fun assertToastContainsTextIsNotDisplayed(@StringRes resId: Int, vararg args: Any?) {
+    val expected = ApplicationProvider.getApplicationContext<Context>().getString(resId, *args)
+    Assert.assertFalse(ShadowToast.getTextOfLatestToast().contains(expected))
   }
 
   /**

--- a/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/testutils/UITestUtils.kt
+++ b/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/testutils/UITestUtils.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.EditText
+import android.widget.TimePicker
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.test.core.app.ApplicationProvider
@@ -41,6 +42,23 @@ object UITestUtils {
 
     val expected = ApplicationProvider.getApplicationContext<Context>().getString(resId, *args)
     Assert.assertEquals(expected, ShadowToast.getTextOfLatestToast())
+  }
+
+  @JvmStatic
+  fun assertToastIsDisplayedContainsText(@StringRes resId: Int, vararg args: Any?) {
+    MatcherAssert.assertThat(
+      "No toast was displayed",
+      ShadowToast.getLatestToast(),
+      Matchers.notNullValue()
+    )
+
+    val expected = ApplicationProvider.getApplicationContext<Context>().getString(resId, *args)
+    Assert.assertTrue(ShadowToast.getTextOfLatestToast().contains(expected))
+  }
+
+  @JvmStatic
+  fun assertToastIsDisplayedOnlyOnce() {
+    Assert.assertEquals(1, ShadowToast.shownToastCount())
   }
 
   /**

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapterTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapterTest.kt
@@ -25,6 +25,9 @@ import com.github.dedis.popstellar.testutils.Base64DataUtils
 import com.github.dedis.popstellar.testutils.BundleBuilder
 import com.github.dedis.popstellar.testutils.MessageSenderHelper
 import com.github.dedis.popstellar.testutils.MockitoKotlinHelpers
+import com.github.dedis.popstellar.testutils.UITestUtils.assertToastIsDisplayedContainsText
+import com.github.dedis.popstellar.testutils.UITestUtils.assertToastIsDisplayedOnlyOnce
+import com.github.dedis.popstellar.testutils.UITestUtils.assertToastIsDisplayedWithText
 import com.github.dedis.popstellar.testutils.fragment.ActivityFragmentScenarioRule
 import com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject
 import com.github.dedis.popstellar.ui.lao.LaoActivity
@@ -37,6 +40,7 @@ import com.github.dedis.popstellar.utility.security.KeyManager
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import java.security.InvalidKeyException
 import java.time.Instant
 import javax.inject.Inject
 import org.junit.Assert
@@ -64,7 +68,7 @@ class ChirpListAdapterTest {
       EventState.CLOSED,
       HashSet(),
       "",
-      ""
+      "",
     )
   private val REACTION_ID = Base64DataUtils.generateMessageID()
   private val REACTION =
@@ -75,7 +79,7 @@ class ChirpListAdapterTest {
       SENDER_1,
       Reaction.ReactionEmoji.DOWNVOTE.code,
       CHIRP_1.id,
-      TIMESTAMP
+      TIMESTAMP,
     )
   private val REACTION3 =
     Reaction(
@@ -83,7 +87,7 @@ class ChirpListAdapterTest {
       SENDER_1,
       Reaction.ReactionEmoji.HEART.code,
       CHIRP_1.id,
-      TIMESTAMP
+      TIMESTAMP,
     )
 
   @Inject lateinit var socialMediaRepository: SocialMediaRepository
@@ -131,7 +135,7 @@ class ChirpListAdapterTest {
       LaoActivity::class.java,
       BundleBuilder().putString(Constants.LAO_ID_EXTRA, LAO_ID).build(),
       LaoActivityPageObject.containerId(),
-      ChirpListFragment::class.java
+      ChirpListFragment::class.java,
     ) {
       ChirpListFragment()
     }
@@ -226,7 +230,7 @@ class ChirpListAdapterTest {
       Assert.assertNotNull(time)
       Assert.assertEquals(
         DateUtils.getRelativeTimeSpanString(TIMESTAMP_1 * 1000),
-        time.text.toString()
+        time.text.toString(),
       )
 
       // Ensure that the buttons are visible
@@ -248,7 +252,7 @@ class ChirpListAdapterTest {
       Assert.assertNotNull(textView2)
       Assert.assertEquals(
         activity.applicationContext.getString(R.string.deleted_chirp_2),
-        textView2.text.toString()
+        textView2.text.toString(),
       )
 
       // Assert that the bin is not visible
@@ -301,13 +305,25 @@ class ChirpListAdapterTest {
     }
   }
 
+  //@Test
+  //fun testErrorToastDisplayedOnce() {
+  //  // error shows since tests LAO are not fully initialized ("user" participated in no roll calls)
+  //  itemTest()
+//
+  //  Thread.sleep(3500)
+  //  assertToastIsDisplayedWithText(R.string.error_retrieve_own_token, "")
+  //  assertToastIsDisplayedOnlyOnce()
+  //}
+
   companion object {
     private const val CREATION_TIME: Long = 1631280815
     private const val LAO_NAME = "laoName"
     private val SENDER_KEY_1: KeyPair = Base64DataUtils.generatePoPToken()
     private val SENDER_KEY_2: KeyPair = Base64DataUtils.generatePoPToken()
+    private val SENDER_KEY_3: KeyPair = Base64DataUtils.generatePoPToken()
     private val SENDER_1 = SENDER_KEY_1.publicKey
     private val SENDER_2 = SENDER_KEY_2.publicKey
+    private val SENDER_3 = SENDER_KEY_3.publicKey
     private val LAO_ID = generateLaoId(SENDER_1, CREATION_TIME, LAO_NAME)
     private val MESSAGE_ID_1 = Base64DataUtils.generateMessageID()
     private val MESSAGE_ID_2 = Base64DataUtils.generateMessageID()
@@ -328,7 +344,7 @@ class ChirpListAdapterTest {
       activity: FragmentActivity,
       viewModel: LaoViewModel,
       socialMediaViewModel: SocialMediaViewModel,
-      chirps: List<Chirp>?
+      chirps: List<Chirp>?,
     ): ChirpListAdapter {
       val adapter = ChirpListAdapter(activity, socialMediaViewModel, viewModel)
       adapter.replaceList(chirps)

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapterTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapterTest.kt
@@ -25,8 +25,6 @@ import com.github.dedis.popstellar.testutils.Base64DataUtils
 import com.github.dedis.popstellar.testutils.BundleBuilder
 import com.github.dedis.popstellar.testutils.MessageSenderHelper
 import com.github.dedis.popstellar.testutils.MockitoKotlinHelpers
-import com.github.dedis.popstellar.testutils.UITestUtils.assertToastContainsTextIsNotDisplayed
-import com.github.dedis.popstellar.testutils.UITestUtils.assertToastIsDisplayedContainsText
 import com.github.dedis.popstellar.testutils.fragment.ActivityFragmentScenarioRule
 import com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject
 import com.github.dedis.popstellar.ui.lao.LaoActivity
@@ -303,51 +301,13 @@ class ChirpListAdapterTest {
     }
   }
 
-  @Test
-  fun testNoTokenErrorToastDoesNotDisplayOnLaunch() {
-    Mockito.`when`(
-        keyManager.getValidPoPToken(ArgumentMatchers.anyString(), MockitoKotlinHelpers.any())
-      )
-      .thenReturn(SENDER_KEY_3 as PoPToken)
-
-    activityScenarioRule.scenario.onActivity { activity: LaoActivity ->
-      assertToastContainsTextIsNotDisplayed(R.string.error_retrieve_own_token, "")
-
-      val socialMediaViewModel = obtainSocialMediaViewModel(activity, LAO_ID)
-      val viewModel = obtainViewModel(activity)
-      val chirpListAdapter =
-        createChirpListAdapter(activity, viewModel, socialMediaViewModel, createChirpList())
-
-      val layout = LinearLayout(activity.applicationContext)
-      val parent = TextView(activity.applicationContext)
-      parent.text = "Mock Title"
-      layout.addView(parent)
-
-      val view1 = chirpListAdapter.getView(0, null, layout)
-      Assert.assertNotNull(view1)
-
-      val addChirpButton = view1.findViewById<ImageButton>(R.id.social_media_send_fragment_button)
-      Assert.assertNotNull(addChirpButton)
-      addChirpButton.callOnClick()
-
-        val chirpText = activity.findViewById<TextView>(R.id.entry_box_chirp)
-        chirpText.text = "test chirp"
-        val sendButton = activity.findViewById<ImageButton>(R.id.send_chirp_button)
-        sendButton.callOnClick()
-
-        assertToastIsDisplayedContainsText(R.string.error_retrieve_own_token, "")
-    }
-  }
-
   companion object {
     private const val CREATION_TIME: Long = 1631280815
     private const val LAO_NAME = "laoName"
     private var SENDER_KEY_1: KeyPair = Base64DataUtils.generatePoPToken()
     private val SENDER_KEY_2: KeyPair = Base64DataUtils.generatePoPToken()
-    private val SENDER_KEY_3: KeyPair = Base64DataUtils.generatePoPToken()
     private val SENDER_1 = SENDER_KEY_1.publicKey
     private val SENDER_2 = SENDER_KEY_2.publicKey
-    private val SENDER_3 = SENDER_KEY_3.publicKey
     private val LAO_ID = generateLaoId(SENDER_1, CREATION_TIME, LAO_NAME)
     private val MESSAGE_ID_1 = Base64DataUtils.generateMessageID()
     private val MESSAGE_ID_2 = Base64DataUtils.generateMessageID()

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListFragmentTest.kt
@@ -278,64 +278,6 @@ class ChirpListFragmentTest {
         }
     }
 
-    //@Test
-    //fun testAddingAndDeletingReaction(){
-    //    val chirps = createChirpList()
-    //    activityScenarioRule.scenario.onActivity { activity: LaoActivity ->
-    //        val socialMediaViewModel = obtainSocialMediaViewModel(activity, LAO_ID)
-//
-    //        val viewModel = obtainViewModel(activity)
-    //        val chirpListAdapter =
-    //                createChirpListAdapter(activity, viewModel, socialMediaViewModel, chirps)
-//
-    //        // Use a non null ViewGroup to inflate the card
-    //        val layout = LinearLayout(activity.applicationContext)
-    //        val parent = TextView(activity.applicationContext)
-    //        parent.text = "Mock Title"
-    //        layout.addView(parent)
-//
-    //        // Get the view for the first chirp in the list.
-    //        val view1 = chirpListAdapter.getView(0, null, layout)
-    //        Assert.assertNotNull(view1)
-//
-    //        // Verify the upvote is not set
-    //        var upvoteButton = view1.findViewById<ImageButton>(R.id.upvote_button)
-    //        Assert.assertNotNull(upvoteButton)
-    //        Assert.assertFalse(upvoteButton.isSelected)
-    //        upvoteButton.callOnClick()
-    //        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-    //        Assert.assertTrue(upvoteButton.isSelected)
-    //        upvoteButton.callOnClick()
-    //        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-    //        Assert.assertFalse(upvoteButton.isSelected)
-//
-    //        // Verify the downvote is not set
-    //        val downvoteButton = view1.findViewById<ImageButton>(R.id.downvote_button)
-    //        Assert.assertNotNull(downvoteButton)
-    //        Assert.assertFalse(downvoteButton.isSelected)
-    //        downvoteButton.callOnClick()
-    //        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-    //        Assert.assertTrue(downvoteButton.isSelected)
-    //        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-    //        upvoteButton.callOnClick()
-    //        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-    //        Assert.assertFalse(downvoteButton.isSelected)
-    //        Assert.assertTrue(upvoteButton.isSelected)
-//
-//
-    //        // Verify the heart is not set
-    //        val heartButton = view1.findViewById<ImageButton>(R.id.heart_button)
-    //        Assert.assertNotNull(heartButton)
-    //        Assert.assertFalse(heartButton.isSelected)
-    //        heartButton.callOnClick()
-    //        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-    //        Assert.assertTrue(heartButton.isSelected)
-    //        heartButton.callOnClick()
-    //        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
-    //        Assert.assertFalse(heartButton.isSelected)
-    //    }
-    //}
-
     @Test
     fun viewButtonTest() {
         val chirps = createChirpList()
@@ -359,7 +301,8 @@ class ChirpListFragmentTest {
             val upvoteButton = view1.findViewById<ImageButton>(R.id.upvote_button)
             Assert.assertNotNull(upvoteButton)
             upvoteButton.callOnClick()
-            socialMediaRepository.deleteReaction(LAO_ID, REACTION_ID)
+            // click again to deselect
+            upvoteButton.callOnClick()
             // Wait for the observable to be notified
             InstrumentationRegistry.getInstrumentation().waitForIdleSync()
             Assert.assertFalse(upvoteButton.isSelected)

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListFragmentTest.kt
@@ -11,6 +11,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.dedis.popstellar.R
 import com.github.dedis.popstellar.model.objects.Chirp
+import com.github.dedis.popstellar.model.objects.Lao
 import com.github.dedis.popstellar.model.objects.Lao.Companion.generateLaoId
 import com.github.dedis.popstellar.model.objects.Reaction
 import com.github.dedis.popstellar.model.objects.RollCall
@@ -18,6 +19,7 @@ import com.github.dedis.popstellar.model.objects.event.EventState
 import com.github.dedis.popstellar.model.objects.security.KeyPair
 import com.github.dedis.popstellar.model.objects.security.MessageID
 import com.github.dedis.popstellar.model.objects.security.PoPToken
+import com.github.dedis.popstellar.repository.LAORepository
 import com.github.dedis.popstellar.repository.RollCallRepository
 import com.github.dedis.popstellar.repository.SocialMediaRepository
 import com.github.dedis.popstellar.repository.remote.GlobalNetworkManager
@@ -106,6 +108,9 @@ class ChirpListFragmentTest {
     @Rule
     var rule = InstantTaskExecutorRule()
 
+    @Inject
+    lateinit var laoRepository: LAORepository
+
     @JvmField
     @Rule(order = 0)
     val mockitoRule: MockitoTestRule = MockitoJUnit.testRule(this)
@@ -121,7 +126,7 @@ class ChirpListFragmentTest {
                 @Throws(KeyException::class)
                 override fun before() {
                     hiltRule.inject()
-
+                    laoRepository.updateLao(LAO)
                     rollCallRepository.updateRollCall(LAO_ID, ROLL_CALL)
                     socialMediaRepository.addChirp(LAO_ID, CHIRP_1)
                     socialMediaRepository.addChirp(LAO_ID, CHIRP_2)
@@ -267,8 +272,69 @@ class ChirpListFragmentTest {
             val bin2 = view2.findViewById<ImageButton>(R.id.delete_chirp_button)
             Assert.assertNotNull(bin2)
             Assert.assertEquals(View.GONE.toLong(), bin2.visibility.toLong())
+
+            // remove the first chirp
+            bin.callOnClick()
         }
     }
+
+    //@Test
+    //fun testAddingAndDeletingReaction(){
+    //    val chirps = createChirpList()
+    //    activityScenarioRule.scenario.onActivity { activity: LaoActivity ->
+    //        val socialMediaViewModel = obtainSocialMediaViewModel(activity, LAO_ID)
+//
+    //        val viewModel = obtainViewModel(activity)
+    //        val chirpListAdapter =
+    //                createChirpListAdapter(activity, viewModel, socialMediaViewModel, chirps)
+//
+    //        // Use a non null ViewGroup to inflate the card
+    //        val layout = LinearLayout(activity.applicationContext)
+    //        val parent = TextView(activity.applicationContext)
+    //        parent.text = "Mock Title"
+    //        layout.addView(parent)
+//
+    //        // Get the view for the first chirp in the list.
+    //        val view1 = chirpListAdapter.getView(0, null, layout)
+    //        Assert.assertNotNull(view1)
+//
+    //        // Verify the upvote is not set
+    //        var upvoteButton = view1.findViewById<ImageButton>(R.id.upvote_button)
+    //        Assert.assertNotNull(upvoteButton)
+    //        Assert.assertFalse(upvoteButton.isSelected)
+    //        upvoteButton.callOnClick()
+    //        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    //        Assert.assertTrue(upvoteButton.isSelected)
+    //        upvoteButton.callOnClick()
+    //        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    //        Assert.assertFalse(upvoteButton.isSelected)
+//
+    //        // Verify the downvote is not set
+    //        val downvoteButton = view1.findViewById<ImageButton>(R.id.downvote_button)
+    //        Assert.assertNotNull(downvoteButton)
+    //        Assert.assertFalse(downvoteButton.isSelected)
+    //        downvoteButton.callOnClick()
+    //        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    //        Assert.assertTrue(downvoteButton.isSelected)
+    //        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    //        upvoteButton.callOnClick()
+    //        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    //        Assert.assertFalse(downvoteButton.isSelected)
+    //        Assert.assertTrue(upvoteButton.isSelected)
+//
+//
+    //        // Verify the heart is not set
+    //        val heartButton = view1.findViewById<ImageButton>(R.id.heart_button)
+    //        Assert.assertNotNull(heartButton)
+    //        Assert.assertFalse(heartButton.isSelected)
+    //        heartButton.callOnClick()
+    //        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    //        Assert.assertTrue(heartButton.isSelected)
+    //        heartButton.callOnClick()
+    //        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    //        Assert.assertFalse(heartButton.isSelected)
+    //    }
+    //}
 
     @Test
     fun viewButtonTest() {
@@ -293,7 +359,6 @@ class ChirpListFragmentTest {
             val upvoteButton = view1.findViewById<ImageButton>(R.id.upvote_button)
             Assert.assertNotNull(upvoteButton)
             upvoteButton.callOnClick()
-            // Remove the upvote reaction
             socialMediaRepository.deleteReaction(LAO_ID, REACTION_ID)
             // Wait for the observable to be notified
             InstrumentationRegistry.getInstrumentation().waitForIdleSync()
@@ -323,6 +388,7 @@ class ChirpListFragmentTest {
         private val SENDER_2 = SENDER_KEY_2.publicKey
         private val SENDER_3 = SENDER_KEY_3.publicKey
         private val LAO_ID = generateLaoId(SENDER_1, CREATION_TIME, LAO_NAME)
+        private val LAO = Lao(LAO_ID)
         private val MESSAGE_ID_1 = Base64DataUtils.generateMessageID()
         private val MESSAGE_ID_2 = Base64DataUtils.generateMessageID()
         private const val TEXT_1 = "text1"

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaHomeFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaHomeFragmentTest.kt
@@ -6,16 +6,29 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.github.dedis.popstellar.R
+import com.github.dedis.popstellar.model.objects.Lao
 import com.github.dedis.popstellar.model.objects.Lao.Companion.generateLaoId
+import com.github.dedis.popstellar.model.objects.RollCall
+import com.github.dedis.popstellar.model.objects.event.EventState
 import com.github.dedis.popstellar.model.objects.security.KeyPair
+import com.github.dedis.popstellar.model.objects.security.PoPToken
+import com.github.dedis.popstellar.repository.LAORepository
+import com.github.dedis.popstellar.repository.RollCallRepository
 import com.github.dedis.popstellar.testutils.Base64DataUtils
 import com.github.dedis.popstellar.testutils.BundleBuilder
+import com.github.dedis.popstellar.testutils.MockitoKotlinHelpers
+import com.github.dedis.popstellar.testutils.UITestUtils
 import com.github.dedis.popstellar.testutils.fragment.ActivityFragmentScenarioRule
 import com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject
 import com.github.dedis.popstellar.testutils.pages.lao.socialmedia.SocialMediaHomePageObject
+import com.github.dedis.popstellar.testutils.pages.lao.socialmedia.SocialMediaSendPageObject
 import com.github.dedis.popstellar.ui.lao.LaoActivity
 import com.github.dedis.popstellar.utility.Constants
+import com.github.dedis.popstellar.utility.error.keys.NoRollCallException
+import com.github.dedis.popstellar.utility.security.KeyManager
+import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Assert
@@ -23,17 +36,51 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExternalResource
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.junit.MockitoJUnit
 import org.mockito.junit.MockitoTestRule
+import javax.inject.Inject
 
 @HiltAndroidTest
 @RunWith(AndroidJUnit4::class)
 class SocialMediaHomeFragmentTest {
-  @JvmField @Rule var rule = InstantTaskExecutorRule()
+  private val ROLL_CALL =
+    RollCall(
+      LAO_ID,
+      LAO_ID,
+      "",
+      CREATION_TIME,
+      CREATION_TIME,
+      CREATION_TIME,
+      EventState.CLOSED,
+      HashSet(),
+      "",
+      "",
+    )
 
-  @JvmField @Rule(order = 0) val mockitoRule: MockitoTestRule = MockitoJUnit.testRule(this)
+  @Inject
+  lateinit var laoRepository: LAORepository
 
-  @JvmField @Rule(order = 1) val hiltRule = HiltAndroidRule(this)
+  @Inject
+  lateinit var rollCallRepository: RollCallRepository
+
+  @BindValue
+  @Mock
+  lateinit var keyManager: KeyManager
+
+  @JvmField
+  @Rule
+  var rule = InstantTaskExecutorRule()
+
+  @JvmField
+  @Rule(order = 0)
+  val mockitoRule: MockitoTestRule = MockitoJUnit.testRule(this)
+
+  @JvmField
+  @Rule(order = 1)
+  val hiltRule = HiltAndroidRule(this)
 
   @JvmField
   @Rule(order = 2)
@@ -41,6 +88,14 @@ class SocialMediaHomeFragmentTest {
     object : ExternalResource() {
       override fun before() {
         hiltRule.inject()
+
+        laoRepository.updateLao(LAO)
+        rollCallRepository.updateRollCall(LAO_ID, ROLL_CALL)
+        Mockito.`when`(keyManager.mainPublicKey).thenReturn(SENDER_KEY_1.publicKey)
+        Mockito.`when`(
+          keyManager.getValidPoPToken(ArgumentMatchers.anyString(), MockitoKotlinHelpers.any())
+        )
+          .thenReturn(SENDER_KEY_1 as PoPToken)
       }
     }
 
@@ -55,6 +110,7 @@ class SocialMediaHomeFragmentTest {
     ) {
       SocialMediaHomeFragment()
     }
+
 
   @Test
   fun testBackButtonBehaviour() {
@@ -78,6 +134,33 @@ class SocialMediaHomeFragmentTest {
     }
   }
 
+  @Test
+  fun testPoPTokenToastError() {
+    Mockito.`when`(
+      keyManager.getValidPoPToken(ArgumentMatchers.anyString(), MockitoKotlinHelpers.any())
+    ).thenThrow(NoRollCallException(LAO.id))
+
+    activityScenarioRule.scenario.onActivity {
+      // Check on launch of the activity this is not displayed
+      UITestUtils.assertLatestToastContent(false, R.string.error_retrieve_own_token, "")
+
+      val addChirpButton = SocialMediaHomePageObject.getAddChirpButton()
+      Assert.assertNotNull(addChirpButton)
+      addChirpButton.perform(ViewActions.click())
+      InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+      val chirpText = SocialMediaSendPageObject.entryBoxChirpText()
+      chirpText.perform(UITestUtils.forceTypeText("test"))
+      InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+      val sendButton = SocialMediaSendPageObject.sendChirpButton()
+      sendButton.perform(ViewActions.click())
+      InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+      UITestUtils.assertLatestToastContent(true, R.string.error_retrieve_own_token, "")
+    }
+  }
+
   companion object {
     private const val CREATION_TIME: Long = 1631280815
     private const val LAO_NAME = "laoName"
@@ -85,5 +168,6 @@ class SocialMediaHomeFragmentTest {
     private val SENDER_KEY_2: KeyPair = Base64DataUtils.generatePoPToken()
     private val SENDER_1 = SENDER_KEY_1.publicKey
     private val LAO_ID = generateLaoId(SENDER_1, CREATION_TIME, LAO_NAME)
+    private val LAO = Lao(LAO_ID)
   }
 }


### PR DESCRIPTION
addressing issue #1848 

Disabled error toast when the error is `InvalidPoPTokenException`, otherwise it would just pop multiple times for every single chirps. The same error is displayed once on opening the Social Tab in `isOwner` so the user is still aware that no token is available.