### PR TITLE
Changing the chirp profile color for linked LAOs members

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapter.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapter.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.BaseAdapter
 import android.widget.ImageButton
+import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.DrawableRes
@@ -89,6 +90,7 @@ class ChirpListAdapter(
     val itemUsername = view.findViewById<TextView>(R.id.social_media_username)
     val itemTime = view.findViewById<TextView>(R.id.social_media_time)
     val itemText = view.findViewById<TextView>(R.id.social_media_text)
+    val itemProfile = view.findViewById<ImageView>(R.id.social_media_profile)
     val deleteChirp = view.findViewById<ImageButton>(R.id.delete_chirp_button)
     val upvoteChirp = view.findViewById<ImageButton>(R.id.upvote_button)
     val downvoteChirp = view.findViewById<ImageButton>(R.id.downvote_button)
@@ -191,6 +193,11 @@ class ChirpListAdapter(
     itemUsername.text = senderUsername
     itemTime.text = DateUtils.getRelativeTimeSpanString(timestamp * 1000)
     itemText.text = text
+
+    // Changes the color of the profile if the chirps comes from another LAO
+    if (chirp.laoId != laoViewModel.laoId) {
+      itemProfile.imageTintList = context.getColorStateList(R.color.gray)
+    }
 
     return view
   }

--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapter.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapter.kt
@@ -195,7 +195,9 @@ class ChirpListAdapter(
     itemText.text = text
 
     // Changes the color of the profile if the chirps comes from another LAO
-    if (chirp.laoId != laoViewModel.laoId) {
+    if (chirp.laoId == laoViewModel.laoId) {
+      itemProfile.imageTintList = context.getColorStateList(R.color.colorAccent)
+    } else {
       itemProfile.imageTintList = context.getColorStateList(R.color.gray)
     }
 

--- a/fe2-android/app/src/main/res/layout/chirp_card.xml
+++ b/fe2-android/app/src/main/res/layout/chirp_card.xml
@@ -6,6 +6,7 @@
   android:orientation="horizontal">
 
   <ImageView
+    android:id="@+id/social_media_profile"
     android:layout_width="@dimen/bottom_navigation_view_height"
     android:layout_height="@dimen/bottom_navigation_view_height"
     android:contentDescription="@string/profile"

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapterTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapterTest.kt
@@ -1,5 +1,6 @@
 package com.github.dedis.popstellar.ui.lao.socialmedia
 
+import android.content.Context
 import android.text.format.DateUtils
 import android.view.View
 import android.widget.ImageButton
@@ -8,6 +9,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.fragment.app.FragmentActivity
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.dedis.popstellar.R
@@ -319,6 +321,7 @@ class ChirpListAdapterTest {
       val viewModel = obtainViewModel(activity)
       val chirpListAdapter =
               createChirpListAdapter(activity, viewModel, socialMediaViewModel, chirps)
+      val context = ApplicationProvider.getApplicationContext<Context>()
 
       // Use a non null ViewGroup to inflate the card
       val layout = LinearLayout(activity.applicationContext)
@@ -342,7 +345,7 @@ class ChirpListAdapterTest {
       // The chirp of the other LAO should be gray
       val profile2 = view2.findViewById<ImageView>(R.id.social_media_profile)
       Assert.assertNotNull(profile2)
-      Assert.assertEquals(-8355712, profile2.imageTintList?.defaultColor)
+      Assert.assertEquals(context.getColor(R.color.gray), profile2.imageTintList?.defaultColor)
     }
   }
 

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapterTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapterTest.kt
@@ -3,6 +3,7 @@ package com.github.dedis.popstellar.ui.lao.socialmedia
 import android.text.format.DateUtils
 import android.view.View
 import android.widget.ImageButton
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
@@ -37,6 +38,7 @@ import com.github.dedis.popstellar.utility.security.KeyManager
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import io.reactivex.Observable
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
@@ -72,9 +74,9 @@ class ChirpListAdapterTest {
   private val REACTION2 =
     Reaction(
       Base64DataUtils.generateMessageID(),
-      SENDER_1,
+      SENDER_2,
       Reaction.ReactionEmoji.DOWNVOTE.code,
-      CHIRP_1.id,
+      CHIRP_3.id,
       TIMESTAMP,
     )
   private val REACTION3 =
@@ -301,24 +303,74 @@ class ChirpListAdapterTest {
     }
   }
 
+  @Test
+  fun profileDisplayTest() {
+    val mockSocialMediaViewModel = Mockito.mock(SocialMediaViewModel::class.java)
+    Mockito.`when`(mockSocialMediaViewModel.chirps)
+            .thenReturn(Observable.just(ArrayList(listOf(CHIRP_1, CHIRP_3))))
+    Mockito.`when`(mockSocialMediaViewModel.getReactions(LAO_ID, MESSAGE_ID_1))
+            .thenReturn(Observable.just(setOf(REACTION)))
+    Mockito.`when`(mockSocialMediaViewModel.getReactions(LAO_ID_2, MESSAGE_ID_3))
+            .thenReturn(Observable.just(setOf(REACTION2)))
+
+    val chirps = ArrayList(listOf(CHIRP_1, CHIRP_3))
+    activityScenarioRule.scenario.onActivity { activity: LaoActivity ->
+      val socialMediaViewModel = mockSocialMediaViewModel
+      val viewModel = obtainViewModel(activity)
+      val chirpListAdapter =
+              createChirpListAdapter(activity, viewModel, socialMediaViewModel, chirps)
+
+      // Use a non null ViewGroup to inflate the card
+      val layout = LinearLayout(activity.applicationContext)
+      val parent = TextView(activity.applicationContext)
+      parent.text = "Mock Title"
+      layout.addView(parent)
+
+      // Get the view for the first chirp in the list.
+      val view1 = chirpListAdapter.getView(0, null, layout)
+      Assert.assertNotNull(view1)
+
+      // The chirp of our LAO should have an unmodified color (null in this case)
+      val profile1 = view1.findViewById<ImageView>(R.id.social_media_profile)
+      Assert.assertNotNull(profile1)
+      Assert.assertNull(profile1.imageTintList)
+
+      // Get the view for the second chirp in the list.
+      val view2 = chirpListAdapter.getView(1, null, layout)
+      Assert.assertNotNull(view2)
+
+      // The chirp of the other LAO should be gray
+      val profile2 = view2.findViewById<ImageView>(R.id.social_media_profile)
+      Assert.assertNotNull(profile2)
+      Assert.assertEquals(-8355712, profile2.imageTintList?.defaultColor)
+    }
+  }
+
   companion object {
     private const val CREATION_TIME: Long = 1631280815
-    private const val LAO_NAME = "laoName"
+    private const val LAO_NAME_1 = "laoName1"
+    private const val LAO_NAME_2 = "laoName2"
     private var SENDER_KEY_1: KeyPair = Base64DataUtils.generatePoPToken()
     private val SENDER_KEY_2: KeyPair = Base64DataUtils.generatePoPToken()
     private val SENDER_1 = SENDER_KEY_1.publicKey
     private val SENDER_2 = SENDER_KEY_2.publicKey
-    private val LAO_ID = generateLaoId(SENDER_1, CREATION_TIME, LAO_NAME)
+    private val LAO_ID = generateLaoId(SENDER_1, CREATION_TIME, LAO_NAME_1)
+    private val LAO_ID_2 = generateLaoId(SENDER_2, CREATION_TIME, LAO_NAME_2)
     private val MESSAGE_ID_1 = Base64DataUtils.generateMessageID()
     private val MESSAGE_ID_2 = Base64DataUtils.generateMessageID()
+    private val MESSAGE_ID_3 = Base64DataUtils.generateMessageID()
     private const val TEXT_1 = "text1"
     private const val TEXT_2 = "text2"
+    private const val TEXT_3 = "text3"
     private const val TIMESTAMP_1: Long = 1632204910
     private const val TIMESTAMP_2: Long = 1632204900
+    private const val TIMESTAMP_3: Long = 1632204905
     private val CHIRP_1 =
             Chirp(MESSAGE_ID_1, SENDER_1, TEXT_1, TIMESTAMP_1, MessageID(""), LAO_ID)
     private val CHIRP_2 =
             Chirp(MESSAGE_ID_2, SENDER_2, TEXT_2, TIMESTAMP_2, MessageID(""), LAO_ID).deleted()
+    private val CHIRP_3 =
+            Chirp(MESSAGE_ID_3, SENDER_2, TEXT_3, TIMESTAMP_3, MessageID(""), LAO_ID_2)
     private val TIMESTAMP = Instant.now().epochSecond
 
     private fun createChirpList(): List<Chirp> {

--- a/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapterTest.kt
+++ b/fe2-android/app/src/test/ui/robolectric/com/github/dedis/popstellar/ui/lao/socialmedia/ChirpListAdapterTest.kt
@@ -333,10 +333,10 @@ class ChirpListAdapterTest {
       val view1 = chirpListAdapter.getView(0, null, layout)
       Assert.assertNotNull(view1)
 
-      // The chirp of our LAO should have an unmodified color (null in this case)
+      // The chirp of our LAO should be blue
       val profile1 = view1.findViewById<ImageView>(R.id.social_media_profile)
       Assert.assertNotNull(profile1)
-      Assert.assertNull(profile1.imageTintList)
+      Assert.assertEquals(context.getColor(R.color.colorAccent), profile1.imageTintList?.defaultColor)
 
       // Get the view for the second chirp in the list.
       val view2 = chirpListAdapter.getView(1, null, layout)


### PR DESCRIPTION
When two (or more) LAOs are linked with federation and they send chirps, chirps from the user's LAO are displayed with a blue profile and chirps from another LAO are displayed with gray profile.

![Screenshot_20240627_235401](https://github.com/dedis/popstellar/assets/100276728/757b9eda-40f9-4132-ae25-de1d75ac78f5)