### PR TITLE
fixed wrong title for Digital Cash tab

### DIFF
--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -256,7 +256,7 @@
   <string name="digital_cash_issue">Issue</string>
   <string name="digital_cash_history">Transaction History</string>
   <string name="digital_cash_receive">Receive</string>
-  <string name="digital_cash_home">Home</string>
+  <string name="digital_cash_home">Digital Cash</string>
   <string name="digital_cash_receipt">Receipt</string>
   <string name="digital_cash_send_button">Send</string>
   <string name="digital_cash_amount">Amount</string>


### PR DESCRIPTION
addressing #1867 

![image](https://github.com/dedis/popstellar/assets/100324323/6145ca4a-bee5-474e-b53b-886df6b74ac9)
