### PR TITLE
Sending Sorted Attendees List and Validation for CloseRollCall

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/election/QuestionResult.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/election/QuestionResult.kt
@@ -11,7 +11,9 @@ class QuestionResult(ballotOption: String?, count: Int) {
   val count: Int
 
   init {
-    verify().stringNotEmpty(ballotOption, "ballot option").greaterOrEqualThan(count, 0, "count")
+    verify()
+        .stringNotEmpty(ballotOption, "ballot option")
+        .greaterOrEqualThan(count.toLong(), 0, "count")
 
     ballot = ballotOption!!
     this.count = count

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/CloseRollCall.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/CloseRollCall.kt
@@ -33,11 +33,11 @@ class CloseRollCall(
 
   init {
     verify()
-        .stringListIsSorted(attendees.map { toString() }, "attendees")
+        .stringListIsSorted(attendees, "attendees")
         .validPastTimes(closedAt)
+        .greaterOrEqualThan(closedAt, 0, "closedAt")
         .isNotEmptyBase64(laoId, "laoId")
         .isNotEmptyBase64(closes, "closes")
-        .greaterOrEqualThan(closedAt, 0, "closedAt")
 
     this.updateId = generateCloseRollCallId(laoId, closes, closedAt)
     this.attendees = ArrayList(attendees)

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/CloseRollCall.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/CloseRollCall.kt
@@ -4,8 +4,9 @@ import com.github.dedis.popstellar.model.Immutable
 import com.github.dedis.popstellar.model.network.method.message.data.Action
 import com.github.dedis.popstellar.model.network.method.message.data.Data
 import com.github.dedis.popstellar.model.network.method.message.data.Objects
-import com.github.dedis.popstellar.model.objects.RollCall
+import com.github.dedis.popstellar.model.objects.RollCall.Companion.generateCloseRollCallId
 import com.github.dedis.popstellar.model.objects.security.PublicKey
+import com.github.dedis.popstellar.utility.MessageValidator.verify
 import com.google.gson.annotations.SerializedName
 
 /** Data sent to close a Roll-Call */
@@ -25,11 +26,22 @@ class CloseRollCall(
     @field:SerializedName("closed_at") val closedAt: Long,
     attendees: List<PublicKey>
 ) : Data {
-  @SerializedName("update_id")
-  val updateId: String = RollCall.generateCloseRollCallId(laoId, closes, closedAt)
+  @SerializedName("update_id") val updateId: String
 
-  val attendees: List<PublicKey> = ArrayList(attendees)
+  var attendees: List<PublicKey> = ArrayList()
     get() = ArrayList(field)
+
+  init {
+    verify()
+        .stringListIsSorted(attendees.map { toString() }, "attendees")
+        .validPastTimes(closedAt)
+        .isNotEmptyBase64(laoId, "laoId")
+        .isNotEmptyBase64(closes, "closes")
+        .greaterOrEqualThan(closedAt, 0, "closedAt")
+
+    this.updateId = generateCloseRollCallId(laoId, closes, closedAt)
+    this.attendees = ArrayList(attendees)
+  }
 
   override val `object`: String
     get() = Objects.ROLL_CALL.`object`

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/event/RollCallBuilder.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/event/RollCallBuilder.kt
@@ -30,7 +30,7 @@ class RollCallBuilder {
     start = rollCall.startTimestamp
     end = rollCall.end
     state = rollCall.state
-    attendees = HashSet(rollCall.attendees)
+    attendees = LinkedHashSet(rollCall.attendees)
     location = rollCall.location
     description = rollCall.description
   }
@@ -102,7 +102,7 @@ class RollCallBuilder {
         start,
         end,
         state!!,
-        attendees!!,
+      LinkedHashSet(attendees),
         location!!,
         description!!)
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/event/RollCallBuilder.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/event/RollCallBuilder.kt
@@ -66,12 +66,12 @@ class RollCallBuilder {
   }
 
   fun setAttendees(attendees: Set<PublicKey>): RollCallBuilder {
-    this.attendees = HashSet(attendees)
+    this.attendees = LinkedHashSet(attendees)
     return this
   }
 
   fun setEmptyAttendees(): RollCallBuilder {
-    attendees = HashSet()
+    attendees = LinkedHashSet()
     return this
   }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/event/RollCallBuilder.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/model/objects/event/RollCallBuilder.kt
@@ -102,7 +102,7 @@ class RollCallBuilder {
         start,
         end,
         state!!,
-      LinkedHashSet(attendees),
+        LinkedHashSet(attendees),
         location!!,
         description!!)
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapter.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapter.kt
@@ -14,10 +14,11 @@ class RollCallArrayAdapter(
     private val layout: Int,
     private val attendeesList: List<String>,
     private val myToken: PoPToken?,
+    private val fragment: RollCallFragment
 ) : ArrayAdapter<String>(context, layout, attendeesList) {
 
   init {
-    RollCallFragment.isAttendeeListSorted(attendeesList, context)
+    fragment.isAttendeeListSorted(attendeesList, context)
   }
 
   override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapter.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapter.kt
@@ -16,6 +16,10 @@ class RollCallArrayAdapter(
     private val myToken: PoPToken?,
 ) : ArrayAdapter<String>(context, layout, attendeesList) {
 
+  init {
+    RollCallFragment.isAttendeeListSorted(attendeesList, context)
+  }
+
   override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
     val view = super.getView(position, convertView, parent)
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
@@ -1,6 +1,7 @@
 package com.github.dedis.popstellar.ui.lao.event.rollcall
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.content.pm.ActivityInfo
 import android.graphics.Color
 import android.os.Bundle
@@ -9,6 +10,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.content.ContentProviderCompat.requireContext
+import androidx.lifecycle.MutableLiveData
 import com.github.dedis.popstellar.R
 import com.github.dedis.popstellar.databinding.RollCallFragmentBinding
 import com.github.dedis.popstellar.model.objects.RollCall
@@ -253,6 +256,7 @@ class RollCallFragment : AbstractEventFragment {
               .getAttendees()
               .stream()
               .map(PublicKey::encoded)
+              .sorted(compareBy(String::toString))
               .collect(Collectors.toList())
 
       binding.rollCallAttendeesText.text =
@@ -342,15 +346,25 @@ class RollCallFragment : AbstractEventFragment {
 
   companion object {
     val TAG: String = RollCallFragment::class.java.simpleName
+    private val deAnonymizationWarned = MutableLiveData(false)
 
     @JvmStatic
     fun newInstance(persistentId: String?): RollCallFragment {
+      deAnonymizationWarned.value = false
       val fragment = RollCallFragment()
       val bundle = Bundle(1)
       bundle.putString(ROLL_CALL_ID, persistentId)
       fragment.arguments = bundle
-
       return fragment
+    }
+
+    fun isAttendeeListSorted(attendeesList: List<String>, context: Context): Boolean {
+      if (attendeesList != attendeesList.sorted() && deAnonymizationWarned.value == false) {
+        deAnonymizationWarned.value = true
+        logAndShow(context, TAG, R.string.roll_call_attendees_list_not_sorted)
+        return false
+      }
+      return true
     }
 
     /**

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
@@ -30,6 +30,7 @@ import com.github.dedis.popstellar.utility.ActivityUtils.getQRCodeColor
 import com.github.dedis.popstellar.utility.ActivityUtils.handleExpandArrow
 import com.github.dedis.popstellar.utility.Constants.ID_NULL
 import com.github.dedis.popstellar.utility.Constants.ROLL_CALL_ID
+import com.github.dedis.popstellar.utility.error.ErrorUtils
 import com.github.dedis.popstellar.utility.error.ErrorUtils.logAndShow
 import com.github.dedis.popstellar.utility.error.UnknownLaoException
 import com.github.dedis.popstellar.utility.error.UnknownRollCallException
@@ -263,10 +264,10 @@ class RollCallFragment : AbstractEventFragment {
               resources.getString(R.string.roll_call_scanned),
               rollCallViewModel.getAttendees().size)
     } else if (rollCall.isClosed) {
-      attendeesList =
-          rollCall.attendees.stream().map(PublicKey::encoded).collect(Collectors.toList())
+        val orderedAttendees: MutableSet<PublicKey> = LinkedHashSet(rollCall.attendees)
+        attendeesList = orderedAttendees.stream().map(PublicKey::encoded).collect(Collectors.toList())
 
-      // Show the list of attendees if the roll call has ended
+        // Show the list of attendees if the roll call has ended
       binding.rollCallAttendeesText.text =
           String.format(resources.getString(R.string.roll_call_attendees), rollCall.attendees.size)
     }
@@ -358,7 +359,8 @@ class RollCallFragment : AbstractEventFragment {
     }
 
     fun isAttendeeListSorted(attendeesList: List<String>, context: Context): Boolean {
-      if (attendeesList != attendeesList.sorted() && deAnonymizationWarned.value == false) {
+
+      if (attendeesList.isNotEmpty() && attendeesList != attendeesList.sorted() && deAnonymizationWarned.value == false) {
         deAnonymizationWarned.value = true
         logAndShow(context, TAG, R.string.roll_call_attendees_list_not_sorted)
         return false

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
@@ -30,7 +30,6 @@ import com.github.dedis.popstellar.utility.ActivityUtils.getQRCodeColor
 import com.github.dedis.popstellar.utility.ActivityUtils.handleExpandArrow
 import com.github.dedis.popstellar.utility.Constants.ID_NULL
 import com.github.dedis.popstellar.utility.Constants.ROLL_CALL_ID
-import com.github.dedis.popstellar.utility.error.ErrorUtils
 import com.github.dedis.popstellar.utility.error.ErrorUtils.logAndShow
 import com.github.dedis.popstellar.utility.error.UnknownLaoException
 import com.github.dedis.popstellar.utility.error.UnknownRollCallException
@@ -264,10 +263,10 @@ class RollCallFragment : AbstractEventFragment {
               resources.getString(R.string.roll_call_scanned),
               rollCallViewModel.getAttendees().size)
     } else if (rollCall.isClosed) {
-        val orderedAttendees: MutableSet<PublicKey> = LinkedHashSet(rollCall.attendees)
-        attendeesList = orderedAttendees.stream().map(PublicKey::encoded).collect(Collectors.toList())
+      val orderedAttendees: MutableSet<PublicKey> = LinkedHashSet(rollCall.attendees)
+      attendeesList = orderedAttendees.stream().map(PublicKey::encoded).collect(Collectors.toList())
 
-        // Show the list of attendees if the roll call has ended
+      // Show the list of attendees if the roll call has ended
       binding.rollCallAttendeesText.text =
           String.format(resources.getString(R.string.roll_call_attendees), rollCall.attendees.size)
     }
@@ -360,7 +359,9 @@ class RollCallFragment : AbstractEventFragment {
 
     fun isAttendeeListSorted(attendeesList: List<String>, context: Context): Boolean {
 
-      if (attendeesList.isNotEmpty() && attendeesList != attendeesList.sorted() && deAnonymizationWarned.value == false) {
+      if (attendeesList.isNotEmpty() &&
+          attendeesList != attendeesList.sorted() &&
+          deAnonymizationWarned.value == false) {
         deAnonymizationWarned.value = true
         logAndShow(context, TAG, R.string.roll_call_attendees_list_not_sorted)
         return false

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
@@ -53,6 +53,8 @@ class RollCallFragment : AbstractEventFragment {
   private val managementTextMap = buildManagementTextMap()
   private val managementIconMap = buildManagementIconMap()
 
+  private val deAnonymizationWarned = MutableLiveData(false)
+
   constructor()
 
   override fun onCreateView(
@@ -274,11 +276,7 @@ class RollCallFragment : AbstractEventFragment {
     if (attendeesList != null) {
       binding.listViewAttendees.adapter =
           RollCallArrayAdapter(
-              requireContext(),
-              android.R.layout.simple_list_item_1,
-              attendeesList,
-              popToken,
-          )
+              requireContext(), android.R.layout.simple_list_item_1, attendeesList, popToken, this)
     }
   }
 
@@ -338,6 +336,17 @@ class RollCallFragment : AbstractEventFragment {
     return map
   }
 
+  fun isAttendeeListSorted(attendeesList: List<String>, context: Context): Boolean {
+    if (attendeesList.isNotEmpty() &&
+        attendeesList != attendeesList.sorted() &&
+        deAnonymizationWarned.value == false) {
+      deAnonymizationWarned.value = true
+      logAndShow(context, TAG, R.string.roll_call_attendees_list_not_sorted)
+      return false
+    }
+    return true
+  }
+
   @VisibleForTesting(otherwise = VisibleForTesting.NONE)
   constructor(rollCall: RollCall) {
     this.rollCall = rollCall
@@ -345,28 +354,14 @@ class RollCallFragment : AbstractEventFragment {
 
   companion object {
     val TAG: String = RollCallFragment::class.java.simpleName
-    private val deAnonymizationWarned = MutableLiveData(false)
 
     @JvmStatic
     fun newInstance(persistentId: String?): RollCallFragment {
-      deAnonymizationWarned.value = false
       val fragment = RollCallFragment()
       val bundle = Bundle(1)
       bundle.putString(ROLL_CALL_ID, persistentId)
       fragment.arguments = bundle
       return fragment
-    }
-
-    fun isAttendeeListSorted(attendeesList: List<String>, context: Context): Boolean {
-
-      if (attendeesList.isNotEmpty() &&
-          attendeesList != attendeesList.sorted() &&
-          deAnonymizationWarned.value == false) {
-        deAnonymizationWarned.value = true
-        logAndShow(context, TAG, R.string.roll_call_attendees_list_not_sorted)
-        return false
-      }
-      return true
     }
 
     /**

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragment.kt
@@ -10,7 +10,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.lifecycle.MutableLiveData
 import com.github.dedis.popstellar.R
 import com.github.dedis.popstellar.databinding.RollCallFragmentBinding

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallViewModel.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallViewModel.kt
@@ -37,6 +37,7 @@ import java.util.TreeSet
 import java.util.stream.Collectors
 import javax.inject.Inject
 import timber.log.Timber
+import java.util.ArrayList
 
 @HiltViewModel
 class RollCallViewModel
@@ -262,6 +263,7 @@ constructor(
     nbScanned.postValue(attendees.size)
   }
 
+    @Inject
   fun getAttendees(): Set<PublicKey> {
     return attendees
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallViewModel.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallViewModel.kt
@@ -33,10 +33,10 @@ import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.Single
 import java.time.Instant
+import java.util.TreeSet
 import java.util.stream.Collectors
 import javax.inject.Inject
 import timber.log.Timber
-import java.util.TreeSet
 
 @HiltViewModel
 class RollCallViewModel
@@ -53,7 +53,7 @@ constructor(
 ) : AndroidViewModel(application), QRCodeScanningViewModel {
   private lateinit var laoId: String
 
-private val attendees: TreeSet<PublicKey> = TreeSet(Comparator.comparing { it.toString() })
+  private val attendees: TreeSet<PublicKey> = TreeSet(compareBy { it.toString() })
   override val nbScanned = MutableLiveData<Int>()
   lateinit var attendedRollCalls: Observable<List<RollCall>>
     private set

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallViewModel.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallViewModel.kt
@@ -36,6 +36,7 @@ import java.time.Instant
 import java.util.stream.Collectors
 import javax.inject.Inject
 import timber.log.Timber
+import java.util.TreeSet
 
 @HiltViewModel
 class RollCallViewModel
@@ -52,7 +53,7 @@ constructor(
 ) : AndroidViewModel(application), QRCodeScanningViewModel {
   private lateinit var laoId: String
 
-  private val attendees: MutableSet<PublicKey> = HashSet()
+private val attendees: TreeSet<PublicKey> = TreeSet(Comparator.comparing { it.toString() })
   override val nbScanned = MutableLiveData<Int>()
   lateinit var attendedRollCalls: Observable<List<RollCall>>
     private set

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallViewModel.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallViewModel.kt
@@ -33,11 +33,11 @@ import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.Single
 import java.time.Instant
+import java.util.ArrayList
 import java.util.TreeSet
 import java.util.stream.Collectors
 import javax.inject.Inject
 import timber.log.Timber
-import java.util.ArrayList
 
 @HiltViewModel
 class RollCallViewModel
@@ -263,7 +263,7 @@ constructor(
     nbScanned.postValue(attendees.size)
   }
 
-    @Inject
+  @Inject
   fun getAttendees(): Set<PublicKey> {
     return attendees
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/MessageValidator.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/MessageValidator.kt
@@ -307,7 +307,7 @@ object MessageValidator {
 
     /** Helper method to check that a string list is sorted */
     fun stringListIsSorted(list: List<*>, field: String): MessageValidatorBuilder {
-      require(list == list.sortedBy{it.toString()}) { "$field must be sorted" }
+      require(list == list.sortedBy { it.toString() }) { "$field must be sorted" }
       return this
     }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/MessageValidator.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/MessageValidator.kt
@@ -306,10 +306,8 @@ object MessageValidator {
     }
 
     /** Helper method to check that a string list is sorted */
-    fun stringListIsSorted(list: List<String>, field: String): MessageValidatorBuilder {
-      for (i in 0 until list.size - 1) {
-        require(list[i + 1] >= list[i]) { "$field must be sorted" }
-      }
+    fun stringListIsSorted(list: List<*>, field: String): MessageValidatorBuilder {
+      require(list == list.sortedBy{it.toString()}) { "$field must be sorted" }
       return this
     }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/MessageValidator.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/MessageValidator.kt
@@ -211,7 +211,7 @@ object MessageValidator {
      * @param value the value to compare to
      * @throws IllegalArgumentException if the value is not greater or equal than the given value
      */
-    fun greaterOrEqualThan(input: Int, value: Int, field: String): MessageValidatorBuilder {
+    fun greaterOrEqualThan(input: Long, value: Long, field: String): MessageValidatorBuilder {
       require(input >= value) { "$field must be greater or equal than $value" }
       return this
     }
@@ -302,6 +302,14 @@ object MessageValidator {
         "Unsupported voting method in question: ${title}. Must be one of $validVotingMethods."
       }
       validBallotOptions(ballotOptions)
+      return this
+    }
+
+    /** Helper method to check that a string list is sorted */
+    fun stringListIsSorted(list: List<String>, field: String): MessageValidatorBuilder {
+      for (i in 0 until list.size - 1) {
+        require(list[i + 1] >= list[i]) { "$field must be sorted" }
+      }
       return this
     }
 

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.kt
@@ -125,8 +125,23 @@ constructor(
     val updateId = closeRollCall.updateId
     val closes = closeRollCall.closes
     val existingRollCall = rollCallRepo.getRollCallWithId(laoView.id, closes)
-    val currentAttendees = existingRollCall.attendees
-    currentAttendees.addAll(closeRollCall.attendees)
+
+    val currentAttendees: Set<PublicKey>
+    if (closeRollCall.attendees.containsAll(existingRollCall.attendees)) {
+        // closeRollCall.attendees is sorted, so we prefer to use it if we can
+      currentAttendees = closeRollCall.attendees.toMutableSet()
+    } else {
+        // if both lists have different attendees, we merge them even though we lose the order
+        // We are not ordering it because it is important to keep the order that we received to know if we face de-anonymization
+      currentAttendees = existingRollCall.attendees
+      currentAttendees.addAll(closeRollCall.attendees)
+    }
+
+    // log existingRollCall.attendees and closeRollCall.attendees
+    Timber.tag(TAG).d("existingRollCall.attendees: %s", existingRollCall.attendees)
+    Timber.tag(TAG).d("closeRollCall.attendees: %s", closeRollCall.attendees)
+    // log currentAttendees
+    Timber.tag(TAG).d("currentAttendees: %s", currentAttendees)
 
     val builder = RollCallBuilder()
     builder
@@ -142,7 +157,6 @@ constructor(
         .setEnd(closeRollCall.closedAt)
     val laoId = laoView.id
     val rollCall = builder.build()
-
     witnessingRepo.addWitnessMessage(laoId, closeRollCallWitnessMessage(messageId, rollCall))
     if (witnessingRepo.areWitnessesEmpty(laoId)) {
       addRollCallRoutine(rollCallRepo, digitalCashRepo, laoId, rollCall)

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.kt
@@ -128,11 +128,12 @@ constructor(
 
     val currentAttendees: Set<PublicKey>
     if (closeRollCall.attendees.containsAll(existingRollCall.attendees)) {
-        // closeRollCall.attendees is sorted, so we prefer to use it if we can
+      // closeRollCall.attendees is sorted, so we prefer to use it if we can
       currentAttendees = closeRollCall.attendees.toMutableSet()
     } else {
-        // if both lists have different attendees, we merge them even though we lose the order
-        // We are not ordering it because it is important to keep the order that we received to know if we face de-anonymization
+      // if both lists have different attendees, we merge them even though we lose the order
+      // We are not ordering it because it is important to keep the order that we received to know
+      // if we face de-anonymization
       currentAttendees = existingRollCall.attendees
       currentAttendees.addAll(closeRollCall.attendees)
     }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/RollCallHandler.kt
@@ -138,12 +138,6 @@ constructor(
       currentAttendees.addAll(closeRollCall.attendees)
     }
 
-    // log existingRollCall.attendees and closeRollCall.attendees
-    Timber.tag(TAG).d("existingRollCall.attendees: %s", existingRollCall.attendees)
-    Timber.tag(TAG).d("closeRollCall.attendees: %s", closeRollCall.attendees)
-    // log currentAttendees
-    Timber.tag(TAG).d("currentAttendees: %s", currentAttendees)
-
     val builder = RollCallBuilder()
     builder
         .setId(updateId)

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -176,6 +176,8 @@
   <string name="roll_call_scanned">Scanned tokens : %1$d</string>
   <string name="roll_call_description_title">Description</string>
   <string name="roll_call_location_title">Location</string>
+<string name="roll_call_attendees_list_not_sorted">Attendees list is not sorted, risk of de-anonymization</string>
+
 
   <!-- Meeting -->
   <string name="meeting_title">Meeting</string>

--- a/fe2-android/app/src/main/res/values/strings.xml
+++ b/fe2-android/app/src/main/res/values/strings.xml
@@ -176,7 +176,7 @@
   <string name="roll_call_scanned">Scanned tokens : %1$d</string>
   <string name="roll_call_description_title">Description</string>
   <string name="roll_call_location_title">Location</string>
-<string name="roll_call_attendees_list_not_sorted">Attendees list is not sorted, risk of de-anonymization</string>
+<string name="roll_call_attendees_list_not_sorted">Attendees list is not sorted, risk of de-anonymization"</string>
 
 
   <!-- Meeting -->

--- a/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/event/rollcall/RollCallFragmentPageObject.java
+++ b/fe2-android/app/src/test/framework/common/java/com/github/dedis/popstellar/testutils/pages/lao/event/rollcall/RollCallFragmentPageObject.java
@@ -17,7 +17,6 @@ public class RollCallFragmentPageObject {
   public static ViewInteraction rollCallTitle() {
     return onView(withId(R.id.roll_call_fragment_title));
   }
-
   public static ViewInteraction rollCallStatusText() {
     return onView(withId(R.id.roll_call_status));
   }

--- a/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/testutils/UITestUtils.kt
+++ b/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/testutils/UITestUtils.kt
@@ -61,12 +61,6 @@ object UITestUtils {
     Assert.assertNotEquals(expected, ShadowToast.getTextOfLatestToast())
   }
 
-
-  @JvmStatic
-  fun assertNoToastIsDisplayed() {
-    Assert.assertNull(ShadowToast.getLatestToast())
-  }
-
   @JvmStatic
   fun assertToastIsDisplayedContainsText(@StringRes resId: Int, vararg args: Any?) {
     MatcherAssert.assertThat(

--- a/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/testutils/UITestUtils.kt
+++ b/fe2-android/app/src/test/framework/robolectric/java/com/github/dedis/popstellar/testutils/UITestUtils.kt
@@ -43,6 +43,30 @@ object UITestUtils {
     Assert.assertEquals(expected, ShadowToast.getTextOfLatestToast())
   }
 
+  /**
+   * Assert that the latest toast was shown with the expected text
+   *
+   * @param resId expected
+   * @param args arguments to the resource
+   */
+  @JvmStatic
+  fun assertToastDisplayedHasNotText(@StringRes resId: Int, vararg args: Any?) {
+    MatcherAssert.assertThat(
+      "No toast was displayed",
+      ShadowToast.getLatestToast(),
+      Matchers.notNullValue()
+    )
+
+    val expected = ApplicationProvider.getApplicationContext<Context>().getString(resId, *args)
+    Assert.assertNotEquals(expected, ShadowToast.getTextOfLatestToast())
+  }
+
+
+  @JvmStatic
+  fun assertNoToastIsDisplayed() {
+    Assert.assertNull(ShadowToast.getLatestToast())
+  }
+
   @JvmStatic
   fun assertToastIsDisplayedContainsText(@StringRes resId: Int, vararg args: Any?) {
     MatcherAssert.assertThat(

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/InviteFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/InviteFragmentTest.kt
@@ -2,10 +2,7 @@ package com.github.dedis.popstellar.ui.lao
 
 import android.content.ClipboardManager
 import android.content.Context
-import android.widget.Button
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.test.espresso.Espresso
-import androidx.test.espresso.EspressoException
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.assertion.ViewAssertions
@@ -20,13 +17,11 @@ import com.github.dedis.popstellar.testutils.BundleBuilder
 import com.github.dedis.popstellar.testutils.fragment.ActivityFragmentScenarioRule
 import com.github.dedis.popstellar.testutils.pages.lao.InviteFragmentPageObject
 import com.github.dedis.popstellar.testutils.pages.lao.LaoActivityPageObject
-import com.github.dedis.popstellar.ui.lao.event.election.CastVoteOpenBallotFragmentTest
 import com.github.dedis.popstellar.utility.security.KeyManager
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import junit.framework.TestCase
-import javax.inject.Inject
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExternalResource
@@ -35,6 +30,7 @@ import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.junit.MockitoJUnit
 import org.mockito.junit.MockitoTestRule
+import javax.inject.Inject
 
 @SmallTest
 @HiltAndroidTest

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/CastVoteOpenBallotFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/CastVoteOpenBallotFragmentTest.kt
@@ -202,7 +202,7 @@ class CastVoteOpenBallotFragmentTest {
     private const val PLURALITY = "Plurality"
     private val laoSubject = BehaviorSubject.createDefault(LaoView(LAO))
     private val ROLL_CALL =
-      RollCall("id", "id", "rc", 0L, 1L, 2L, EventState.CLOSED, HashSet(), "nowhere", "none")
+      RollCall("id", "id", "rc", 0L, 1L, 2L, EventState.CLOSED, LinkedHashSet(), "nowhere", "none")
     private val ELECTION_ID = generateElectionSetupId(LAO_ID, CREATION, TITLE)
     private val ELECTION_QUESTION_1 =
       ElectionQuestion(

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/CastVoteSecretBallotFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/CastVoteSecretBallotFragmentTest.kt
@@ -136,7 +136,7 @@ class CastVoteSecretBallotFragmentTest {
     private const val PLURALITY = "Plurality"
     private val laoSubject = BehaviorSubject.createDefault(LaoView(LAO))
     private val ROLL_CALL =
-      RollCall("id", "id", "rc", 0L, 1L, 2L, EventState.CLOSED, HashSet(), "nowhere", "none")
+      RollCall("id", "id", "rc", 0L, 1L, 2L, EventState.CLOSED, LinkedHashSet(), "nowhere", "none")
     private val ELECTION_ID = generateElectionSetupId(LAO_ID, CREATION, TITLE)
     private val ELECTION_QUESTION_1 =
       ElectionQuestion(

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/ElectionFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/election/ElectionFragmentTest.kt
@@ -66,7 +66,7 @@ class ElectionFragmentTest {
       START,
       END,
       EventState.CLOSED,
-      HashSet(),
+      LinkedHashSet(),
       LOCATION,
       ROLL_CALL_DESC
     )

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/eventlist/EventListAdapterTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/eventlist/EventListAdapterTest.kt
@@ -44,12 +44,12 @@ class EventListAdapterTest {
       1L,
       2L,
       EventState.CREATED,
-      HashSet(),
+      LinkedHashSet(),
       "not lausanne",
       "no"
     )
   private val ROLL_CALL2 =
-    RollCall("12345", "12345", "Name", 2L, 3L, 4L, EventState.CREATED, HashSet(), "nowhere", "foo")
+    RollCall("12345", "12345", "Name", 2L, 3L, 4L, EventState.CREATED, LinkedHashSet(), "nowhere", "foo")
 
   private lateinit var events: Subject<Set<Event>>
 

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapterTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapterTest.kt
@@ -51,14 +51,14 @@ class RollCallArrayAdapterTest {
     }
 
     @Test
-    fun verify_our_token_is_highlighted() {
+    fun verifyOurTokenIsHighlighted() {
         val view = adapter.getView(0, mockView, mock(ViewGroup::class.java)) as TextView
         val color = ContextCompat.getColor(context, R.color.colorAccent)
         Assert.assertEquals(color, view.currentTextColor)
     }
 
     @Test
-    fun verify_other_token_is_not_highlighted() {
+    fun verifyOtherTokenIsNotHighlighted() {
         val view = adapter.getView(1, mockView, mock(ViewGroup::class.java)) as TextView
         val color = ContextCompat.getColor(context, R.color.textOnBackground)
         Assert.assertEquals(color, view.currentTextColor)

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapterTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallArrayAdapterTest.kt
@@ -44,7 +44,7 @@ class RollCallArrayAdapterTest {
         val myToken = PoPToken(MY_PRIVATE_KEY, MY_PUBLIC_KEY)
         val otherToken = PoPToken(OTHER_PRIVATE_KEY, OTHER_PUBLIC_KEY)
         attendeesList = listOf(myToken.publicKey.encoded, otherToken.publicKey.encoded)
-        adapter = RollCallArrayAdapter(context, R.id.valid_token_layout_text, attendeesList, myToken)
+        adapter = RollCallArrayAdapter(context, R.id.valid_token_layout_text, attendeesList, myToken, mock(RollCallFragment::class.java))
         mockView = TextView(context)
         val colorAccent = ContextCompat.getColor(context, R.color.textOnBackground)
         (mockView as TextView).setTextColor(colorAccent)

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragmentTest.kt
@@ -537,6 +537,7 @@ class RollCallFragmentTest {
       )
 
     UITestUtils.assertToastDisplayedHasNotText(R.string.roll_call_attendees_list_not_sorted)
+    UITestUtils.assertNoToastIsDisplayed()
   }
 
   @Test

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragmentTest.kt
@@ -537,7 +537,6 @@ class RollCallFragmentTest {
       )
 
     UITestUtils.assertToastDisplayedHasNotText(R.string.roll_call_attendees_list_not_sorted)
-    UITestUtils.assertNoToastIsDisplayed()
   }
 
   @Test

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/event/rollcall/RollCallFragmentTest.kt
@@ -140,8 +140,6 @@ class RollCallFragmentTest {
         Mockito.`when`(laoRepo.getLaoView(MockitoKotlinHelpers.any())).thenAnswer { LaoView(LAO) }
         rollCallRepo.updateRollCall(LAO_ID, ROLL_CALL)
         rollCallRepo.updateRollCall(LAO_ID, ROLL_CALL_2)
-        rollCallRepo.updateRollCall(LAO_ID, ROLL_CALL_SORTED_ATTENDEES)
-        rollCallRepo.updateRollCall(LAO_ID, ROLL_CALL_UNSORTED_ATTENDEES)
 
         Mockito.`when`(keyManager.mainPublicKey).thenReturn(SENDER)
         Mockito.`when`(networkManager.messageSender).thenReturn(messageSenderHelper.mockedSender)
@@ -524,6 +522,7 @@ class RollCallFragmentTest {
 
   @Test
   fun sortedAttendeeListShowsNoToast() {
+    rollCallRepo.updateRollCall(LAO_ID, ROLL_CALL_SORTED_ATTENDEES)
     rollCallRepo.updateRollCall(LAO_ID, closeRollCall(ROLL_CALL_SORTED_ATTENDEES))
     InstrumentationRegistry.getInstrumentation().waitForIdleSync()
     openRollCallWithDescription(ROLL_CALL_SORTED_ATTENDEES)
@@ -542,6 +541,7 @@ class RollCallFragmentTest {
 
   @Test
   fun unSortedAttendeeListShowsToast() {
+    rollCallRepo.updateRollCall(LAO_ID, ROLL_CALL_UNSORTED_ATTENDEES)
     rollCallRepo.updateRollCall(LAO_ID, closeRollCall(ROLL_CALL_UNSORTED_ATTENDEES))
     InstrumentationRegistry.getInstrumentation().waitForIdleSync()
     openRollCallWithDescription(ROLL_CALL_UNSORTED_ATTENDEES)

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/popcha/PoPCHAHomeFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/popcha/PoPCHAHomeFragmentTest.kt
@@ -95,7 +95,7 @@ class PoPCHAHomeFragmentTest {
             1632204910,
             1632204900,
             EventState.CLOSED,
-            attendees,
+            LinkedHashSet(attendees),
             "bc",
             ""
           )

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapterTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapterTest.kt
@@ -62,7 +62,7 @@ class ChirpListAdapterTest {
       TIMESTAMP_1,
       TIMESTAMP_2,
       EventState.CLOSED,
-      HashSet(),
+      LinkedHashSet(),
       "",
       "",
     )

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListFragmentTest.kt
@@ -64,7 +64,7 @@ class ChirpListFragmentTest {
                     TIMESTAMP_1,
                     TIMESTAMP_2,
                     EventState.CLOSED,
-                    HashSet(),
+                LinkedHashSet(),
                     "",
                     "",
             )

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaHomeFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/SocialMediaHomeFragmentTest.kt
@@ -59,7 +59,7 @@ class SocialMediaHomeFragmentTest {
       CREATION_TIME,
       CREATION_TIME,
       EventState.CLOSED,
-      HashSet(),
+      LinkedHashSet(),
       "",
       "",
     )

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/token/TokenFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/token/TokenFragmentTest.kt
@@ -51,7 +51,7 @@ class TokenFragmentTest {
       ROLL_CALL_START,
       ROLL_CALL_END,
       EventState.CLOSED,
-      HashSet(),
+      LinkedHashSet(),
       LOCATION,
       ROLL_CALL_DESC
     )

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/token/TokenListFragmentTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/token/TokenListFragmentTest.kt
@@ -54,7 +54,7 @@ class TokenListFragmentTest {
       ROLL_CALL_START,
       ROLL_CALL_END,
       EventState.CREATED,
-      HashSet(),
+      LinkedHashSet(),
       LOCATION,
       ROLL_CALL_DESC
     )

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/CloseRollCallTest.kt
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/CloseRollCallTest.kt
@@ -10,6 +10,7 @@ import com.github.dedis.popstellar.model.objects.security.Base64URLData
 import com.github.dedis.popstellar.testutils.Base64DataUtils
 import com.github.dedis.popstellar.utility.MessageValidator
 import com.github.dedis.popstellar.utility.security.HashSHA256.hash
+import com.google.android.gms.common.util.CollectionUtils.listOf
 import junit.framework.TestCase.assertNotNull
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert
@@ -17,6 +18,7 @@ import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.time.Instant
+import java.util.ArrayList
 import java.util.Collections
 
 @RunWith(AndroidJUnit4::class)
@@ -94,9 +96,7 @@ class CloseRollCallTest {
   @Test(expected = IllegalArgumentException::class)
   fun constructorFailsWhenAttendeesNotSorted() {
     val unsortedAttendees = ArrayList(attendees).toMutableList()
-    if (unsortedAttendees[0].toString() > unsortedAttendees[1].toString()) {
-      Collections.swap(unsortedAttendees, 0, 1)
-    }
+    Collections.swap(unsortedAttendees, 0, 1)
 
     CloseRollCall(validBase64LaoId, validBase64Closes, pastTime, unsortedAttendees)
   }

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/CloseRollCallTest.kt
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/model/network/method/message/data/rollcall/CloseRollCallTest.kt
@@ -6,13 +6,18 @@ import com.github.dedis.popstellar.model.network.method.message.data.Action
 import com.github.dedis.popstellar.model.network.method.message.data.Objects
 import com.github.dedis.popstellar.model.objects.event.EventState
 import com.github.dedis.popstellar.model.objects.event.EventType
+import com.github.dedis.popstellar.model.objects.security.Base64URLData
+import com.github.dedis.popstellar.testutils.Base64DataUtils
+import com.github.dedis.popstellar.utility.MessageValidator
 import com.github.dedis.popstellar.utility.security.HashSHA256.hash
-import java.time.Instant
+import junit.framework.TestCase.assertNotNull
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.time.Instant
+import java.util.Collections
 
 @RunWith(AndroidJUnit4::class)
 class CloseRollCallTest {
@@ -80,6 +85,57 @@ class CloseRollCallTest {
     )
   }
 
+  @Test
+  fun constructorSucceedsWithValidData() {
+    val closeRollCall = CloseRollCall(validBase64LaoId, validBase64Closes, pastTime, validAttendees)
+    assertNotNull(closeRollCall)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun constructorFailsWhenAttendeesNotSorted() {
+    val unsortedAttendees = ArrayList(attendees).toMutableList()
+    if (unsortedAttendees[0].toString() > unsortedAttendees[1].toString()) {
+      Collections.swap(unsortedAttendees, 0, 1)
+    }
+
+    CloseRollCall(validBase64LaoId, validBase64Closes, pastTime, unsortedAttendees)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun constructorFailsWhenClosedAtInFuture() {
+    CloseRollCall(validBase64LaoId, validBase64Closes, futureTime, validAttendees)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun constructorFailsWhenTooLongPastTime() {
+    CloseRollCall(validBase64LaoId, validBase64Closes, tooLongPastTime, validAttendees)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun constructorFailsWhenLaoIdNotBase64() {
+    CloseRollCall(invalidBase64, validBase64Closes, pastTime, validAttendees)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun constructorFailsWhenLaoIdEmpty() {
+    CloseRollCall(emptyBase64, validBase64Closes, pastTime, validAttendees)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun constructorFailsWhenClosesNotBase64() {
+    CloseRollCall(validBase64LaoId, invalidBase64, pastTime, validAttendees)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun constructorFailsWhenClosesEmpty() {
+    CloseRollCall(validBase64LaoId, emptyBase64, pastTime, validAttendees)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun constructorFailsWhenClosedAtNegative() {
+    CloseRollCall(validBase64LaoId, validBase64Closes, negativeClosedAt, validAttendees)
+  }
+
   companion object {
     private val LAO_ID = hash("LAO_ID")
     private const val NAME = "NAME"
@@ -88,5 +144,27 @@ class CloseRollCallTest {
     private val CREATE_ROLL_CALL = CreateRollCall(NAME, TIME, TIME, TIME, LOCATION, null, LAO_ID)
     private val OPEN_ROLL_CALL = OpenRollCall(LAO_ID, CREATE_ROLL_CALL.id, TIME, EventState.CREATED)
     private val CLOSE_ROLL_CALL = CloseRollCall(LAO_ID, OPEN_ROLL_CALL.updateId, TIME, ArrayList())
+
+    private val attendees = listOf(
+      Base64DataUtils.generatePublicKey(),
+      Base64DataUtils.generatePublicKey(),
+      Base64DataUtils.generatePublicKey(),
+      Base64DataUtils.generatePublicKey(),
+      Base64DataUtils.generatePublicKey(),
+      Base64DataUtils.generatePublicKey()
+    )
+
+    private val validAttendees = attendees.sortedBy { it.toString() }
+
+    private val pastTime = Instant.now().epochSecond - 1000
+    private val futureTime = Instant.now().epochSecond + 10000
+    private val tooLongPastTime = Instant.now().epochSecond - MessageValidator.MessageValidatorBuilder.VALID_PAST_DELAY
+    private val negativeClosedAt = (-1).toLong()
+
+    private val invalidBase64 = "invalidBase64String"
+    private val emptyBase64 = Base64URLData("".toByteArray()).encoded
+    private val validBase64LaoId = Base64URLData("validLaoId".toByteArray()).encoded
+    private val validBase64Closes = Base64URLData("validCloses".toByteArray()).encoded
+
   }
 }

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/WitnessingRepositoryTest.kt
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/WitnessingRepositoryTest.kt
@@ -194,7 +194,7 @@ class WitnessingRepositoryTest {
         CREATION + 10,
         CREATION + 20,
         EventState.CREATED,
-        HashSet(),
+        LinkedHashSet(),
         "loc",
         ""
       )

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/database/RollCallDatabaseTest.kt
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/database/RollCallDatabaseTest.kt
@@ -65,7 +65,7 @@ class RollCallDatabaseTest {
         CREATION + 10,
         CREATION + 20,
         EventState.CREATED,
-        HashSet(),
+        LinkedHashSet(),
         "loc",
         ""
       )

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/database/WitnessDatabaseTest.kt
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/repository/database/WitnessDatabaseTest.kt
@@ -212,7 +212,7 @@ class WitnessDatabaseTest {
         CREATION + 10,
         CREATION + 20,
         EventState.CREATED,
-        HashSet(),
+        LinkedHashSet(),
         "loc",
         ""
       )

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/RollCallHandlerTest.kt
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/handler/RollCallHandlerTest.kt
@@ -185,7 +185,7 @@ class RollCallHandlerTest {
         now + 1,
         now + 2,
         EventState.CREATED,
-        HashSet(),
+        LinkedHashSet(),
         "somewhere",
         "desc"
       )

--- a/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/security/KeyManagerTest.kt
+++ b/fe2-android/app/src/test/unit/java/com/github/dedis/popstellar/utility/security/KeyManagerTest.kt
@@ -106,7 +106,7 @@ class KeyManagerTest {
         creation1 + 1,
         creation1 + 75,
         EventState.CLOSED,
-        HashSet(),
+        LinkedHashSet(),
         "location",
         "desc"
       )
@@ -119,7 +119,7 @@ class KeyManagerTest {
         creation2 + 1,
         creation2 + 75,
         EventState.CLOSED,
-        HashSet(),
+        LinkedHashSet(),
         "EPFL",
         "do not come"
       )
@@ -160,7 +160,7 @@ class KeyManagerTest {
         (5421364 + 1).toLong(),
         (5421364 + 145).toLong(),
         EventState.CLOSED,
-        HashSet(),
+        LinkedHashSet(),
         "ETHZ",
         "do come"
       )


### PR DESCRIPTION
### Summary

Addressing [issue #1847](https://github.com/dedis/popstellar/issues/1847). FE2 Organizers were sending unordered list of scanned attendees for a `RollCall`, enhancing risks of de-anonymization.

### Main Changes

- Organizer now sends a sorted list of attendees when closing a RollCall.
- UI displays the attendees list in the same order it is received when opening a closed RollCall.
- If the list displayed is not sorted, a toast warns the user about the risk of de-anonymization.
- We do not reorder the list if it is sent unordered, we just warn the user, because if the list has been sent unordered then it is too late already.
- Changed all utilization of `HashSet` to `LinkedHashSet` (in `RollCall` scope) to keep the set ordered as it came in

### Other Changes

I added checking for ordered attendees list at creation, so I also added full validation of message data while I was here.

- Added full validation for the CloseRollCall message data.
- Added complete tests for the CloseRollCall validation.

### UI Updates

- Ensured the attendees list is displayed in the same order it is received.
- Added a toast notification if the list is not sorted.
