### PR TITLE
 Fix #1775 Digital Cash Warning: RollCallId not defined

### DIFF
--- a/fe1-web/src/features/digital-cash/screens/SendReceive/SendReceive.tsx
+++ b/fe1-web/src/features/digital-cash/screens/SendReceive/SendReceive.tsx
@@ -321,7 +321,7 @@ export const SendReceiveHeaderRight = () => {
     return null;
   }
 
-  if (rollCallId === null) {
+  if (!serializedRollCallId) {
     toast.show(STRINGS.digital_cash_error_rollcall_not_defined, {
       type: 'warning',
       placement: 'bottom',

--- a/fe1-web/src/features/digital-cash/screens/SendReceive/SendReceive.tsx
+++ b/fe1-web/src/features/digital-cash/screens/SendReceive/SendReceive.tsx
@@ -321,12 +321,15 @@ export const SendReceiveHeaderRight = () => {
     return null;
   }
 
-  if (serializedPopToken === null) {
+  if (rollCallId === null) {
     toast.show(STRINGS.digital_cash_error_rollcall_not_defined, {
       type: 'warning',
       placement: 'bottom',
       duration: FOUR_SECONDS,
     });
+  }
+
+  if (serializedPopToken === null) {
     return null;
   }
 

--- a/fe1-web/src/features/digital-cash/screens/SendReceive/SendReceive.tsx
+++ b/fe1-web/src/features/digital-cash/screens/SendReceive/SendReceive.tsx
@@ -317,15 +317,16 @@ export const SendReceiveHeaderRight = () => {
     }
   }, [popToken]);
 
+  if (isCoinbase) {
+    return null;
+  }
+
   if (serializedPopToken === null) {
     toast.show(STRINGS.digital_cash_error_rollcall_not_defined, {
       type: 'warning',
       placement: 'bottom',
       duration: FOUR_SECONDS,
     });
-    return null;
-  }
-  if (isCoinbase) {
     return null;
   }
 


### PR DESCRIPTION
The warning toast 'RollcallId not defined, cannot generate PoP token' was showing up at unecesserary times.  
Explanation of the bug:
1. When using coin issuance (i.e `isCoinbase` is `true`) the parameter `rollCallId` is undefined which is expected.
2. In other cases: the hook `useRollCallTokenByRollCallId` is not synchronous and returns `undefined` for a few cycles causing `encodePopToken` to throw an error and `serializedPopToken` to be null even though `rollCallId` is well defined.