### PR TITLE
Fix rumor process order

### DIFF
--- a/be2-scala/src/main/resources/logback.xml
+++ b/be2-scala/src/main/resources/logback.xml
@@ -13,7 +13,7 @@
   </logger>
 
 <!--Set root(general) logs level to INFO/DEBUG on STDOUT-->
-  <root level="OFF">
+  <root level="INFO">
     <appender-ref ref="STDOUT"/>
   </root>
 

--- a/be2-scala/src/main/resources/logback.xml
+++ b/be2-scala/src/main/resources/logback.xml
@@ -1,14 +1,20 @@
 <!--Configuration for ch.qos.logback-->
 <!--Set debug to true to show debug logs on STDOUT-->
 <configuration debug="false" scan="true" scanPeriod="15 seconds">
+  <akkaProperty name="AKKA_LOGLEVEL" path="akka.loglevel" />
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} - %highlight(%-5level) : %logger{0} > %msg%n</pattern>
     </encoder>
   </appender>
 
+  <logger name="ch.epfl.pop" level="INFO" additivity="false">
+      <appender-ref ref="STDOUT" />
+  </logger>
+
 <!--Set root(general) logs level to INFO/DEBUG on STDOUT-->
-  <root level="INFO">
+  <root level="OFF">
     <appender-ref ref="STDOUT"/>
   </root>
+
 </configuration>


### PR DESCRIPTION
Before, a rumor would be refused is unprocessable. Now even if we cannot process it (because not for us or another reason), it is written in memory allowing for following rumors to be processed