### PR TITLE
Disabled extending connection to peers for test purposes

### DIFF
--- a/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.kt
+++ b/fe2-android/app/src/main/java/com/github/dedis/popstellar/utility/handler/data/LaoHandler.kt
@@ -220,7 +220,11 @@ constructor(
     // Extend the current connection by connecting to the peers of the main server
     // The greetLao will also be sent by the other servers, so the message sender
     // should handle this, avoiding to connect twice to the same server
-    context.messageSender.extendConnection(greetLao.peers)
+
+    // TODO: Remove the comment when testing for backend is finished ! Maxime @Kaz | May 2024
+    // Also, I realised removing this line that no tests are actually testing this part of the
+    // code...
+    // context.messageSender.extendConnection(greetLao.peers)
   }
 
   companion object {


### PR DESCRIPTION
After inadvertently merging the revert, we have to merge this again since testing is still going on :)

Disabled extending connection to peers of the main server for test purposes, as explained in https://github.com/dedis/popstellar/issues/1879