### PR TITLE
[BE2] add peers back and send empty heartbeat

### DIFF
--- a/be2-scala/src/main/scala/ch/epfl/pop/decentralized/ConnectionMediator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/decentralized/ConnectionMediator.scala
@@ -77,7 +77,7 @@ final case class ConnectionMediator(
           Right(JsonRpcRequest(
             RpcValidator.JSON_RPC_VERSION,
             MethodType.heartbeat,
-            new ParamsWithMap(map),
+            new ParamsWithMap(Map.empty),
             None
           ))
         )

--- a/be2-scala/src/main/scala/ch/epfl/pop/decentralized/ConnectionMediator.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/decentralized/ConnectionMediator.scala
@@ -77,7 +77,7 @@ final case class ConnectionMediator(
           Right(JsonRpcRequest(
             RpcValidator.JSON_RPC_VERSION,
             MethodType.heartbeat,
-            new ParamsWithMap(Map.empty), // new ParamsWithMap(map),
+            new ParamsWithMap(map),
             None
           ))
         )

--- a/be2-scala/src/main/scala/ch/epfl/pop/storage/DbActor.scala
+++ b/be2-scala/src/main/scala/ch/epfl/pop/storage/DbActor.scala
@@ -171,7 +171,7 @@ final case class DbActor(
 
     val askAddresses = Await.ready(connectionMediator ? ConnectionMediator.ReadPeersClientAddress(), duration).value.get
     val addresses = askAddresses match {
-      case Success(ConnectionMediator.ReadPeersClientAddressAck(result)) => List.empty // result
+      case Success(ConnectionMediator.ReadPeersClientAddressAck(result)) => result
       case _                                                             => List.empty
     }
 


### PR DESCRIPTION
Server should share peers to client again, and client should handle connection.

Server should now only send empty heartbeat to keep the connection alive. Spread of messages is handled by Gossip