### PR TITLE
[BE1][BE2] Add timestamp to rumors

### DIFF
--- a/docs/embedme.sh
+++ b/docs/embedme.sh
@@ -34,7 +34,7 @@ BEGIN {
 {
     # if this is a closing block line, unsets the del variable to stop deleting
     # lines if it was the case
-    if ($0 ~ /^\`\`\`$/) {
+    if ($0 ~ /^```$/) {
         del=0;
         print $0;
     
@@ -44,7 +44,7 @@ BEGIN {
 
     # if this is the start of an opening block, we indicate that with the
     # last_line variable
-    } else if ($0 ~ /\`\`\`json5/) {
+    } else if ($0 ~ /```json5/) {
         last_line=1;
         print $0;
 

--- a/docs/embedme.sh
+++ b/docs/embedme.sh
@@ -34,7 +34,7 @@ BEGIN {
 {
     # if this is a closing block line, unsets the del variable to stop deleting
     # lines if it was the case
-    if ($0 ~ /^```$/) {
+    if ($0 ~ /^\`\`\`$/) {
         del=0;
         print $0;
     
@@ -44,7 +44,7 @@ BEGIN {
 
     # if this is the start of an opening block, we indicate that with the
     # last_line variable
-    } else if ($0 ~ /```json5/) {
+    } else if ($0 ~ /\`\`\`json5/) {
         last_line=1;
         print $0;
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -197,6 +197,9 @@ and its arguments (`params`).
         },
         {
             "$ref": "method/rumor_state.json"
+        },
+        {
+            "$ref": "method/paged_catchup.json"
         }
     ],
 
@@ -982,6 +985,12 @@ RPC
     "params": {
         "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
         "rumor_id": 1,
+        "clock" : {
+            "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 3,
+            "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
+            "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
+            "r8cG9HyJ1FGBke_5IblCdH19mvy39MvLFSArVmY3FpY=": 10
+        },
         "messages": {
             "/root/nLghr9_P406lfkMjaNWqyohLxOiGlQee8zad4qAfj18=/social/8qlv4aUT5-tBodKp4RszY284CFYVaoDZK6XKiw9isSw=": [
                 {
@@ -1072,6 +1081,10 @@ RPC
       "description": "[Integer] ID of the rumor",
       "type": "integer"
     },
+    "clock" : {
+      "description": "Rumor state in which this message has been sent",
+      "$ref": "./rumor_state.json"
+    },
     "messages": {
       "description": "Key-value of channels and messages per channel",
       "type": "object",
@@ -1081,7 +1094,8 @@ RPC
   "required": [
     "sender_id",
     "rumor_id",
-    "messages"
+    "messages",
+    "clock"
   ]
 }
 
@@ -1127,6 +1141,12 @@ Response in case of success
     {
       "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
       "rumor_id": 1,
+      "clock" : {
+        "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 3,
+        "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
+        "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
+        "r8cG9HyJ1FGBke_5IblCdH19mvy39MvLFSArVmY3FpY=": 9
+      },
       "messages": {
         "/root/nLghr9_P406lfkMjaNWqyohLxOiGlQee8zad4qAfj18=/social/8qlv4aUT5-tBodKp4RszY284CFYVaoDZK6XKiw9isSw=": [
           {
@@ -1142,6 +1162,12 @@ Response in case of success
     {
       "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
       "rumor_id": 2,
+      "clock" : {
+        "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 3,
+        "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
+        "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
+        "r8cG9HyJ1FGBke_5IblCdH19mvy39MvLFSArVmY3FpY=": 10
+      },
       "messages": {
         "/root/nLghr9_P406lfkMjaNWqyohLxOiGlQee8zad4qAfj18=/HnXDyvSSron676Icmvcjk5zXvGLkPJ1fVOaWOxItzBE=": [
           {
@@ -1273,8 +1299,7 @@ Response (in case of success)
             "signature": "ONylxgHA9cbsB_lwdfbn3iyzRd4aTpJhBMnvEKhmJF_niE_pUHdmjxDXjEwFyvo5WiH1NZXWyXG27SYEpkasCA==",
             "message_id": "2mAAevx61TZJi4groVGqqkeLEQq0e-qM6PGmTWuShyY=",
             "witness_signatures": []
-        },
-        // ...9 other messages
+        }
     ]
 }
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -985,7 +985,7 @@ RPC
     "params": {
         "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
         "rumor_id": 1,
-        "clock" : {
+        "timestamp" : {
             "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 3,
             "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
             "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
@@ -1081,7 +1081,7 @@ RPC
       "description": "[Integer] ID of the rumor",
       "type": "integer"
     },
-    "clock" : {
+    "timestamp" : {
       "description": "Rumor state in which this message has been sent",
       "$ref": "./rumor_state.json"
     },
@@ -1095,7 +1095,7 @@ RPC
     "sender_id",
     "rumor_id",
     "messages",
-    "clock"
+    "timestamp"
   ]
 }
 
@@ -1141,7 +1141,7 @@ Response in case of success
     {
       "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
       "rumor_id": 1,
-      "clock" : {
+      "timestamp" : {
         "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 3,
         "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
         "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
@@ -1162,7 +1162,7 @@ Response in case of success
     {
       "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
       "rumor_id": 2,
-      "clock" : {
+      "timestamp" : {
         "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 3,
         "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
         "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,

--- a/protocol/examples/answer/rumor_state_ans.json
+++ b/protocol/examples/answer/rumor_state_ans.json
@@ -6,7 +6,7 @@
       "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
       "rumor_id": 1,
       "timestamp" : {
-        "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 3,
+        "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 1,
         "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
         "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
         "r8cG9HyJ1FGBke_5IblCdH19mvy39MvLFSArVmY3FpY=": 9
@@ -27,7 +27,7 @@
       "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
       "rumor_id": 2,
       "timestamp" : {
-        "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 3,
+        "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 2,
         "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
         "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
         "r8cG9HyJ1FGBke_5IblCdH19mvy39MvLFSArVmY3FpY=": 10

--- a/protocol/examples/answer/rumor_state_ans.json
+++ b/protocol/examples/answer/rumor_state_ans.json
@@ -5,7 +5,7 @@
     {
       "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
       "rumor_id": 1,
-      "clock" : {
+      "timestamp" : {
         "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 3,
         "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
         "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
@@ -26,7 +26,7 @@
     {
       "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
       "rumor_id": 2,
-      "clock" : {
+      "timestamp" : {
         "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 3,
         "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
         "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,

--- a/protocol/examples/answer/rumor_state_ans.json
+++ b/protocol/examples/answer/rumor_state_ans.json
@@ -5,6 +5,12 @@
     {
       "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
       "rumor_id": 1,
+      "clock" : {
+        "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 3,
+        "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
+        "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
+        "r8cG9HyJ1FGBke_5IblCdH19mvy39MvLFSArVmY3FpY=": 9
+      },
       "messages": {
         "/root/nLghr9_P406lfkMjaNWqyohLxOiGlQee8zad4qAfj18=/social/8qlv4aUT5-tBodKp4RszY284CFYVaoDZK6XKiw9isSw=": [
           {
@@ -20,6 +26,12 @@
     {
       "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
       "rumor_id": 2,
+      "clock" : {
+        "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 3,
+        "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
+        "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
+        "r8cG9HyJ1FGBke_5IblCdH19mvy39MvLFSArVmY3FpY=": 10
+      },
       "messages": {
         "/root/nLghr9_P406lfkMjaNWqyohLxOiGlQee8zad4qAfj18=/HnXDyvSSron676Icmvcjk5zXvGLkPJ1fVOaWOxItzBE=": [
           {

--- a/protocol/examples/query/rumor/rumor.json
+++ b/protocol/examples/query/rumor/rumor.json
@@ -5,6 +5,12 @@
     "params": {
         "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
         "rumor_id": 1,
+        "clock" : {
+            "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 3,
+            "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
+            "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
+            "r8cG9HyJ1FGBke_5IblCdH19mvy39MvLFSArVmY3FpY=": 10
+        },
         "messages": {
             "/root/nLghr9_P406lfkMjaNWqyohLxOiGlQee8zad4qAfj18=/social/8qlv4aUT5-tBodKp4RszY284CFYVaoDZK6XKiw9isSw=": [
                 {

--- a/protocol/examples/query/rumor/rumor.json
+++ b/protocol/examples/query/rumor/rumor.json
@@ -6,7 +6,7 @@
         "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
         "rumor_id": 1,
         "timestamp" : {
-            "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 3,
+            "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 1,
             "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
             "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
             "r8cG9HyJ1FGBke_5IblCdH19mvy39MvLFSArVmY3FpY=": 10

--- a/protocol/examples/query/rumor/rumor.json
+++ b/protocol/examples/query/rumor/rumor.json
@@ -5,7 +5,7 @@
     "params": {
         "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
         "rumor_id": 1,
-        "clock" : {
+        "timestamp" : {
             "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 3,
             "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
             "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,

--- a/protocol/examples/query/rumor/wrong_rumor_additional_params.json
+++ b/protocol/examples/query/rumor/wrong_rumor_additional_params.json
@@ -5,6 +5,12 @@
     "params": {
         "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
         "rumor_id": 1,
+        "timestamp" : {
+            "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 1,
+            "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
+            "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
+            "r8cG9HyJ1FGBke_5IblCdH19mvy39MvLFSArVmY3FpY=": 10
+        },
         "messages": {
             "/root/nLghr9_P406lfkMjaNWqyohLxOiGlQee8zad4qAfj18=/social/8qlv4aUT5-tBodKp4RszY284CFYVaoDZK6XKiw9isSw=": [
                 {

--- a/protocol/examples/query/rumor/wrong_rumor_missing_channel.json
+++ b/protocol/examples/query/rumor/wrong_rumor_missing_channel.json
@@ -5,6 +5,12 @@
     "params": {
         "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
         "rumor_id": 1,
+        "timestamp" : {
+            "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 1,
+            "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
+            "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
+            "r8cG9HyJ1FGBke_5IblCdH19mvy39MvLFSArVmY3FpY=": 10
+        },
         "messages": {
             "": [
                 {

--- a/protocol/examples/query/rumor/wrong_rumor_missing_messages.json
+++ b/protocol/examples/query/rumor/wrong_rumor_missing_messages.json
@@ -4,6 +4,12 @@
     "method": "rumor",
     "params": {
         "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
-        "rumor_id": 1
+        "rumor_id": 1,
+        "timestamp" : {
+            "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 1,
+            "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
+            "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
+            "r8cG9HyJ1FGBke_5IblCdH19mvy39MvLFSArVmY3FpY=": 10
+        }
     }
 }

--- a/protocol/examples/query/rumor/wrong_rumor_missing_sender_id.json
+++ b/protocol/examples/query/rumor/wrong_rumor_missing_sender_id.json
@@ -4,6 +4,12 @@
     "method": "rumor",
     "params": {
         "rumor_id": 1,
+        "timestamp" : {
+            "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 1,
+            "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
+            "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
+            "r8cG9HyJ1FGBke_5IblCdH19mvy39MvLFSArVmY3FpY=": 10
+        },
         "messages": {
             "/root/nLghr9_P406lfkMjaNWqyohLxOiGlQee8zad4qAfj18=/social/8qlv4aUT5-tBodKp4RszY284CFYVaoDZK6XKiw9isSw=": [
                 {

--- a/protocol/examples/query/rumor/wrong_rumor_missing_timestamp.json
+++ b/protocol/examples/query/rumor/wrong_rumor_missing_timestamp.json
@@ -3,13 +3,7 @@
     "id": 4,
     "method": "rumor",
     "params": {
-        "sender_id": "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=",
-        "timestamp" : {
-            "J9fBzJV70Jk5c-i3277Uq4CmeL4t53WDfUghaK0HpeM=": 1,
-            "RZOPi59Iy5gkpS2mkpfQJNl44HKc2jVbF0iTGm0RvfU=": 5,
-            "CfG2ByLhtLJH--T2BL9hZ6eGm11tpkE-5KuvysSCY0I=": 1,
-            "r8cG9HyJ1FGBke_5IblCdH19mvy39MvLFSArVmY3FpY=": 10
-        },
+        "rumor_id": 1,
         "messages": {
             "/root/nLghr9_P406lfkMjaNWqyohLxOiGlQee8zad4qAfj18=/social/8qlv4aUT5-tBodKp4RszY284CFYVaoDZK6XKiw9isSw=": [
                 {

--- a/protocol/query/method/object/rumor.json
+++ b/protocol/query/method/object/rumor.json
@@ -15,6 +15,10 @@
       "description": "[Integer] ID of the rumor",
       "type": "integer"
     },
+    "clock" : {
+      "description": "Rumor state in which this message has been sent",
+      "$ref": "./rumor_state.json"
+    },
     "messages": {
       "description": "Key-value of channels and messages per channel",
       "type": "object",
@@ -24,6 +28,7 @@
   "required": [
     "sender_id",
     "rumor_id",
-    "messages"
+    "messages",
+    "clock"
   ]
 }

--- a/protocol/query/method/object/rumor.json
+++ b/protocol/query/method/object/rumor.json
@@ -15,7 +15,7 @@
       "description": "[Integer] ID of the rumor",
       "type": "integer"
     },
-    "clock" : {
+    "timestamp" : {
       "description": "Rumor state in which this message has been sent",
       "$ref": "./rumor_state.json"
     },
@@ -29,6 +29,6 @@
     "sender_id",
     "rumor_id",
     "messages",
-    "clock"
+    "timestamp"
   ]
 }


### PR DESCRIPTION
To be able to add partial ordering to messages, we want to add a vector clock to each rumor. For this, jsonRPC of Rumor has been changed with the addition of a RumorState object, that will represent the rumor state in which a rumor has been sent