### PR TITLE
[REVERT] Re-enable connection extension to peers

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.kt
@@ -220,10 +220,7 @@ constructor(
     // Extend the current connection by connecting to the peers of the main server
     // The greetLao will also be sent by the other servers, so the message sender
     // should handle this, avoiding to connect twice to the same server
-    // TODO: Remove the comment when testing for backend is finished ! Maxime @Kaz | May 2024
-    // Also, I realised removing this line that no tests are actually testing this part of the
-    // code...
-    // context.messageSender.extendConnection(greetLao.peers)
+    context.messageSender.extendConnection(greetLao.peers)
   }
 
   companion object {


### PR DESCRIPTION
Extending connection to peers of the main server has been disabled for testing purposes in #1881. This PR serves as a revert option, for when we will need to enable connection extension again :)